### PR TITLE
docs: update README Claude Code install to plugin marketplace method

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,15 +81,26 @@ If you prefer not to use the terminal, copying the `skills/nature-*` folder(s) i
 
 ### 2. Claude Code
 
-Claude Code does **not** currently load Codex-style `SKILL.md` folders as native skills.
-Its closest reusable primitives are:
+**Primary method: Plugin marketplace installation**
 
-- **Subagents**: `~/.claude/agents/` or `.claude/agents/`
-- **Custom slash commands**: `~/.claude/commands/` or `.claude/commands/`
+This repository is published as a Claude Code plugin, making installation simple.
 
-The recommended approach is to convert a skill into a **subagent**.
+```bash
+# Add the marketplace (one-time)
+/plugin marketplace add https://github.com/Yuan1z0825/nature-skills
 
-**Create a user-level subagent**
+# Install the plugin
+/plugin install nature-skills
+
+# Reload to apply
+/reload-plugins
+```
+
+All nine skills are available automatically after reload. No manual wrapper setup needed.
+
+**Alternative: subagent wrapper**
+
+If you prefer manual control over individual skills, create a user-level subagent:
 
 ```bash
 mkdir -p ~/.claude/agents


### PR DESCRIPTION
## Summary
- Update the Claude Code installation section to use the plugin marketplace as the primary method
- The repo already ships `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`
- Keep the subagent wrapper as a documented alternative

## Test plan
- [ ] `/plugin marketplace add https://github.com/Yuan1z0825/nature-skills`
- [ ] `/plugin install nature-skills`
- [ ] `/reload-plugins` registers all 9 skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)