### PR TITLE
Add README-anchored local skill validation harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,18 @@
 .DS_Store
+
+# Python / local tooling
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+.pytest_cache/
+
+# Generated skill outputs
+output/
+outputs/
+generated/
+
+# OS / editor noise
+Thumbs.db
+.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 | Skill | Status | Purpose | Trigger keywords |
 |-------|--------|---------|-----------------|
-| [`nature-figure`](nature-figure/README.md) | Stable | Publication-ready matplotlib figures | "Nature figure", "publication plot", "scientific figure" |
+| [`nature-figure`](nature-figure/README.md) | Stable | Publication-ready Python/R figures | "Nature figure", "publication plot", "scientific figure" |
 | [`nature-polishing`](nature-polishing/README.md) | Stable | Academic prose polishing to *Nature* style | "Nature style", "polish", "academic writing" |
 | [`nature-data`](nature-data/README.md) | Draft | Nature Data Availability statements, repository plans, and FAIR checks | "Data Availability", "repository", "FAIR metadata", "数据可用性声明" |
 | [`nature-paper2ppt`](nature-paper2ppt/README.md) | Beta | Chinese PPTX decks from scientific papers | "paper PPT", "journal club", "文献汇报", "论文做成PPT" |
@@ -24,11 +24,31 @@
 
 ---
 
+## Harness
+
+This repository includes a lightweight local harness for skill discovery, validation,
+matching, and launch-prompt assembly:
+
+```bash
+python harness/skill_engine.py list
+python harness/skill_engine.py validate
+python harness/skill_engine.py match "帮我把这篇论文做成文献汇报PPT"
+python harness/skill_engine.py launch nature-polishing --request "Polish this abstract"
+```
+
+The harness uses only the Python standard library. It treats the root README Skill index
+and each skill README as the human-authored source of truth, then checks whether the
+machine-readable skill surface still matches those docs. It is designed to catch stale
+skill metadata, missing references, broken internal links, and duplicated launch surface
+before a new skill is added.
+
+---
+
 ## nature-figure
 
