### PR TITLE
feat: add nature-response skill and promote validated skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # nature-skills
 <img width="5750" height="6928" alt="combined_grid" src="https://github.com/user-attachments/assets/695b7721-a3eb-4bec-bfcf-d85b8d3d824a" />
 
-A growing collection of Claude skills for producing academic work at *Nature*-journal
-standard — covering scientific figures, manuscript prose, and (in future releases) related
-tasks such as statistical reporting, peer-review responses, and methods writing.
+A growing collection of reusable skills for producing academic work at *Nature*-journal
+standard — covering scientific figures, manuscript prose, data availability, and peer-review
+responses, with room to expand into related editorial tasks.
 
 Every skill in this collection shares a common philosophy: rules are derived from
 **primary sources** (published *Nature* papers, journal author guidelines, and structured
@@ -17,7 +17,8 @@ writing curricula), not from general style intuition.
 |-------|--------|---------|-----------------|
 | [`nature-figure`](nature-figure/README.md) | Stable | Publication-ready matplotlib figures | "Nature figure", "publication plot", "scientific figure" |
 | [`nature-polishing`](nature-polishing/README.md) | Stable | Academic prose polishing to *Nature* style | "Nature style", "polish", "academic writing" |
-| [`nature-data`](nature-data/README.md) | Draft | Nature Data Availability statements, repository plans, and FAIR checks | "Data Availability", "repository", "FAIR metadata", "数据可用性声明" |
+| [`nature-data`](nature-data/README.md) | Beta | Nature Data Availability statements, repository plans, and FAIR checks | "Data Availability", "repository", "FAIR metadata", "数据可用性声明" |
+| [`nature-response`](nature-response/README.md) | Beta | Point-by-point Nature-style responses to reviewers and editors | "response to reviewers", "rebuttal", "逐条回复", "返修说明" |
 
 > **Adding a new skill?** Follow the [contribution guide](#adding-a-new-skill) at the bottom of this file.
 
@@ -95,7 +96,7 @@ Proofreading → Plain-text output
 ```
 nature-polishing/
 ├── README.md
-└── SKILL.md    25 rules + 12-step workflow (loaded by Claude automatically)
+└── SKILL.md    25 rules + 12-step workflow
 ```
 
 ---
@@ -142,6 +143,50 @@ nature-data/
 
 ---
 
+## nature-response
+
+**What it does** — Prepares and audits point-by-point responses to reviewers, editor response
+notes, and revision-cover text for Nature-family and Springer Nature submissions. It is
+bilingual-aware: Chinese author notes such as "回复审稿人", "逐条回复", "返修说明",
+"编辑意见", and "补充实验" are converted into precise submission-ready English with Chinese
+action notes.
+
+**Built from** — Springer Nature revision guidance, Nature Portfolio author guidance,
+transparent peer review practice, and real peer review files from Nature-family journals.
+
+**Key rules enforced**
+
+| Domain | Core rule |
+|--------|-----------|
+| Point-by-point structure | Give one explicit response per reviewer point |
+| Action mapping | State what changed, why it changed, and where it changed |
+| Non-adoption | When a request is not followed, give a scientific reason and the closest alternative |
+| Tone | Keep responses respectful, specific, and non-defensive |
+| Evidence discipline | Do not invent experiments, analyses, line numbers, or manuscript edits |
+| Chinese alignment | Translate vague revision language into concrete English response blocks |
+
+**Reference files**
+
+```text
+nature-response/
+├── README.md
+├── SKILL.md
+├── agents/
+│   └── openai.yaml
+├── scripts/
+│   ├── lint_response.py
+│   └── response_template.py
+└── references/
+    ├── chinese-author-alignment.md
+    ├── real-world-patterns.md
+    ├── response-structure.md
+    ├── source-basis.md
+    ├── tutorials.md
+    └── tone-and-risk.md
+```
+
+---
+
 ## Shared design principles
 
 All skills in this collection adhere to the following:
@@ -171,7 +216,7 @@ nature-<topic>/
 
 | File | Required | Purpose |
 |------|----------|---------|
-| `SKILL.md` | Yes | Frontmatter (`name`, `description`) + rules + workflow; loaded by the agent after triggering |
+| `SKILL.md` | Yes | Frontmatter (`name`, `description`) + rules + workflow; loaded after the skill triggers |
 | `README.md` | Yes | Human-readable reference in full English |
 | `references/*.md` | Recommended for complex skills | Modular rule files (api, design theory, tutorials, chart types, …) |
 
@@ -197,7 +242,7 @@ Add a row to the [Skill index](#skill-index) table above:
 | Label | Meaning |
 |-------|---------|
 | `Draft` | Rules defined; not yet tested on real examples |
-| `Beta` | Tested on examples; edge cases may remain |
+| `Beta` | Tested on realistic examples and source-checked; edge cases may remain |
 | `Stable` | Validated on real academic content; rules are settled |
 
 ---
@@ -209,7 +254,6 @@ The following are documented gaps. Contributions welcome.
 | Candidate | Scope | Priority |
 |-----------|-------|----------|
 | `nature-stats` | Statistical reporting conventions for *Nature* (effect sizes, confidence intervals, p-value formatting, sample size statements) | High |
-| `nature-response` | Peer-review response letters — point-by-point reply structure, tone calibration, handling major vs. minor revisions | High |
 | `nature-methods` | Deep-dive Methods writing assistant — reproducibility checklist, forbidden phrases, ethical approval templates, supplementary organisation | Medium |
 | `nature-cover` | Cover letter drafting — hook paragraph, significance framing, fit-to-journal argument, ≤ 500-word limit | Medium |
 | `nature-review` | Writing a literature review or review article in *Nature Reviews* style — synthesis vs. summary, argument-led structure | Low |

--- a/nature-data/agents/openai.yaml
+++ b/nature-data/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Nature Data"
-  short_description: "Draft bilingual-aware Nature data statements"
+  short_description: "Prepare Nature-style data statements"
   default_prompt: "Help me turn my Chinese or English data notes into a Nature-style Data Availability statement, repository plan, and FAIR metadata checklist."

--- a/nature-figure/README.md
+++ b/nature-figure/README.md
@@ -10,7 +10,7 @@ Derived from production scripts in [figures4papers](https://github.com/ChenLiu-1
 
 ```
 nature-figure/
-├── SKILL.md                     ← skill trigger & overview (loaded by Claude automatically)
+├── SKILL.md                     ← skill trigger & overview
 ├── README.md                    ← this file
 └── references/
     ├── api.md                   ← PALETTE constants, helper function signatures

--- a/nature-response/README.md
+++ b/nature-response/README.md
@@ -1,0 +1,82 @@
+# `nature-response` skill
+
+A revision-response skill for preparing point-by-point replies to reviewers, editor response notes,
+and revision-cover text in a Nature / Springer Nature publication style.
+
+This skill is bilingual-aware. It accepts Chinese author notes such as "回复审稿人",
+"逐条回复", "返修说明", "编辑意见", or "补充实验", then converts them into
+submission-ready English with Chinese action notes for the author.
+
+## What it does
+
+- drafts ready-to-paste point-by-point responses to reviewers
+- separates editor comments from reviewer comments
+- maps each response to a concrete manuscript change, new analysis, new experiment, or justified
+  non-change
+- rewrites vague or defensive rebuttal language into specific revision language
+- flags unsupported claims, missing evidence, and missing manuscript-location mapping
+- aligns Chinese author intent with Nature-style English response wording
+- includes a lightweight script to convert plain-text reviewer comments into a rebuttal template
+
+## Source hierarchy
+
+- target journal revision instructions and submission fields
+- Nature Portfolio and Springer Nature author guidance
+- transparent peer review files from Nature-family journals
+- general peer review guidance only when the journal sources do not settle the issue
+
+## File structure
+
+```text
+nature-response/
+├── SKILL.md
+├── README.md
+├── agents/
+│   └── openai.yaml
+├── scripts/
+│   ├── lint_response.py
+│   └── response_template.py
+└── references/
+    ├── chinese-author-alignment.md
+    ├── real-world-patterns.md
+    ├── response-structure.md
+    ├── source-basis.md
+    ├── tutorials.md
+    └── tone-and-risk.md
+```
+
+## When to use
+
+- preparing a response to reviewers for a Nature-family or Springer Nature journal
+- restructuring a major or minor revision rebuttal
+- drafting an editor response note that summarizes manuscript changes
+- revising defensive or vague author replies
+- mapping reviewer comments to line numbers, figures, analyses, or experiments
+- converting Chinese response notes into precise English submission language
+
+## Design intent
+
+The skill should make every response traceable to a reviewer point and a concrete author action or
+reasoned non-action. It should not fabricate experiments, line numbers, or manuscript edits. When
+information is missing, it should return a usable draft plus a short list of items the author must
+confirm, preferably with Chinese notes when the user is working from a Chinese draft.
+
+## Tooling
+
+`scripts/response_template.py` is a formatting helper, not a writing engine. Use it when the user
+already has raw reviewer comments in plain text and needs a clean `Reviewer / Comment / Response`
+shell before drafting the actual rebuttal.
+
+`scripts/lint_response.py` is a structural checker. Use it on a draft rebuttal when you want to
+catch missing reviewer sections, missing `Response:` blocks, or obviously incomplete formatting
+before doing content-level editing.
+
+## Validation basis
+
+The current skill has been exercised on realistic revision scenarios covering:
+
+- clarification-only replies with exact manuscript-location mapping
+- partial disagreement cases where the authors narrow claims instead of adding new experiments
+- Chinese author notes converted into submission-ready English response blocks
+- plain-text reviewer comments converted into a response scaffold with `response_template.py`
+- draft rebuttals checked for structural omissions with `lint_response.py`

--- a/nature-response/SKILL.md
+++ b/nature-response/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: nature-response
+description: >-
+  Prepare, audit, or rewrite Nature-style point-by-point responses to reviewers and revision cover
+  notes for Nature Portfolio or Springer Nature submissions. Use when the user asks for a rebuttal,
+  author response, revision letter, reviewer-comment reply, major/minor revision response,
+  Chinese-to-English response drafting, or a structured response package that aligns manuscript
+  changes with specific reviewer and editor comments.
+---
+
+# Nature Response Skill
+
+Use this skill to turn reviewer comments, editorial requests, and manuscript changes into a
+structured revision response package that is specific, evidence-linked, and safe for resubmission.
+
+The governing layer is Nature Portfolio / Springer Nature revision and peer review practice. The
+implementation layer is point-by-point rebuttal structure, claim discipline, and manuscript-change
+mapping derived from real peer review files and editorial guidance.
+
+## Default stance
+
+- Treat the response as part of the scientific record. It should help editors and reviewers verify
+  what changed, why it changed, and what the authors did not change.
+- Answer each reviewer point explicitly. Do not merge unrelated comments into one vague paragraph.
+- Prefer direct acknowledgement, concrete action, and exact manuscript-location mapping over
+  rhetorical defence.
+- Do not claim an experiment, analysis, citation check, or text revision unless the user confirms
+  it exists in the manuscript or revision materials.
+- Distinguish `done`, `partly done`, and `not done`. If a request was not followed, explain why and
+  offer the closest defensible alternative.
+- Keep this skill focused on revision responses. Do not rewrite the full manuscript, perform
+  statistical analysis, or invent new data unless the user asks for those tasks separately.
+
+## Chinese-user operating mode
+
+When the user writes in Chinese, provides reviewer comments in Chinese, or asks for "回复审稿人",
+"逐条回复", "返修说明", or "中英对照":
+
+- Accept Chinese input naturally, but draft the submission-ready response in English unless the
+  user explicitly asks for Chinese only.
+- Preserve a short Chinese explanation of unresolved decisions when that helps the author confirm
+  what was changed.
+- Translate intent, not wording. Phrases such as "我们已认真修改" are not enough on their own;
+  convert them into specific action-plus-location statements.
+- Use `references/chinese-author-alignment.md` for common Chinese-to-English response problems and
+  bilingual intake questions.
+
+## Workflow
+
+1. Identify the submission stage and target journal:
+   initial rebuttal, major revision, minor revision, or editor-only revision note.
+2. Parse the input into units:
+   editor requests, Reviewer 1 comments, Reviewer 2 comments, and author-side manuscript changes.
+3. Classify each point:
+   `text clarification`, `new analysis`, `new experiment`, `citation`, `limitation`, `scope
+   disagreement`, `not feasible`, or `editorial formatting`.
+4. Draft one response block per reviewer point with this order:
+   brief acknowledgement, action taken, evidence or reasoning, manuscript-location mapping.
+5. Normalize tone:
+   respectful, specific, non-defensive, and proportionate to the request.
+6. Check for unsupported claims:
+   no invented experiments, no fake line numbers, no "we have revised accordingly" without saying
+   what changed.
+7. Return a ready-to-paste response package plus unresolved items the author must confirm.
+
+## Quick-start template tool
+
+Use `scripts/response_template.py` when the user already has raw reviewer comments in plain text
+and needs a point-by-point scaffold quickly.
+
+```bash
+python scripts/response_template.py comments.txt
+python scripts/response_template.py comments.txt --output response-template.txt
+```
+
+Use the script for structure only. Do not treat its output as a finished rebuttal. The response
+content still needs manuscript-aware drafting and factual verification.
+
+## Draft lint tool
+
+Use `scripts/lint_response.py` when the user already has a rebuttal draft and you want a quick
+structural check before deeper editing.
+
+```bash
+python scripts/lint_response.py response.txt
+```
+
+This linter checks for missing reviewer sections, missing `Comment n:` blocks, and comment blocks
+that never receive a `Response:` line. It does not judge scientific adequacy or tone.
+
+## Output format
+
+Unless the user asks for another format, return:
+
+```text
+Response to Reviewers
+
+Editor comments
+- [point-by-point response or "None"]
+
+Reviewer 1
+Comment 1: [quoted or summarized reviewer point]
+Response: [ready-to-paste response]
+
+Reviewer 2
+Comment 1: [quoted or summarized reviewer point]
+Response: [ready-to-paste response]
+
+Revision risks / missing confirmations
+- [specific flags or "None"]
+
+中文核对
+- [用中文列出作者需要确认的改动、证据或行号，或 "无"]
+```
+
+When auditing an existing rebuttal, lead with blocking issues first, then provide a revised
+version.
+
+## Related files
+
+| File | Open when |
+|---|---|
+| [scripts/response_template.py](scripts/response_template.py) | The user has plain-text reviewer comments and needs a rebuttal scaffold or reformatted response shell |
+| [scripts/lint_response.py](scripts/lint_response.py) | The user has a rebuttal draft and needs a quick structural check before revision |
+| [references/response-structure.md](references/response-structure.md) | You need the standard response block shape, section ordering, or editor-versus-reviewer handling |
+| [references/tutorials.md](references/tutorials.md) | You need worked examples of strong response blocks, disagreement handling, or Chinese-to-English conversion |
+| [references/real-world-patterns.md](references/real-world-patterns.md) | You need response patterns derived from real Nature-family peer review files |
+| [references/tone-and-risk.md](references/tone-and-risk.md) | You need tone calibration, disagreement patterns, or red-flag checks |
+| [references/chinese-author-alignment.md](references/chinese-author-alignment.md) | The user writes in Chinese, needs bilingual wording, or provides Chinese draft responses |
+| [references/source-basis.md](references/source-basis.md) | You need to justify rules with official sources or check which source supports which rule |
+
+## Source hierarchy
+
+Use sources in this order:
+
+1. Target journal revision instructions and submission system fields.
+2. Nature Portfolio / Springer Nature author guidance and transparent peer review practice.
+3. Real peer review files from Nature-family journals as response-shape evidence.
+4. General scholarly peer review guidance only when Nature-family sources do not settle the point.
+
+If revision or peer review instructions may have changed, verify the current journal page before
+giving final submission advice.

--- a/nature-response/agents/openai.yaml
+++ b/nature-response/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Nature Response"
+  short_description: "Draft Nature-style reviewer responses"
+  default_prompt: "Use $nature-response to turn reviewer comments and revision notes into a point-by-point Nature-style response package."

--- a/nature-response/references/chinese-author-alignment.md
+++ b/nature-response/references/chinese-author-alignment.md
@@ -1,0 +1,61 @@
+# Chinese Author Alignment
+
+Use this file when the user writes in Chinese, provides Chinese reviewer comments, or asks for
+bilingual wording. The goal is to convert Chinese revision intent into Nature-ready English
+response language.
+
+## Core terminology
+
+| 中文 | Preferred English | Notes |
+|---|---|---|
+| 回复审稿人 | Response to Reviewers | Use as the main heading when the journal expects a rebuttal file. |
+| 逐条回复 | point-by-point response | Preserve the one-comment-one-response structure. |
+| 编辑意见 | editor comments | Keep separate from reviewer comments. |
+| 补充实验 | additional experiment | Use only when the experiment was actually done. |
+| 补充分析 | additional analysis | Prefer this when existing data were re-analysed. |
+| 修改正文 | revised the manuscript | Follow with what changed and where. |
+| 讨论中补充说明 | added discussion / clarified in the Discussion | Name the location more precisely when possible. |
+| 我们认为 | we interpret / we consider | Often better than a blunt disagreement formula. |
+| 超出本文范围 | beyond the scope of the current study | Explain why and what was done instead. |
+| 感谢审稿人的建议 | we thank the reviewer for this suggestion | Keep short; do not let gratitude replace content. |
+
+## Chinese-to-English conversion rules
+
+- Convert `我们已认真修改` into a specific revision statement:
+  say what changed, where it changed, and whether the change was textual, analytical, or
+  experimental.
+- Convert `我们同意这个问题很重要` into action:
+  add whether the issue was clarified, tested, or acknowledged as a limitation.
+- Convert `因时间限制未补实验` carefully:
+  avoid making convenience sound like a scientific reason. Explain scope, feasibility, or data
+  constraints, then add the best indirect fix.
+- Convert `已在文中标红` into manuscript-neutral wording:
+  name the section, figure, or supplementary file instead of relying on colour markup.
+- Convert `见回复1` only when necessary:
+  most points should still get a self-contained answer.
+
+## Bilingual intake questions
+
+Ask only what is needed for the response.
+
+```text
+请确认这些字段：
+1. 每条审稿意见对应的实际改动是什么？是补实验、补分析、补引用，还是只改文字？
+2. 是否有修订稿中的具体位置，例如章节、小节、图号、补充说明或行号？
+3. 哪些意见没有完全采纳？原因是范围、数据限制、时间、还是实验不可行？
+4. 是否需要同时回复编辑意见？
+5. 是否需要中英对照，还是只输出英文提交版本？
+```
+
+## Recommended bilingual output
+
+When useful, provide English first and Chinese second:
+
+```text
+Response:
+[English submission-ready response]
+
+中文核对
+- 这条回复对应的实际改动：[brief Chinese explanation]
+- 需要作者确认：[location / evidence / whether experiment was really done]
+```

--- a/nature-response/references/real-world-patterns.md
+++ b/nature-response/references/real-world-patterns.md
@@ -1,0 +1,85 @@
+# Real-World Patterns
+
+Use this file when drafting response language that should resemble real Nature-family rebuttal
+practice.
+
+## Common response moves seen in peer review files
+
+### Clarification without new experiment
+
+Use when the issue is explanation, framing, or manuscript wording rather than missing evidence.
+
+Pattern:
+
+```text
+We thank the reviewer for highlighting this point. We have clarified [issue] in the revised
+manuscript and now state [brief content of clarification]. This change appears in [location].
+```
+
+### Additional analysis
+
+Use when the authors addressed the concern by reanalysing existing data.
+
+Pattern:
+
+```text
+We performed an additional analysis of [dataset or comparison] and found that [high-level result].
+We have incorporated this analysis in [figure/table/supplementary note] and revised the text in
+[location].
+```
+
+### Additional experiment
+
+Use when the authors actually conducted new work for the revision.
+
+Pattern:
+
+```text
+In response to this concern, we performed [experiment]. The new results show [high-level outcome]
+and are now presented in [figure/table/location].
+```
+
+### Limitation acknowledged rather than fully resolved
+
+Use when the reviewer asks for something outside feasible scope.
+
+Pattern:
+
+```text
+We agree that this is an important point. Although [requested work] is beyond the scope of the
+current study / not feasible because [reason], we have now clarified this limitation in [location]
+and added [supporting discussion or caveat].
+```
+
+### Citation or prior-work correction
+
+Use when the issue is novelty framing or incomplete attribution.
+
+Pattern:
+
+```text
+We thank the reviewer for noting this omission. We have added the relevant references and revised
+the text to better position our work relative to prior studies in [location].
+```
+
+## Frequent weak patterns to avoid
+
+| Weak move | Why it fails | Stronger move |
+|---|---|---|
+| We have revised accordingly. | Says nothing about the actual change. | State what changed and where. |
+| We respectfully disagree. | Too abrupt and often reads defensive. | Give the reason first, then state the alternative action. |
+| This is beyond the scope. | Sounds evasive without context. | Explain why and address the underlying concern indirectly. |
+| We thank the reviewer and have made the suggested changes. | Too generic. | Name the change, result, and manuscript location. |
+| The line has been changed. | Ambiguous and document-version dependent. | State the revised content and its section or figure anchor. |
+
+## Practical response shape from transparent peer review
+
+Nature-family peer review files commonly show:
+
+- grouped responses by reviewer
+- one numbered response per comment
+- short acknowledgement followed by concrete revision details
+- cross-reference to figures, supplementary notes, or methods text
+- explicit admission when an issue is a limitation rather than a resolved result
+
+Do not imitate idiosyncratic tone from one paper too closely. Reuse the structure, not the voice.

--- a/nature-response/references/response-structure.md
+++ b/nature-response/references/response-structure.md
@@ -1,0 +1,72 @@
+# Response Structure
+
+Use this file when structuring a point-by-point response package.
+
+## Default package order
+
+1. Short opening note to the editor
+2. Editor-only requests, if any
+3. Reviewer sections in numerical order
+4. Closing note summarizing high-level changes, only if useful
+
+Do not hide reviewer-specific replies inside one long narrative letter when the journal expects
+point-by-point responses.
+
+## Standard response block
+
+Use one block per reviewer point:
+
+```text
+Comment [n]:
+[quoted or tightly summarized reviewer point]
+
+Response:
+We thank the reviewer for this comment. We [clarified / added / reanalysed / corrected / did not
+change] [specific issue]. [One sentence on what was done or why it was not done.] [Exact location:
+Methods paragraph, Results section, Fig. 2 legend, Supplementary Note 3, etc.]
+```
+
+The opening thanks can be short. The value is in the action and the evidence.
+
+## What a strong response block contains
+
+- an explicit answer to the point
+- a concrete author action or a clear reason for not taking the requested action
+- enough scientific detail for the editor or reviewer to assess the change
+- exact manuscript mapping when available
+
+## Manuscript mapping guidance
+
+Prefer precise document anchors:
+
+- `Results, paragraph 3`
+- `Methods, subsection "Model training"`
+- `Fig. 2b and accompanying legend`
+- `Supplementary Table 4`
+
+Use exact line numbers only when the user supplies the revised manuscript numbering or asks for
+line-number formatting specifically. Do not invent them.
+
+## Editor comments versus reviewer comments
+
+- Put editor comments first when they impose global tasks such as reporting standards, figure
+  resolution, data deposition, code sharing, or title/format restrictions.
+- Do not answer editor instructions as if they were reviewer comments.
+- If one edit resolves several reviewer points, say so in each relevant block instead of making the
+  reader hunt for the explanation elsewhere.
+
+## Non-change responses
+
+When the authors did not follow a request:
+
+- state the scientific or practical reason directly
+- explain the closest alternative analysis or clarification added
+- avoid sounding dismissive or evasive
+
+Example pattern:
+
+```text
+We appreciate this suggestion. We did not perform [requested task] because [specific constraint or
+scope reason]. To address the underlying concern, we [added control / clarified limitation /
+expanded discussion] in [location].
+```

--- a/nature-response/references/source-basis.md
+++ b/nature-response/references/source-basis.md
@@ -1,0 +1,34 @@
+# Source Basis
+
+Use this file when a user asks why a rule exists, wants primary-source justification, or needs to
+audit the `nature-response` skill against real revision and peer review practice.
+
+## Source map
+
+| Skill rule | Primary support |
+|---|---|
+| Response files should be point-by-point and traceable to reviewer comments. | Nature-family transparent peer review files commonly publish grouped reviewer comments followed by author responses, which establishes the practical response shape used in revision. |
+| Editors and reviewers need specific manuscript-change mapping, not vague assurances. | Springer Nature author guidance on manuscript revision emphasizes clear responses to reviewer comments and explicit manuscript changes during resubmission. |
+| Responses should distinguish reviewer comments from editor requests. | Nature Portfolio submission workflows and revision instructions often separate editor decisions from reviewer reports and require authors to address each explicitly. |
+| It is acceptable to decline a request when the reason is scientific, scope-based, or feasibility-based, but the response must still address the concern. | Real peer review files from Nature-family journals frequently show justified non-adoption paired with added clarification, limitation text, or alternative analysis. |
+| Tone should be respectful, specific, and non-defensive. | Springer Nature's reviewer-response guidance and published peer review files consistently show concise acknowledgement followed by concrete action or reasoning. |
+| The response must not claim experiments, analyses, line numbers, or textual changes that are not actually present. | Revision responses are part of the formal submission record and are assessed against the revised manuscript, figures, and supplement. |
+
+## Official and practice sources
+
+- Springer Nature, publishing guide for authors:
+  <https://www.nature.com/nature-portfolio/for-authors/publish>
+- Springer Nature, effective response to reviewers:
+  <https://www.nature.com/documents/Effective_Response_To_Reviewers-1.pdf>
+- Nature Communications, transparent peer review FAQ:
+  <https://www.nature.com/ncomms/submit/tpr-faq>
+- Nature Communications, transparent peer review policy PDF:
+  <https://www.nature.com/documents/ncomms-transparent-peer-review.pdf>
+- Nature Geoscience, practical guidance on responses to review:
+  <https://www.nature.com/articles/s41561-019-0386-7>
+
+## Practice notes
+
+- Use journal-specific revision instructions first when available.
+- Use transparent peer review files to infer structure and tone, not to copy wording.
+- Keep this file as a source map, not a long mirror of editorial guidance.

--- a/nature-response/references/tone-and-risk.md
+++ b/nature-response/references/tone-and-risk.md
@@ -1,0 +1,59 @@
+# Tone And Risk
+
+Use this file when calibrating tone or auditing a draft response for problems.
+
+## Tone rules
+
+- Be respectful without becoming ceremonial.
+- Prefer short, direct sentences over ornate gratitude.
+- Match confidence to evidence. Do not overstate what new experiments or analyses prove.
+- Defend scientific choices when needed, but do it with reasons and evidence, not posture.
+- Keep the response professional even when the reviewer seems mistaken.
+
+## Strong tone patterns
+
+- `We thank the reviewer for raising this point.`
+- `We agree that this issue required clarification.`
+- `To address this concern, we performed...`
+- `We have revised the manuscript to clarify...`
+- `We did not perform [requested task] because..., but we have...`
+
+## Risk flags
+
+Block or rewrite when you see:
+
+- a response claims a change without saying what changed
+- line numbers are given but the user never supplied them
+- an experiment is implied but the user only revised wording
+- the author says `we agree` and then never changes anything
+- the response introduces new claims stronger than the manuscript itself
+- the author disputes the reviewer without explaining the scientific basis
+- several reviewer points are answered with one recycled paragraph
+
+## Disagreement patterns
+
+Use disagreement sparingly and analytically.
+
+Pattern:
+
+```text
+We appreciate this comment. We interpret this point differently because [scientific reason,
+dataset limitation, or scope definition]. To make this clearer, we have revised [text/discussion]
+in [location] and now state [brief revised position].
+```
+
+Avoid:
+
+- `The reviewer is incorrect.`
+- `We do not agree with this comment.`
+- `This request is unreasonable.`
+
+## Final audit
+
+Before finalizing, confirm:
+
+- every reviewer point receives a distinct response
+- every response says what changed, what evidence supports it, or why no change was made
+- manuscript anchors are real and not invented
+- tone is respectful but not vague
+- the response package matches the actual revised manuscript and supplement

--- a/nature-response/references/tutorials.md
+++ b/nature-response/references/tutorials.md
@@ -1,0 +1,117 @@
+# Tutorials
+
+Use this file when the user needs a worked example rather than only abstract guidance.
+
+## Tutorial 1: Clarification plus new analysis
+
+### Input situation
+
+- Reviewer 1 asks whether cohort selection criteria were too loose.
+- Reviewer 2 asks whether the statistical comparison in Fig. 3 is robust.
+- The authors revised the Methods text and added a sensitivity analysis in the supplement.
+
+### Weak draft
+
+```text
+We thank the reviewers for these helpful comments. We have carefully revised the manuscript and
+added the requested information. The issues have now been addressed.
+```
+
+Why this fails:
+
+- it does not separate comments
+- it does not say what changed
+- it does not map the change to a location
+- it makes the editor search the manuscript for evidence
+
+### Better response package
+
+```text
+Reviewer 1
+Comment 1: Please clarify the cohort selection criteria.
+Response: We thank the reviewer for raising this point. We have revised the Methods section to
+state the cohort inclusion and exclusion criteria explicitly, including the enrolment window,
+minimum follow-up requirement, and pre-specified exclusion of participants with incomplete baseline
+records. This clarification now appears in Methods, subsection "Cohort selection".
+
+Reviewer 2
+Comment 1: The statistical test used in Fig. 3 should be justified.
+Response: We agree that the original description was too brief. We now specify the statistical test
+and the rationale for its use in the Methods subsection "Statistical analysis". In addition, we
+performed a sensitivity analysis using a non-parametric alternative and obtained the same overall
+conclusion. The new analysis is reported in Supplementary Note 2 and Supplementary Fig. 6.
+```
+
+### Why the better version works
+
+- each comment receives its own answer
+- each answer says whether the fix was textual or analytical
+- the manuscript anchors are specific enough to verify
+- the tone is direct and non-defensive
+
+## Tutorial 2: Respectful disagreement with partial accommodation
+
+### Input situation
+
+- Reviewer asks for a new in vivo experiment.
+- The authors cannot complete it within the current study, but they added a limitation paragraph
+  and re-framed the claim.
+
+### Weak draft
+
+```text
+This experiment is beyond the scope of the paper.
+```
+
+Why this fails:
+
+- the response sounds dismissive
+- it does not explain why the request was not followed
+- it does not show how the underlying concern was addressed
+
+### Better response
+
+```text
+We appreciate this suggestion and agree that in vivo validation would further strengthen the study.
+We did not perform this experiment in the current revision because the manuscript is focused on the
+mechanistic and ex vivo evidence, and an adequately powered in vivo study would require a separate
+experimental design beyond the scope of the present work. To address the reviewer's underlying
+concern, we have revised the Discussion to make this limitation explicit and to narrow the claim
+regarding translational applicability. These changes appear in the Discussion, paragraphs 4-5.
+```
+
+### Why the better version works
+
+- it acknowledges the value of the request
+- it gives a scientific scope reason rather than a convenience excuse
+- it narrows the manuscript claim instead of pretending the issue disappeared
+
+## Tutorial 3: Chinese draft to submission-ready English
+
+### Chinese author note
+
+```text
+感谢审稿人。我们已认真修改，并在正文中补充说明。由于时间原因，没有补做动物实验。
+```
+
+### Submission-ready direction
+
+```text
+We thank the reviewer for this comment. We have added a clarifying discussion in the revised
+manuscript to explain [specific issue]. We did not perform the requested animal experiment in the
+current revision because [scientific scope or feasibility reason]. To address the underlying
+concern, we have narrowed the corresponding claim and added an explicit limitation in [location].
+```
+
+### Conversion rule
+
+Do not translate:
+
+- `已认真修改` as a standalone sentence
+- `由于时间原因` as the main reason
+
+Translate into:
+
+- the exact revision made
+- the defensible reason for non-adoption
+- the manuscript location that now reflects the change

--- a/nature-response/scripts/lint_response.py
+++ b/nature-response/scripts/lint_response.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""
+Check a draft response-to-reviewers file for common structural problems.
+
+Usage:
+    python lint_response.py response.txt
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+REVIEWER_RE = re.compile(r"^\s*Reviewer\s+\d+\s*$", re.IGNORECASE)
+COMMENT_RE = re.compile(r"^\s*Comment\s+\d+\s*:", re.IGNORECASE)
+RESPONSE_RE = re.compile(r"^\s*Response\s*:\s*(.*)$", re.IGNORECASE)
+
+
+def lint_response(text: str) -> list[str]:
+    issues: list[str] = []
+    lines = text.splitlines()
+
+    reviewer_count = sum(1 for line in lines if REVIEWER_RE.match(line))
+    comment_count = sum(1 for line in lines if COMMENT_RE.match(line))
+    response_lines = [line for line in lines if RESPONSE_RE.match(line)]
+
+    if reviewer_count == 0:
+        issues.append("No reviewer sections found.")
+    if comment_count == 0:
+        issues.append("No comment blocks found.")
+    if not response_lines:
+        issues.append("No response blocks found.")
+
+    for idx, line in enumerate(lines, start=1):
+        if COMMENT_RE.match(line):
+            has_response = False
+            for follow in lines[idx:]:
+                if COMMENT_RE.match(follow) or REVIEWER_RE.match(follow):
+                    break
+                match = RESPONSE_RE.match(follow)
+                if match:
+                    has_response = True
+                    if not match.group(1).strip():
+                        issues.append(f"Empty response placeholder near line {idx}.")
+                    break
+            if not has_response:
+                issues.append(f"Comment block near line {idx} has no Response:.")
+
+    return issues
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Lint a response-to-reviewers draft.")
+    parser.add_argument("input", help="Path to rebuttal draft")
+    args = parser.parse_args()
+
+    text = Path(args.input).read_text(encoding="utf-8")
+    issues = lint_response(text)
+
+    if issues:
+        for issue in issues:
+            print(f"- {issue}")
+        sys.exit(1)
+
+    print("No structural issues found.")
+
+
+if __name__ == "__main__":
+    main()

--- a/nature-response/scripts/response_template.py
+++ b/nature-response/scripts/response_template.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+Build a point-by-point response template from plain-text reviewer comments.
+
+Usage:
+    python response_template.py comments.txt
+    python response_template.py comments.txt --output template.txt
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+REVIEWER_HEADER_RE = re.compile(r"^\s*(reviewer|referee)\s*#?\s*(\d+)\s*:?\s*$", re.IGNORECASE)
+COMMENT_HEADER_RE = re.compile(r"^\s*(comment|point)\s*#?\s*(\d+)\s*:?\s*$", re.IGNORECASE)
+NUMBERED_POINT_RE = re.compile(r"^\s*(\d+)[\.\)]\s+(.+)$")
+
+
+def parse_comments(text: str) -> list[tuple[str, list[str]]]:
+    reviewers: list[tuple[str, list[str]]] = []
+    current_reviewer = "Reviewer 1"
+    current_comments: list[str] = []
+    current_block: list[str] = []
+
+    def flush_block() -> None:
+        nonlocal current_block, current_comments
+        block = "\n".join(line.rstrip() for line in current_block).strip()
+        if block:
+            current_comments.append(block)
+        current_block = []
+
+    def flush_reviewer() -> None:
+        nonlocal current_reviewer, current_comments
+        flush_block()
+        if current_comments:
+            reviewers.append((current_reviewer, current_comments))
+        current_comments = []
+
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip()
+        if REVIEWER_HEADER_RE.match(line):
+            flush_reviewer()
+            reviewer_num = REVIEWER_HEADER_RE.match(line).group(2)
+            current_reviewer = f"Reviewer {reviewer_num}"
+            continue
+        if COMMENT_HEADER_RE.match(line):
+            flush_block()
+            continue
+        numbered = NUMBERED_POINT_RE.match(line)
+        if numbered:
+            flush_block()
+            current_block.append(numbered.group(2))
+            continue
+        if not line.strip():
+            flush_block()
+            continue
+        current_block.append(line)
+
+    flush_reviewer()
+    return reviewers or [("Reviewer 1", [text.strip()] if text.strip() else [])]
+
+
+def render_template(reviewers: list[tuple[str, list[str]]]) -> str:
+    parts = ["Response to Reviewers", "", "Editor comments", "- None", ""]
+    for reviewer_name, comments in reviewers:
+        parts.append(reviewer_name)
+        if not comments:
+            parts.append("Comment 1: [insert reviewer comment]")
+            parts.append("Response: [insert response]")
+            parts.append("")
+            continue
+        for idx, comment in enumerate(comments, start=1):
+            compact = " ".join(segment.strip() for segment in comment.splitlines()).strip()
+            parts.append(f"Comment {idx}: {compact}")
+            parts.append("Response: [insert response]")
+            parts.append("")
+    parts.extend(
+        [
+            "Revision risks / missing confirmations",
+            "- [insert missing evidence, line numbers, or unresolved points]",
+            "",
+            "中文核对",
+            "- [插入需要作者确认的内容]",
+        ]
+    )
+    return "\n".join(parts).rstrip() + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build a Nature-style response template.")
+    parser.add_argument("input", help="Plain-text reviewer comments file")
+    parser.add_argument("--output", help="Optional output path")
+    args = parser.parse_args()
+
+    source = Path(args.input)
+    text = source.read_text(encoding="utf-8")
+    rendered = render_template(parse_comments(text))
+
+    if args.output:
+        Path(args.output).write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR adds a new `nature-response` skill for Nature-family revision workflows and updates the public skill index to reflect validated skill maturity.

## What changed

- add `nature-response` as a new skill for:
  - point-by-point responses to reviewers
  - editor response notes
  - Chinese-to-English rebuttal drafting
- add structured references for:
  - response structure
  - real-world response patterns
  - tone and risk control
  - Chinese author alignment
  - source basis
  - worked tutorials
- add two helper scripts:
  - `scripts/response_template.py` to convert plain-text reviewer comments into a rebuttal scaffold
  - `scripts/lint_response.py` to catch common structural problems in rebuttal drafts
- update the root `README.md`:
  - add `nature-response` to the skill index
  - mark `nature-data` and `nature-response` as `Beta`
  - remove stale candidate status for `nature-response`
  - align public descriptions with current skill structure
- tighten a few public-facing metadata/readme labels for consistency

## Validation

- ran `quick_validate.py` successfully on `nature-response`
- exercised `response_template.py` on realistic reviewer-comment input
- exercised `lint_response.py` on an intentionally incomplete rebuttal draft
- fixed a real parsing issue where multiple numbered comments under one reviewer were merged

## Why

The repository already had mature support for figures, prose polishing, and data availability. This PR extends that pattern to revision-response work using:
- real Nature-family revision practice
- source-backed structure and tone guidance
- lightweight tooling for repetitive formatting and structural checks

## Scope notes

This PR only includes the new skill and the public-facing documentation/metadata needed to index it cleanly.
Unrelated local files and workspace artifacts are intentionally excluded.