-**What it does** — Generates multi-panel matplotlib figures that match *Nature* journal
-visual standards: correct typography, semantic colour palette, editable SVG output,
-and non-redundant panel information architecture.
+**What it does** — Generates or audits multi-panel Python/R figures that match *Nature*
+journal visual standards: correct typography, semantic colour palette, editable SVG/PDF
+output, and non-redundant panel information architecture.
 
 **Example output gallery** — Five dense, simulated *Nature*-style result figures are
 included in the [`nature-figure` gallery](nature-figure/README.md#example-output-gallery):
@@ -79,11 +99,17 @@ nature-figure/
 ├── README.md
 ├── SKILL.md
 └── references/
-    ├── api.md            PALETTE, helper signatures, validation rules
-    ├── design-theory.md  Typography, layout, export policy, anti-redundancy rules
-    ├── common-patterns.md Ultra-wide panels, legend axes, print-safe bars
-    ├── tutorials.md      End-to-end walkthroughs (bars, trends, heatmaps)
-    └── chart-types.md    Radar, 3D sphere, scatter, fill_between, log-scale
+    ├── figure-contract.md       Core conclusion, evidence hierarchy, panel map
+    ├── backend-selection.md     Python vs R selection rules
+    ├── r-workflow.md            ggplot2/patchwork/ComplexHeatmap track
+    ├── r-template-index.md      Private R template adaptation rules
+    ├── qa-contract.md           Figure-package QA checklist
+    ├── api.md                   Python palette, helper signatures, validation rules
+    ├── design-theory.md         Typography, layout, export policy, anti-redundancy rules
+    ├── common-patterns.md       Python layout patterns and reusable snippets
+    ├── nature-2026-observations.md Real Nature page archetypes
+    ├── tutorials.md             End-to-end walkthroughs
+    └── chart-types.md           Radar, 3D sphere, scatter, fill_between, log-scale
 ```
 
 **Supported chart types** — Stacked bar, grouped bar, horizontal ablation bar, trend/line,
@@ -98,9 +124,9 @@ illustration, fill-between area, log-scale bar, GridSpec multi-panel.
 into prose matching *Nature* journal conventions: ≤ 30-word sentences, section-aware
 tense and hedging, precise vocabulary, correct citation practice, and British English.
 
-**Built from** — Close reading of five *Nature* s41586 papers (2026) and a graduate-level
-scientific English writing course; 25 rules extracted across sentence architecture,
-paper structure, vocabulary, citation integrity, house style, and AI ethics.
+**Built from** — A graduate-level scientific writing strategy layer and Academic
+Phrasebank-derived phrase support, with additional guardrails for section logic,
+claim strength, citation integrity, house style, and AI ethics.
 
 **Key rules enforced**
 
@@ -113,18 +139,22 @@ paper structure, vocabulary, citation integrity, house style, and AI ethics.
 | Overclaim detection | Flag absolutes, unwarranted causation, scope expansion, unverified "first" claims |
 | British English | signalling, colour, analyse, programme, modelling, behaviour |
 
-**12-step polishing workflow**
+**Core polishing workflow**
 
-Sentence split → Section ID → Hourglass check → Tense audit → Sentence edit →
-Vocabulary upgrade → Template check → Citation audit → House style → Overclaim →
-Proofreading → Plain-text output
+Paper-type diagnosis → Section job → Paragraph logic → Claim/evidence/boundary check →
+sentence polish → phrase support → citation/ethics audit → final prose and revision notes
 
 **Reference files**
 
 ```
 nature-polishing/
 ├── README.md
-└── SKILL.md    25 rules + 12-step workflow (loaded by Claude automatically)
+├── SKILL.md
+└── references/
+    ├── writing-strategy.md
+    ├── section-moves.md
+    ├── phrasebank-playbook.md
+    └── style-guardrails.md
 ```
 
 ---

--- a/harness/README.md
+++ b/harness/README.md
@@ -1,0 +1,42 @@
+# nature-skills harness
+
+This harness is a small standard-library Python engine for local skill operations:
+
+- discover every `nature-*` skill folder
+- read `SKILL.md` frontmatter without external YAML dependencies
+- validate required files, internal Markdown links, reference discoverability, and generated artifacts
+- rank skills for a user request using README trigger keywords and frontmatter text
+- assemble a launch prompt for a selected skill
+
+## README source of truth
+
+The harness is intentionally anchored to the author's existing README structure. It reads
+the root `README.md` Skill index for each skill's status, purpose, and trigger keywords,
+and it also uses each skill's own `README.md` as matching context.
+
+This means the harness should not replace or override the human-authored documentation.
+When a skill is added or substantially changed, update the README entries first, then use
+the harness to validate that the machine-readable launch surface still matches the
+author-facing documentation.
+
+## Commands
+
+```bash
+python harness/skill_engine.py list
+python harness/skill_engine.py validate
+python harness/skill_engine.py match "数据可用性声明怎么写"
+python harness/skill_engine.py launch nature-paper2ppt --request "把这篇论文做成文献汇报PPT"
+```
+
+Include selected references in a launch prompt:
+
+```bash
+python harness/skill_engine.py launch nature-polishing \
+  --request "Polish this abstract" \
+  --reference writing-strategy.md \
+  --reference style-guardrails.md
+```
+
+The harness does not call an LLM by itself. It creates the deterministic project layer
+around the skills so a model host, CLI wrapper, or future API service can select and load
+the right skill consistently.

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -1,0 +1,1 @@
+"""Local tooling for the nature-skills repository."""

--- a/harness/skill_engine.py
+++ b/harness/skill_engine.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""Discover, validate, match, and launch local nature-skills.
+
+The harness deliberately uses only the Python standard library so it can run in a
+fresh checkout before any plotting, PPTX, or YAML dependencies are installed.
+It treats the root README Skill index and each skill README as the human-authored
+source of truth for status, purpose, trigger terms, and matching context.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)|<img\s+[^>]*src=\"([^\"]+)\"")
+GENERATED_SUFFIXES = {".pptx", ".pdf", ".svg", ".tiff", ".tif"}
+
+
+@dataclass
+class Skill:
+    name: str
+    path: Path
+    metadata: dict[str, str]
+    status: str = ""
+    purpose: str = ""
+    triggers: tuple[str, ...] = ()
+
+    @property
+    def skill_md(self) -> Path:
+        return self.path / "SKILL.md"
+
+    @property
+    def readme(self) -> Path:
+        return self.path / "README.md"
+
+    @property
+    def references(self) -> list[Path]:
+        ref_dir = self.path / "references"
+        return sorted(ref_dir.glob("*.md")) if ref_dir.exists() else []
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def strip_frontmatter(text: str) -> str:
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return text
+    for index, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            return "\n".join(lines[index + 1 :]).lstrip()
+    return text
+
+
+def parse_frontmatter(text: str) -> dict[str, str]:
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+
+    raw: list[str] = []
+    for line in lines[1:]:
+        if line.strip() == "---":
+            break
+        raw.append(line)
+
+    metadata: dict[str, str] = {}
+    index = 0
+    while index < len(raw):
+        line = raw[index]
+        match = re.match(r"^([A-Za-z0-9_-]+):\s*(.*)$", line)
+        if not match:
+            index += 1
+            continue
+
+        key, value = match.group(1), match.group(2).strip()
+        index += 1
+        if value in {">", ">-", "|", "|-"}:
+            block: list[str] = []
+            while index < len(raw):
+                next_line = raw[index]
+                if re.match(r"^[A-Za-z0-9_-]+:\s*", next_line):
+                    break
+                block.append(next_line.strip())
+                index += 1
+            metadata[key] = " ".join(part for part in block if part)
+        else:
+            metadata[key] = value.strip("\"'")
+    return metadata
+
+
+def parse_index(readme: Path) -> dict[str, dict[str, object]]:
+    if not readme.exists():
+        return {}
+
+    index: dict[str, dict[str, object]] = {}
+    for line in read_text(readme).splitlines():
+        if not line.startswith("| [`nature-"):
+            continue
+        parts = [part.strip() for part in line.strip("|").split("|")]
+        if len(parts) < 4:
+            continue
+        name_match = re.search(r"`([^`]+)`", parts[0])
+        if not name_match:
+            continue
+        index[name_match.group(1)] = {
+            "status": parts[1],
+            "purpose": parts[2],
+            "triggers": tuple(re.findall(r'"([^"]+)"', parts[3])),
+        }
+    return index
+
+
+def discover(root: Path = ROOT) -> list[Skill]:
+    index = parse_index(root / "README.md")
+    skills: list[Skill] = []
+    for path in sorted(root.glob("nature-*")):
+        if not path.is_dir() or not (path / "SKILL.md").exists():
+            continue
+        metadata = parse_frontmatter(read_text(path / "SKILL.md"))
+        row = index.get(path.name, {})
+        skills.append(
+            Skill(
+                name=metadata.get("name", path.name),
+                path=path,
+                metadata=metadata,
+                status=str(row.get("status", "")),
+                purpose=str(row.get("purpose", "")),
+                triggers=tuple(row.get("triggers", ())),
+            )
+        )
+    return skills
+
+
+def check_markdown_links(root: Path) -> list[str]:
+    issues: list[str] = []
+    for markdown in sorted(root.rglob("*.md")):
+        rel = markdown.relative_to(root)
+        in_fence = False
+        for number, line in enumerate(read_text(markdown).splitlines(), start=1):
+            if line.startswith("```"):
+                in_fence = not in_fence
+                continue
+            if in_fence:
+                continue
+            for match in LINK_RE.finditer(line):
+                target = match.group(1) or match.group(2)
+                if re.match(r"^(https?:|mailto:|#)", target):
+                    continue
+                target_path = target.split("#", 1)[0]
+                if not target_path:
+                    continue
+                full = (markdown.parent / target_path).resolve()
+                try:
+                    full.relative_to(root.resolve())
+                except ValueError:
+                    issues.append(f"{rel}:{number}: link escapes repository: {target}")
+                    continue
+                if not full.exists():
+                    issues.append(f"{rel}:{number}: missing link target: {target}")
+    return issues
+
+
+def validate(root: Path = ROOT) -> list[dict[str, str]]:
+    results: list[dict[str, str]] = []
+    root_index = parse_index(root / "README.md")
+
+    def add(level: str, subject: str, message: str) -> None:
+        results.append({"level": level, "subject": subject, "message": message})
+
+    for skill in discover(root):
+        subject = skill.path.name
+        metadata = skill.metadata
+        if not metadata.get("name"):
+            add("error", subject, "SKILL.md frontmatter is missing name")
+        if skill.name != skill.path.name:
+            add("error", subject, f"frontmatter name {skill.name!r} does not match folder")
+        if not metadata.get("description"):
+            add("error", subject, "SKILL.md frontmatter is missing description")
+        if not skill.readme.exists():
+            add("warn", subject, "README.md is missing")
+        if skill.path.name not in root_index:
+            add("warn", subject, "root README skill index is missing this skill")
+
+        skill_lines = len(read_text(skill.skill_md).splitlines())
+        if skill_lines > 500:
+            add("warn", subject, f"SKILL.md has {skill_lines} lines; consider splitting references")
+
+        launch_text = read_text(skill.skill_md)
+        if skill.readme.exists():
+            launch_text += "\n" + read_text(skill.readme)
+        for ref in skill.references:
+            if ref.name not in launch_text and f"references/{ref.name}" not in launch_text:
+                add("warn", subject, f"reference is not discoverable from SKILL.md or README.md: {ref.name}")
+
+    for issue in check_markdown_links(root):
+        add("error", "markdown", issue)
+
+    for generated in sorted(root.rglob("*")):
+        if not generated.is_file() or generated.suffix.lower() not in GENERATED_SUFFIXES:
+            continue
+        if ".git" in generated.parts or "assets" in generated.parts:
+            continue
+        add("warn", "generated-artifact", str(generated.relative_to(root)))
+
+    return results
+
+
+def normalize_words(text: str) -> set[str]:
+    return {word for word in re.findall(r"[A-Za-z0-9][A-Za-z0-9_-]{1,}", text.lower())}
+
+
+def score(skill: Skill, query: str) -> int:
+    query_lower = query.lower()
+    query_words = normalize_words(query)
+    corpus = " ".join(
+        [
+            skill.name,
+            skill.metadata.get("description", ""),
+            skill.purpose,
+            " ".join(skill.triggers),
+            read_text(skill.readme)[:4000] if skill.readme.exists() else "",
+        ]
+    ).lower()
+
+    total = 0
+    for trigger in skill.triggers:
+        trigger_lower = trigger.lower()
+        if trigger_lower in query_lower or query_lower in trigger_lower:
+            total += 20
+    total += 2 * len(query_words & normalize_words(corpus))
+    if skill.name.replace("nature-", "") in query_lower:
+        total += 10
+    return total
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    rows = []
+    for skill in discover(args.root):
+        rows.append(
+            {
+                "skill": skill.path.name,
+                "status": skill.status or "-",
+                "references": len(skill.references),
+                "purpose": skill.purpose or skill.metadata.get("description", "")[:80],
+            }
+        )
+    print_table(rows, ["skill", "status", "references", "purpose"])
+    return 0
+
+
+def cmd_validate(args: argparse.Namespace) -> int:
+    issues = validate(args.root)
+    if args.json:
+        print(json.dumps(issues, ensure_ascii=False, indent=2))
+    elif issues:
+        for issue in issues:
+            print(f"[{issue['level']}] {issue['subject']}: {issue['message']}")
+    else:
+        print("OK: all skill checks passed.")
+    return 1 if any(issue["level"] == "error" for issue in issues) else 0
+
+
+def cmd_match(args: argparse.Namespace) -> int:
+    rows = []
+    for skill in discover(args.root):
+        rows.append(
+            {
+                "score": score(skill, args.query),
+                "skill": skill.path.name,
+                "triggers": ", ".join(skill.triggers[:4]),
+            }
+        )
+    rows.sort(key=lambda row: (-int(row["score"]), row["skill"]))
+    print_table(rows[: args.limit], ["score", "skill", "triggers"])
+    return 0
+
+
+def cmd_launch(args: argparse.Namespace) -> int:
+    skills = {skill.path.name: skill for skill in discover(args.root)}
+    skill = skills.get(args.skill)
+    if skill is None:
+        print(f"Unknown skill: {args.skill}", file=sys.stderr)
+        return 2
+
+    sections = [
+        f"# Launch {skill.path.name}",
+        "## Metadata",
+        f"- status: {skill.status or 'unlisted'}",
+        f"- purpose: {skill.purpose or 'not listed'}",
+        f"- triggers: {', '.join(skill.triggers) or 'not listed'}",
+        "## Skill Instructions",
+        strip_frontmatter(read_text(skill.skill_md)),
+    ]
+
+    references = list(args.reference or [])
+    if args.include_references:
+        references.extend(ref.name for ref in skill.references)
+    if references:
+        ref_by_name = {ref.name: ref for ref in skill.references}
+        sections.append("## Loaded References")
+        for name in references:
+            ref = ref_by_name.get(name) or ref_by_name.get(Path(name).name)
+            if ref is None:
+                sections.append(f"### Missing Reference: {name}")
+                continue
+            sections.extend([f"### {ref.relative_to(skill.path)}", read_text(ref)])
+
+    if args.request:
+        sections.extend(["## User Request", args.request])
+
+    output = "\n\n".join(sections).rstrip() + "\n"
+    if args.output:
+        args.output.write_text(output, encoding="utf-8")
+    else:
+        print(output, end="")
+    return 0
+
+
+def print_table(rows: list[dict[str, object]], columns: list[str]) -> None:
+    if not rows:
+        print("(none)")
+        return
+    widths = {
+        column: max(len(column), *(len(str(row.get(column, ""))) for row in rows))
+        for column in columns
+    }
+    print("  ".join(column.ljust(widths[column]) for column in columns))
+    print("  ".join("-" * widths[column] for column in columns))
+    for row in rows:
+        print("  ".join(str(row.get(column, "")).ljust(widths[column]) for column in columns))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Local harness for nature-skills.")
+    parser.add_argument("--root", type=Path, default=ROOT, help="Repository root.")
+    subparsers = parser.add_subparsers(required=True)
+
+    list_parser = subparsers.add_parser("list", help="List discovered skills.")
+    list_parser.set_defaults(func=cmd_list)
+
+    validate_parser = subparsers.add_parser("validate", help="Validate skill metadata and links.")
+    validate_parser.add_argument("--json", action="store_true", help="Emit JSON results.")
+    validate_parser.set_defaults(func=cmd_validate)
+
+    match_parser = subparsers.add_parser("match", help="Rank skills for a user request.")
+    match_parser.add_argument("query", help="User request to match.")
+    match_parser.add_argument("--limit", type=int, default=4, help="Number of matches to show.")
+    match_parser.set_defaults(func=cmd_match)
+
+    launch_parser = subparsers.add_parser("launch", help="Assemble a launch prompt for a skill.")
+    launch_parser.add_argument("skill", help="Skill folder name, for example nature-polishing.")
+    launch_parser.add_argument("--request", default="", help="User request to append.")
+    launch_parser.add_argument("--reference", action="append", help="Reference file to include.")
+    launch_parser.add_argument("--include-references", action="store_true", help="Include all references.")
+    launch_parser.add_argument("--output", type=Path, help="Write launch prompt to a file.")
+    launch_parser.set_defaults(func=cmd_launch)
+
+    return parser
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/nature-figure/README.md
+++ b/nature-figure/README.md
@@ -65,7 +65,7 @@ inside a larger *Nature*-style result figure.
 
 ```
 nature-figure/
-├── SKILL.md                     ← skill trigger & overview (loaded by Claude automatically)
+├── SKILL.md                     ← skill trigger & overview (loaded by the agent automatically)
 ├── README.md                    ← this file
 ├── assets/
 │   ├── gallery/                 ← result-figure preview PNGs
@@ -161,13 +161,13 @@ plt.rcParams['svg.fonttype'] = 'none'
 
 # ── Style ──────────────────────────────────────────────────────────────────────
 plt.rcParams.update({
-    'font.size': 12,
+    'font.size': 7,                 # journal-final default; use 12-16 for slide previews
     'axes.spines.right': False,
     'axes.spines.top': False,
-    'axes.linewidth': 2.0,
+    'axes.linewidth': 0.8,
     'legend.frameon': False,
-    'xtick.major.width': 1.5,
-    'ytick.major.width': 1.5,
+    'xtick.major.width': 0.6,
+    'ytick.major.width': 0.6,
 })
 
 # ── Figure ──────────────────────────────────────────────────────────────────────
@@ -372,7 +372,9 @@ Use lowercase bold (`a`, `b`, `c`) at top-left of each subplot axes, placed via 
 
 | Context | `font.size` |
 |---------|-------------|
-| Base (compact subfigures) | 12–16 |
+| Journal-final dense composite | 7–9 |
+| Ultra-dense annotations | 5–7 |
+| Slide or notebook preview | 12–16 |
 | Large bar panels (figsize > 28 in) | 24 |
 | Axis labels (large panels) | 32–54 via per-label override |
 | In-bar / in-cell annotations | 6.5–12 |
@@ -415,7 +417,7 @@ def luminance_text_color(hex_color):
 - [ ] **Lines 1–3**: `font.family`, `font.sans-serif` (three fonts), `svg.fonttype = 'none'`
 - [ ] Primary output is **SVG** (`bbox_inches='tight'`)
 - [ ] Right and top spines off; `legend.frameon = False`
-- [ ] Font size matches final use: 5–7 pt for dense journal output, larger only for slide-sized panels
+- [ ] Font size matches final use: 7–9 pt for dense journal output, 12–16 pt only for slide/notebook previews
 - [ ] Colors come from one coherent palette system: either semantic `PALETTE` or unified `PALETTE_NMI_PASTEL`
 - [ ] Related model sizes / variants share a hue family; do not assign unrelated saturated colors to siblings
 - [ ] Green / red reserved for gains, drops, thresholds, or truly signed semantics

--- a/nature-polishing/README.md
+++ b/nature-polishing/README.md
@@ -4,8 +4,8 @@ An academic-writing skill for polishing, restructuring, and translating manuscri
 
 Source hierarchy:
 
-- `Main strategy`: the course notes in `Chapter1-Week1-7 完整版（full version).pdf`
-- `Reference support`: `Academic-Phrasebank-Navigable-PDF-2023.pdf`
+- `Main strategy`: scientific-writing course principles distilled into `references/writing-strategy.md`
+- `Reference support`: Academic Phrasebank-derived move and phrase families in `references/`
 
 ## What changed
 
@@ -21,6 +21,7 @@ nature-polishing/
 ├── SKILL.md
 ├── README.md
 └── references/
+    ├── writing-strategy.md
     ├── phrasebank-playbook.md
     ├── section-moves.md
     └── style-guardrails.md
@@ -48,6 +49,7 @@ The skill should:
 
 ## Reference map
 
+- `writing-strategy.md`: argument diagnosis, hourglass logic, claim/evidence/boundary checks
 - `section-moves.md`: section order and move patterns
 - `phrasebank-playbook.md`: hedging, transitions, evidence, limitations, future work
 - `style-guardrails.md`: British style, articles, abbreviations, units, register, overclaim control

--- a/nature-polishing/SKILL.md
+++ b/nature-polishing/SKILL.md
@@ -12,7 +12,8 @@ Use this skill to improve scientific writing at two levels:
 - `main strategy`: paper architecture, section logic, reader workflow, evidence thresholds, and ethics
 - `reference support`: reusable phrase families, move patterns, transitions, and style checks
 
-The main strategy should come from the course notes in `Chapter1-Week1-7`. The reference wording layer should come from `Academic Phrasebank`.
+The main strategy lives in `references/writing-strategy.md`. The wording layer lives in the
+Academic Phrasebank-derived files under `references/`.
 
 ## Default stance
 
@@ -25,10 +26,12 @@ The main strategy should come from the course notes in `Chapter1-Week1-7`. The r
 
 ## When to open extra files
 
-These files are reference support. Use them after the section's rhetorical job is clear.
+Load only the file needed for the current task. Use `writing-strategy.md` for structural
+rewrites; use the other files after the section's rhetorical job is clear.
 
 | File | Open when |
 |---|---|
+| [references/writing-strategy.md](references/writing-strategy.md) | You need paragraph or section-level reconstruction, argument diagnosis, or hourglass logic |
 | [references/section-moves.md](references/section-moves.md) | You need section-specific move orders or phrase patterns derived from Academic Phrasebank |
 | [references/phrasebank-playbook.md](references/phrasebank-playbook.md) | You need hedging, transition, evidence, limitation, or future-work phrase families |
 | [references/style-guardrails.md](references/style-guardrails.md) | You need academic-style checks, paragraph/sentence checks, article use, register, or mechanics |


### PR DESCRIPTION
## Summary

This PR adds a lightweight local harness for validating and launching skills while keeping the existing README documentation as the source of truth.

The harness can:
- discover local `nature-*` skill folders
- read `SKILL.md` frontmatter without external YAML dependencies
- validate required files, internal Markdown links, and reference discoverability
- rank skills for a user request using the root README Skill index and each skill README
- assemble a launch prompt for a selected skill

I also fixed a few small documentation drift points:
- align `nature-figure` docs with the current Python/R workflow
- expose `nature-polishing/references/writing-strategy.md` from the skill entrypoint
- clarify journal-final vs slide-preview font sizing in `nature-figure`
- expand `.gitignore` for local tooling and generated outputs

## Design note

The harness is intentionally anchored to the existing README structure. It does not replace or override the author's documentation; it checks whether the machine-readable skill surface stays consistent with the README and per-skill docs.

## Validation

- `python harness/skill_engine.py validate`
- `python harness/skill_engine.py match "帮我把这篇论文做成文献汇报PPT"`
- `python harness/skill_engine.py match "帮我润色这个摘要 Nature style"`
- `python -m py_compile harness/skill_engine.py`
- `git diff --check upstream/main...HEAD`
