### PR TITLE
Add news digest writer skill

### DIFF
--- a/skills/news-digest-writer/SKILL.md
+++ b/skills/news-digest-writer/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: news-digest-writer
+description: Collect news from specified webpages or source lists, select items matching configured topics and rules, and rewrite them into a fixed Chinese news稿 format with source links. Use when Codex needs to open news pages, monitor webpages, pick relevant news, summarize selected items, or produce structured Chinese news drafts from online sources.
+---
+
+# News Digest Writer
+
+## Workflow
+
+1. Read `references/source-list.md` when the user does not provide a specific URL or when recurring sources are needed.
+2. Open each specified webpage with the best available browser or web tool.
+3. Treat the run start time, login time, or user-provided collection time as the collection anchor.
+4. Browse each source chronologically from newest to older. Scroll down, click pagination, or use "load more" until article publish times are older than 26 hours before the collection anchor. If a source lists only a calendar date without a specific time, allow the previous natural calendar day as the earliest acceptable date.
+5. If a webpage cannot be opened, loads too slowly, blocks access, or lacks enough information to verify candidates, retry or use fallback discovery up to 5 total attempts. Fallback discovery includes `site:domain` search queries, opening specific article pages from search results, and trying AMP/mobile variants when available. If all 5 attempts fail, skip that webpage for the current run and continue with other sources.
+6. Extract candidate items with title, URL, publisher/source, publish time, author if available, and body text or summary.
+7. Before final selection, inspect available reports generated in the previous 3 natural days and remove repeated or substantially similar news topics.
+8. Read `references/selection-rules.md` before selecting items.
+9. Keep only items that satisfy the inclusion rules and do not hit the exclusion rules.
+10. Prefer primary sources, official releases, filings, government pages, and reputable media. Use current publish dates and verify time-sensitive claims.
+11. Read `references/article-template.md` before drafting.
+12. Draft in the "印度、东盟农业政策跟踪" monitoring format from `references/article-template.md`. Preserve names, dates, numbers, locations, organizations, and source links.
+13. When the user asks to run a report or output the result, create a Word `.docx` file matching the provided sample format unless the user explicitly asks for plain text only.
+
+## Source Handling
+
+- Use absolute dates such as `2026年5月13日`; avoid only `今天`, `昨日`, or `近期` unless the source itself is vague.
+- Convert relative publish times such as `3 hours ago` or `yesterday` into absolute times using the collection anchor and the source site's timezone when available.
+- If the article has a date but no specific time, accept articles from the collection date and the previous natural calendar day; for example, a May 13 run may include May 12 articles when no time is shown.
+- Do not invent missing facts. If a key detail is unavailable, say it is not disclosed or not found in the source.
+- Do not copy long passages from source articles. Summarize and rewrite in original wording.
+- When multiple articles report the same event, use the most authoritative source as the lead source and list supporting sources separately.
+- For paywalled or partially visible pages, use only visible facts unless another accessible source confirms the missing details.
+- For inaccessible or incomplete webpages, retry or use fallback discovery up to 5 total attempts. After 5 failed attempts, abandon that webpage for the current run instead of blocking the whole report.
+- Fallback discovery pattern: search `site:{domain} {country/source topic keywords} {date/month}` and open specific article URLs from search results. This is required for sources like AKP where the homepage may be difficult to fetch but article pages are searchable.
+
+## Time Window And Paging
+
+- Default valid window: 26 hours before the collection anchor through the collection anchor.
+- Date-only fallback: when no publish time is visible after checking the article page, include articles dated on the collection date or the previous natural calendar day, and exclude older dated articles.
+- Continue scrolling, loading more, or opening the next page while the visible articles may still include items inside the 26-hour window.
+- Stop a source only after reaching articles whose publish times are clearly older than the 26-hour window, or after the source has no more older pages to load.
+- If article cards do not show publish times, open likely relevant articles until their article pages confirm whether they are inside or outside the 26-hour window.
+- Record the collection anchor in the final output when the user asks for a daily or time-windowed digest.
+
+## Three-Day Duplicate Filter
+
+- Before drafting, compare candidates against the generated reports from the previous 3 natural days when those files are available.
+- Check recent `.docx` reports in the user's monitoring folders and the current workspace output folder.
+- Filter out repeated news when the same event, policy, project, agreement, price movement, export/import result, or source URL has already appeared in those recent reports.
+- Keep a later article only if it contains material new facts, such as updated figures, a new policy decision, a new country response, or a meaningful follow-up not covered before.
+
+## Selection
+
+Use `references/selection-rules.md` as the default filter. If the user gives new rules, treat them as higher priority for that run and mention any major conflict with the saved rules.
+
+For each selected item, keep a short internal note with:
+
+- Why it matched the rules
+- Which source supports the core fact
+- Any uncertainty or missing field
+- Whether the item reflects substantive action, not just inspection, exploratory contact, or a small local installment of a broad national program
+- What concrete data supports its significance, such as trade quantity, shipment value, market affected, price, stock, output, procurement scale, or policy implementation scope
+- Whether an otherwise low-data item qualifies as ASEAN-level food security, energy security, agricultural supply-chain, reserve mechanism, or trade facilitation policy cooperation tied to a declaration, action plan, ministerial meeting, or regional mechanism
+
+## Output
+
+Use the fixed "印度、东盟农业政策跟踪" Word document format in `references/article-template.md` unless the user provides another template.
+
+Before finalizing, check:
+
+- Every factual claim is supported by a source.
+- The selected news matches the topic and event rules.
+- Exclude inspection-only or exploratory stories unless they produce a signed agreement, concrete procurement/export/import action, implemented policy, market access change, or measurable agricultural market impact.
+- Exclude minor local progress inside a broad national program unless it has independent significance for agricultural trade, prices, inputs, production capacity, rural finance, or market access.
+- Exclude items with weak data support or small activity scale when they do not represent a national policy shift, cross-border trade action, or measurable agricultural market impact.
+- Exclude small-reach promotional activities, technical/laboratory process stories, and very narrow product-category access updates unless they clearly indicate a broader policy, trade, market-access, or measurable market trend.
+- Include ASEAN-level food security, energy security, agricultural supply-chain, reserve mechanism, or trade facilitation policy cooperation when tied to a named declaration, action plan, meeting, or regional mechanism; title and body must present it as regional policy cooperation, not as a concrete trade result.
+- Repeated or syndicated items are merged rather than duplicated.
+- News already used in the previous 3 natural days is removed unless it adds substantial new facts.
+- The tone is factual, concise, and publishable.
+- Source links are included.
+- Each item follows the sample style: title line, one dense rewritten paragraph ending with source/date in parentheses, and the original URL on the next line.
+- Article body length is a high-priority quality rule, not a cosmetic preference. Each article body should normally land in the 330-380 Chinese character range, with about 350 Chinese characters as the target. Do not treat any draft below 320 Chinese characters as finished unless the source truly lacks additional verified facts after rechecking the article.
+- Before accepting a short draft, add verified facts from the source where available: policy mechanism, responsible agency, product or market scope, trade quantity/value, price or stock data, implementation timeline, affected countries, stated rationale, and follow-up action. If a candidate cannot support at least about 320 Chinese characters of substantive, non-padded content, prefer dropping it rather than publishing a thin item.
+- The hard maximum for each article body is 500 Chinese characters. After meeting the 330-380 target where possible, shorten any draft over 500 characters before generating the Word file.
+- The final artifact is a `.docx` file when a report is being produced.
+- The guide section must correspond one-to-one with final news titles: no numbering, each guide line is exactly the corresponding title plus `。`.
+- Before creating the Word file, check and record each article body length. Revise any body below 320 Chinese characters by adding verified source details or replacing the item; aim for 330-380 characters, and revise any body over 500 Chinese characters down below the hard limit.
+- Before creating the Word file, ensure titles emphasize the substantive trade or policy action, not courtesy language such as thanking, meeting, or discussing. For example, prefer `印尼首批对澳大利亚出口尿素装运出港` over `澳大利亚感谢印尼供应化肥`.
+- Before creating the Word file, check terminology and names: use full official institution names on first mention, translate obscure English technical terms into clear Chinese policy/regulatory language, avoid unexplained raw English, and add necessary geographic qualifiers in titles for unfamiliar places.
+- Use Chinese institution names in titles when available, and avoid raw English acronyms or organization names such as `Bulog`.
+- Introduce or translate source acronyms before use. Prefer Chinese throughout for terms such as `食品供应和价格稳定计划`; do not leave unexplained forms such as `SPHP`.
+- Explain non-universal source categories such as `一区`, `二区`, or `三区` by adding the covered regions or rewriting the sentence so readers understand the scope.
+- Ensure every USD conversion keeps exactly two decimal places.
+- The Word layout follows the user's final formatting rules: red centered bold main title, blue centered daily title, unnumbered guide title lines, one news item per page, first article starts after a page break, 1.5 line spacing, and justified article bodies with a two-character first-line indent.
+
+## Optional Script
+
+Use `scripts/extract_article.py` when a single URL needs quick article text extraction from static HTML. Browser tools may still be better for dynamic pages, login pages, complex layouts, or manual verification.
+
+Use `scripts/extract_recent_report_items.py` to extract recent report titles and URLs for the 3-day duplicate filter.
+
+Use `scripts/create_digest_docx.py` to generate the final Word document from a JSON report payload.

--- a/skills/news-digest-writer/agents/openai.yaml
+++ b/skills/news-digest-writer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "News Digest Writer"
+  short_description: "从指定网页筛选相关新闻内容并按固定模板生成中文新闻稿"
+  default_prompt: "打开指定新闻网页，筛选符合规则的内容，并按固定模板写成中文新闻稿。"

--- a/skills/news-digest-writer/references/article-template.md
+++ b/skills/news-digest-writer/references/article-template.md
@@ -1,0 +1,121 @@
+# Article Template
+
+Use this template for the user's "印度、东盟农业政策跟踪" daily monitoring drafts. The default final output is a Word `.docx` file. The structure is based on the provided Word samples from 2026年4月29日 to 2026年5月12日.
+
+## Document Header
+
+```text
+印度、东盟农业政策跟踪
+总第{issue_number}期
+华南农业大学经济管理学院                          {yyyy.m.d}
+{yyyy年m月d日}印度、东盟农业政策动态
+【本期导读】
+{导读1}
+{导读2}
+```
+
+- Use the collection/report date in both date positions.
+- Use `总第{issue_number}期` only when the issue number is known or provided. If unknown, ask the user or leave a placeholder.
+- Keep `华南农业大学经济管理学院` in the header unless the user provides another unit.
+- The guide section must correspond one-to-one with the final news items. Each guide line should be the exact final news title plus `。`.
+
+## News Item Format
+
+For each selected news item, write:
+
+```text
+{新闻标题}
+近日，{主体/机构}表示/数据显示/发布/宣布，{核心事实}。{背景、数字、原因、影响和后续安排}。（{中文来源名}，{m月d日}）
+{source_url}
+```
+
+- Place each news title on its own line.
+- Put the full rewritten article in one dense paragraph after the title.
+- Put the source name and date at the end of the paragraph in Chinese parentheses, then put the URL on the next line.
+- Use the source Chinese names from `source-list.md`: 曼谷邮报、泰国国家报、高棉时报、安塔拉新闻社.
+- If the source date is not visible, omit the date in parentheses only when it cannot be verified.
+- Do not add labels such as `【正文】`, `【信息来源】`, `摘要`, or `影响分析` inside the final draft unless the user asks for a different format.
+
+## Title Style
+
+- Write a concise declarative Chinese title, usually 16-28 Chinese characters.
+- Write titles for an international agricultural trade and policy briefing, not as general news headlines.
+- Capture the substantive trade or policy action in the title, especially phrases such as `首批出口`, `装运出港`, `签署协议`, `批准协定`, `开放市场准入`, `启动采购`, `进口配额`, `出口限制`, `价格上涨`, or `供应短缺`.
+- Avoid courtesy, diplomatic, or public-relations angles such as `感谢`, `会见`, `强调`, `表示`, or `讨论` when a concrete trade action is available.
+- Do not use raw English organization names or acronyms in titles when a clear Chinese name exists. For example, write `印度尼西亚国家物流署将在2026年投放82.8万吨稳价大米`, not `印尼Bulog全年投放82.8万吨稳价大米`.
+- Prefer the pattern `{国家/主体}+{关键贸易/政策动作}+{产品/市场}`.
+- Add essential location qualifiers in titles when the place may be unfamiliar to the target reader. For example, write `中国磨憨口岸前四月进口鲜榴莲12.1万吨`, not only `磨憨口岸前四月进口鲜榴莲12.1万吨`.
+- Use goal-oriented title wording when appropriate, such as `以冲刺...目标`, to clarify that a policy action supports an export or trade target.
+- Examples of acceptable shapes:
+  - `泰国加大榴莲等水果推广力度，力争出口额较去年增长5%`
+  - `印尼将推动棕榈油产品满足《欧盟零毁林法案》认证`
+  - `霍尔木兹海峡危机推高尿素价格并冲击亚洲粮食安全`
+
+## Paragraph Style
+
+- Start most articles with `近日，`.
+- Body length is a high-priority content-quality rule. Use one long integrated paragraph per item, normally 330-380 Chinese characters, with about 350 Chinese characters as the target.
+- A body below 320 Chinese characters is not acceptable as a finished item unless the source truly lacks additional verified facts after rechecking. First add substantive details from the source: policy mechanism, responsible agency, product or market scope, trade quantity/value, price or stock data, implementation timeline, affected countries, stated rationale, and follow-up action.
+- Do not pad with vague background, generic importance, repetition, or unsupported analysis just to hit the target. If the source cannot support about 320 Chinese characters of substantive content, replace or drop the item.
+- The hard maximum is 500 Chinese characters for each article body. First satisfy the 330-380 target where possible, then shorten any paragraph over 500 characters before generating the Word file.
+- Include concrete numbers, dates, agencies, countries, products, prices, export/import amounts, policy names, and affected markets when available.
+- Sequence the paragraph as: event lead, key data, reason/background, market or policy impact, follow-up action or broader implication.
+- Keep tone neutral, factual, and research-monitoring oriented.
+- Avoid unsupported dramatic words such as `重磅`, `爆发`, `颠覆`, `史诗级`, `遥遥领先`.
+- Translate English source facts into natural simplified Chinese; do not preserve awkward source syntax.
+- Translate obscure professional English terms into generally understandable Chinese policy or regulatory language. Avoid leaving raw technical English in the final text unless the exact term is necessary and can be explained naturally.
+- Translate or introduce source acronyms before use. Prefer the Chinese policy or institution name throughout when it is clear; if an acronym is necessary, write the Chinese name first and put the acronym in parentheses on first mention. Do not use unexplained forms such as `SPHP` or `Bulog`.
+- Explain non-universal administrative or pricing categories on first mention. If a source uses labels such as `一区`, `二区`, or `三区`, add the covered places in parentheses or rewrite the sentence so readers understand the geographic scope.
+- Do not mistranslate technical systems or terms. If a term is unclear, use a broader accurate expression such as `通关制度`, `检验检疫制度`, `出口认证制度`, `追溯系统`, or `相关法规`, based on source context.
+- Use full official institution names on first mention, such as `泰国农业与合作社部`; do not shorten to `农业部` if the country has a more specific official ministry name. After first mention, use `该部门`, `泰方`, or the full name again.
+- Translate all personal names into Chinese. On first mention, use the Chinese transliteration and include the original English name only when needed for disambiguation.
+- Convert every non-USD currency amount into USD immediately after the original amount, using the form `xxxx越南盾（约合xx美元）`, `xxxx泰铢（约合xx美元）`, or the relevant currency name. If an exchange rate must be looked up, use a current reliable rate and keep the conversion approximate.
+- Converted USD amounts must keep exactly two decimal places. For large amounts, use natural Chinese units such as `万美元` or `亿美元`, also with exactly two decimal places when a decimal is shown.
+- Preserve integer data as integers when the source gives integers, including dates, months, years, days, numbers of vessels, people, provinces, policies, containers, animals, and tonnes.
+- Do not add meaningless `.00` to source figures that are integers. Only keep decimals when the original figure has decimals, when rounding is needed, or when presenting currency conversions.
+- Do not over-precision copied percentages or amounts; for example, write `3.82%`, `0.19%`, `约合6.38亿美元`, or `约合1.20美元`, but write `220万吨`, `700万吨`, `3个月`, and `1582艘`.
+
+## Guide Sentence Style
+
+- Each guide sentence must match the corresponding news title exactly, followed by `。`.
+- Do not number guide sentences in the Word output.
+- End each guide sentence with `。`.
+
+## Final Checks
+
+- The header date, source date, and article facts are consistent.
+- The number of guide lines equals the number of news items, and each guide line matches its corresponding news title.
+- Every selected item has a title, one paragraph, and a source URL.
+- The paragraph ends with `（来源名， m月d日）` or `（来源名）` before the URL.
+- There are no bullet lists in the article body.
+- The output keeps only relevant agriculture, rural, agricultural product, input, finance, price, import/export, or trade-policy content.
+- Every currency amount includes an immediate USD conversion unless it is already denominated in USD.
+- Every USD conversion keeps exactly two decimal places, such as `约合4.01亿美元` or `约合5.59美元`.
+- Specialized English words and official terms are translated into clear Chinese, or replaced with a broader accurate policy/regulatory expression when the literal term would be obscure.
+- Acronyms and source shorthand are translated or introduced before use; the final body must not contain unexplained abbreviations.
+- Non-universal labels such as price zones, administrative groupings, program tiers, or source-specific categories are explained with their geographic or policy scope on first mention.
+- Official institution names are complete on first mention and not casually shortened.
+- Titles use Chinese institution names when available and avoid raw English acronyms or organization names.
+- Titles include necessary geographic qualifiers for ports, cities, provinces, or border crossings that readers may not recognize.
+- Personal names are written in Chinese.
+- Numbers are rounded to two decimal places where rounding is appropriate.
+- Integers from the source are not padded with `.00`.
+- Each article body should normally be 330-380 Chinese characters, targeting about 350, and must not exceed 500 Chinese characters. Before Word generation, record the character count of every body; any body below 320 Chinese characters must be expanded with verified source details, replaced with a stronger item, or explicitly justified as source-limited.
+
+## Word Output
+
+- Generate a `.docx` file by default for finished reports.
+- Use `scripts/create_digest_docx.py` with a JSON payload containing `issue_number`, `date_text`, `date_short`, `guide`, and `items`.
+- Match the sample layout:
+  - Main title: `印度、东盟农业政策跟踪`, centered, bold, dark red, 36 pt.
+  - Issue line: centered, bold, 16 pt.
+  - Unit/date line: unit bold and left aligned, date bold and right aligned, 14 pt.
+  - Daily title: centered, bold, blue, 16 pt.
+  - `【本期导读】`: bold, 14 pt.
+  - Guide lines: unnumbered title lines matching final item titles, 12 pt.
+  - Start the first article on a new page after the guide section.
+  - Put each article on its own page.
+  - Item titles: centered, bold, 14 pt.
+  - Item body: 12 pt, justified, one dense paragraph with first-line indent of about 2 Chinese characters.
+  - URL: separate line after each item, aligned with body indentation.
+  - Line spacing: 1.5 for the whole document.

--- a/skills/news-digest-writer/references/selection-rules.md
+++ b/skills/news-digest-writer/references/selection-rules.md
@@ -1,0 +1,70 @@
+# Selection Rules
+
+## Include
+
+- Topics: 农业、农村、农产品、农业投入品、农业金融、农产品进出口、农产品国际贸易政策、农产品国际贸易协定、农业经济、农产品价格。
+- Related keywords: agriculture, agricultural products, rural, fertilizer, seed, pesticide, feed, irrigation, farm credit, agricultural finance, import, export, trade, commodity prices, food prices, crop prices, trade policy, trade agreement.
+- Regions: 东南亚优先，特别关注泰国、柬埔寨、印度尼西亚；include other regions only when directly relevant to agricultural trade with these markets or when the user specifies another market.
+- Event types: 政策发布、贸易协定、进出口变化、关税/非关税措施、价格波动、产量/供应变化、农资供应、农业金融政策、农村经济政策、重大项目、市场准入、检疫规则、政府采购、灾害对农业生产或价格的影响。
+- Regional policy cooperation: ASEAN-level food security, energy security, agricultural supply-chain cooperation, regional reserve mechanisms, trade facilitation, or implementation of ASEAN declarations/action plans may be included as policy consulting items even when specific trade volume is not available.
+- Relevance threshold: The news subject must be a core participant in the event, not merely mentioned in passing.
+- Timeliness: Include articles published within 26 hours before the collection anchor unless the user specifies another window. If the source shows only a calendar date and no time, include articles dated on the collection date or the previous natural calendar day.
+- Duplicate window: Before final selection, remove news that appeared in generated reports from the previous 3 natural days unless the new article adds substantial new facts.
+
+## Exclude
+
+- Pure marketing copy without concrete news facts.
+- Articles with no visible source, publish time, or verifiable event.
+- Articles published earlier than 26 hours before the collection anchor when a specific time is available.
+- Date-only articles older than the previous natural calendar day.
+- News topics, events, or source URLs already used in the previous 3 natural days of generated reports, unless there is a material update.
+- Duplicate reposts that add no new facts.
+- Opinion, rumor, anonymous speculation, or stock-price-only commentary unless the user explicitly asks for that category.
+- Items where the keyword appears only in tags, ads, recommendations, or unrelated sidebars.
+- General politics, tourism, entertainment, crime, or finance news unless it clearly affects agriculture, rural areas, agricultural inputs, agricultural finance, agricultural prices, or agricultural trade.
+- Pure inspection, visit, study tour, exploratory discussion, technology observation, or delegation activity unless it results in a signed agreement, implemented policy, confirmed procurement/export/import deal, market access change, investment launch, or other substantive trade or production action.
+- Small local progress within a very large national program unless the item has clear independent significance for agricultural trade, prices, inputs, production capacity, rural finance, or market access.
+- National-level or policy-framed stories that lack concrete data, implementation details, trade volume, price, procurement quantity, export/import value, affected market, or measurable scale.
+- Small-scale agricultural activities, ceremonies, launches, or harvest events whose data show limited scope or weak representativeness, unless they directly indicate a broader national market trend or policy shift.
+- Promotional campaigns, tasting events, media shows, local brand displays, or product-marketing activities whose practical reach is too small, even when they mention agriculture, rural producers, or geographical indications.
+- Technical research, testing methods, laboratory tools, or operational process improvements that are mainly scientific or quality-control oriented rather than a concrete trade policy, market access decision, export/import action, or regulatory change.
+- Very narrow product-category stories, including single niche seafood or specialty-product access updates, when the affected category has limited coverage and does not indicate a broader agricultural, food, fisheries, or trade-policy trend.
+
+## Ranking
+
+When several items match, prioritize:
+
+1. Higher factual importance or business impact.
+2. More authoritative source.
+3. More recent publication time.
+4. More complete details such as amount, parties, date, location, or official quote.
+
+For final inclusion, prefer fewer stronger items over padding the report. Exclude loosely related public-health, storage, consumer-safety, or general administrative notices unless they directly affect agricultural production, prices, trade, market access, rural economy, agricultural finance, or agricultural inputs.
+
+Do not include a story merely because it mentions agricultural modernization, cooperatives, rural areas, or food security. Require a concrete policy implementation, signed agreement, export/import behavior, procurement, measurable market effect, price change, input supply change, or production capacity impact.
+
+For policy and trade consulting output, favor items with concrete data support: export/import quantity, shipment value, affected country or market, agreement size, tariff/quota, price movement, stock level, production volume, or procurement scale. If an item lacks data support, include it only when the policy action itself is clearly significant at national or cross-border level.
+
+ASEAN-level food security or agricultural supply-chain policy cooperation is a valid exception to the data-support preference when it is tied to a named declaration, action plan, ministerial meeting, regional mechanism, or implementation agenda. Label it clearly as a regional policy cooperation development rather than a concrete trade result.
+
+## Paging And Stop Rule
+
+- For each source, start from the newest list page.
+- Scroll down, click `Next`, or use `Load more` until article publish times fall outside the 26-hour window.
+- If only dates are visible, continue until reaching articles older than the previous natural calendar day.
+- If the list page mixes old and new items, inspect additional pages until there are no plausible in-window items left.
+- Do not stop after the first screen unless all visible items are already older than the 26-hour window.
+- Use the source site's local timezone when clear; otherwise state the timezone assumption in the final output.
+- If a source page or article page cannot be opened, times out, blocks access, or lacks enough information after 5 total attempts, skip it for the current run and continue with other sources.
+- Before skipping, try fallback discovery with `site:domain` search queries and open specific article pages from search results. Use this especially for AKP (`akp.gov.kh`) and sources whose homepage blocks script access.
+
+## Three-Day Duplicate Filter
+
+- Search the previous 3 natural days of generated `.docx` reports before finalizing selection.
+- Compare by source URL, translated title, original title, named entities, product/crop, country, policy/agreement name, and core event.
+- Treat syndicated reposts and follow-on coverage of the same facts as duplicates.
+- Keep an item only when it adds material new information, such as updated trade value, new government action, new market access decision, new price data, or a new affected country.
+
+## Saved User Preferences
+
+Add confirmed user preferences here, such as preferred industries, blocked sources, required regions, or target publication tone.

--- a/skills/news-digest-writer/references/source-list.md
+++ b/skills/news-digest-writer/references/source-list.md
@@ -1,0 +1,73 @@
+# Source List
+
+Use this file for recurring source pages. When the user provides a URL directly, prioritize that URL for the run.
+
+## Thailand
+
+- Source name: 曼谷邮报
+  Site: bangkokpost.com
+  URL: https://www.bangkokpost.com/business
+  Section: Business
+
+- Source name: 泰国国家报
+  Site: nationthailand.com
+  URL: https://www.nationthailand.com/category/business
+  Section: Business
+
+- Source name: 泰国国家报
+  Site: nationthailand.com
+  URL: https://www.nationthailand.com/category/news/policy
+  Section: Policy
+
+## Cambodia
+
+- Source name: 高棉时报
+  Site: khmertimeskh.com
+  URL: https://www.khmertimeskh.com/category/business/
+  Section: Business
+
+- Source name: 柬埔寨新闻社
+  Site: akp.gov.kh
+  URL: https://www.akp.gov.kh/
+  Section: National news agency
+  Notes: If the homepage or category pages do not open directly, search `site:akp.gov.kh Cambodia agriculture export rice trade` and open specific article pages such as `/post/detail/...`.
+
+## Indonesia
+
+- Source name: 安塔拉新闻社
+  Site: antaranews.com
+  URL: https://en.antaranews.com/current-issue
+  Section: Current Issue
+
+- Source name: 安塔拉新闻社
+  Site: antaranews.com
+  URL: https://en.antaranews.com/business-investment
+  Section: Business & Investment
+
+- Source name: 安塔拉新闻社印尼语站
+  Site: antaranews.com
+  URL: https://www.antaranews.com/
+  Section: Indonesian main site
+  Notes: Include Indonesian-language Antara articles when English coverage misses relevant ASEAN food security, energy security, agricultural trade, or supply-chain policy items. Use `site:antaranews.com pangan ASEAN energi pertanian perdagangan` and related Indonesian keywords.
+
+- Source name: 安塔拉新闻社地方频道
+  Site: jatim.antaranews.com
+  URL: https://jatim.antaranews.com/
+  Section: Regional Antara channel
+  Notes: Use fallback search for regional Antara pages, especially `site:jatim.antaranews.com pangan ASEAN energi pertanian perdagangan`.
+
+## Search Queries
+
+- `agriculture agricultural agricultural products`
+- `rural`
+- `agricultural product export`
+- `agricultural product import`
+- `fertilizer`
+- `trade`
+- `pangan ASEAN energi pertanian perdagangan`
+- `ketahanan pangan ASEAN`
+- `food security ASEAN Indonesia agriculture`
+
+## Per-Run Source Notes
+
+Add stable, repeatedly useful sources back into this file after the user confirms they should become defaults. For one-off URLs, use them only for the current run unless the user asks to save them.

--- a/skills/news-digest-writer/scripts/create_digest_docx.py
+++ b/skills/news-digest-writer/scripts/create_digest_docx.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Create a Word report for the India-ASEAN agriculture monitoring digest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from docx import Document
+from docx.enum.text import WD_ALIGN_PARAGRAPH
+from docx.oxml import OxmlElement
+from docx.oxml.ns import qn
+from docx.shared import Inches, Pt, RGBColor
+
+
+def set_run_font(run, size: int, bold: bool = False, color: str | None = None) -> None:
+    run.bold = bold
+    run.font.name = "Times New Roman"
+    run.font.size = Pt(size)
+    if color:
+        run.font.color.rgb = RGBColor.from_string(color)
+    run._element.rPr.rFonts.set(qn("w:eastAsia"), "宋体")
+
+
+def add_paragraph(
+    doc: Document,
+    text: str,
+    size: int = 12,
+    bold: bool = False,
+    align=None,
+    color: str | None = None,
+):
+    para = doc.add_paragraph()
+    if align is not None:
+        para.alignment = align
+    para.paragraph_format.line_spacing = 1.5
+    run = para.add_run(text)
+    set_run_font(run, size=size, bold=bold, color=color)
+    return para
+
+
+def add_unit_date_line(doc: Document, unit: str, date_short: str):
+    para = doc.add_paragraph()
+    para.paragraph_format.line_spacing = 1.5
+    tab_stops = para.paragraph_format.tab_stops
+    tab_stops.add_tab_stop(Inches(6.5), WD_ALIGN_PARAGRAPH.RIGHT)
+    unit_run = para.add_run(unit)
+    set_run_font(unit_run, size=14, bold=True)
+    para.add_run("\t")
+    date_run = para.add_run(date_short)
+    set_run_font(date_run, size=14, bold=True)
+    add_bottom_border(para)
+    return para
+
+
+def set_document_margins(doc: Document) -> None:
+    section = doc.sections[0]
+    section.top_margin = Pt(72)
+    section.bottom_margin = Pt(72)
+    section.left_margin = Pt(72)
+    section.right_margin = Pt(72)
+
+
+def add_bottom_border(paragraph) -> None:
+    p_pr = paragraph._p.get_or_add_pPr()
+    borders = p_pr.find(qn("w:pBdr"))
+    if borders is None:
+        borders = OxmlElement("w:pBdr")
+        p_pr.append(borders)
+    bottom = OxmlElement("w:bottom")
+    bottom.set(qn("w:val"), "single")
+    bottom.set(qn("w:sz"), "6")
+    bottom.set(qn("w:space"), "1")
+    bottom.set(qn("w:color"), "000000")
+    borders.append(bottom)
+
+
+def build_docx(payload: dict, output: Path) -> None:
+    doc = Document()
+    set_document_margins(doc)
+
+    title = add_paragraph(
+        doc,
+        "印度、东盟农业政策跟踪",
+        size=36,
+        bold=True,
+        align=WD_ALIGN_PARAGRAPH.CENTER,
+        color="FF0000",
+    )
+    title.paragraph_format.space_after = Pt(0)
+
+    issue_number = payload.get("issue_number") or "{待确认}"
+    add_paragraph(doc, f"总第{issue_number}期", size=16, bold=True, align=WD_ALIGN_PARAGRAPH.CENTER)
+
+    date_short = payload["date_short"]
+    add_unit_date_line(doc, "华南农业大学经济管理学院", date_short)
+
+    add_paragraph(
+        doc,
+        f"{payload['date_text']}印度、东盟农业政策动态",
+        size=16,
+        bold=True,
+        align=WD_ALIGN_PARAGRAPH.CENTER,
+        color="08199A",
+    )
+    add_paragraph(doc, "【本期导读】", size=14, bold=True)
+
+    guide_items = payload.get("guide") or [item["title"] + "。" for item in payload.get("items", [])]
+    for guide in guide_items:
+        add_paragraph(doc, guide, size=12)
+
+    for item in payload.get("items", []):
+        doc.add_page_break()
+        add_paragraph(doc, item["title"], size=14, bold=True, align=WD_ALIGN_PARAGRAPH.CENTER)
+        body = add_paragraph(doc, item["body"], size=12, align=WD_ALIGN_PARAGRAPH.JUSTIFY)
+        body.paragraph_format.first_line_indent = Pt(21)
+        url = add_paragraph(doc, item["url"], size=12)
+        url.paragraph_format.first_line_indent = Pt(21)
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    doc.save(output)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Create the agriculture monitoring Word digest.")
+    parser.add_argument("payload_json", help="Path to report payload JSON")
+    parser.add_argument("output_docx", help="Output .docx path")
+    args = parser.parse_args()
+
+    payload = json.loads(Path(args.payload_json).read_text(encoding="utf-8"))
+    build_docx(payload, Path(args.output_docx))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/news-digest-writer/scripts/extract_article.py
+++ b/skills/news-digest-writer/scripts/extract_article.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Extract basic article text from a static webpage URL."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from html.parser import HTMLParser
+
+
+class ArticleTextParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self._skip_depth = 0
+        self._capture_title = False
+        self.title_parts: list[str] = []
+        self.text_parts: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag in {"script", "style", "noscript", "svg"}:
+            self._skip_depth += 1
+        if tag == "title":
+            self._capture_title = True
+        if tag in {"p", "h1", "h2", "h3", "li", "blockquote"}:
+            self.text_parts.append("\n")
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in {"script", "style", "noscript", "svg"} and self._skip_depth:
+            self._skip_depth -= 1
+        if tag == "title":
+            self._capture_title = False
+        if tag in {"p", "h1", "h2", "h3", "li", "blockquote"}:
+            self.text_parts.append("\n")
+
+    def handle_data(self, data: str) -> None:
+        if self._skip_depth:
+            return
+        text = data.strip()
+        if not text:
+            return
+        if self._capture_title:
+            self.title_parts.append(text)
+        self.text_parts.append(text)
+
+
+def normalize_text(value: str) -> str:
+    value = re.sub(r"[ \t\r\f\v]+", " ", value)
+    value = re.sub(r"\n{3,}", "\n\n", value)
+    return value.strip()
+
+
+def fetch(url: str, timeout: int) -> str:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124 Safari/537.36"
+            )
+        },
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        charset = response.headers.get_content_charset() or "utf-8"
+        return response.read().decode(charset, errors="replace")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Extract basic article text from a static URL.")
+    parser.add_argument("url", help="Article URL to fetch")
+    parser.add_argument("--timeout", type=int, default=20, help="Request timeout in seconds")
+    parser.add_argument("--max-chars", type=int, default=12000, help="Maximum text characters to return")
+    args = parser.parse_args()
+
+    try:
+        html = fetch(args.url, args.timeout)
+    except Exception as exc:
+        print(json.dumps({"url": args.url, "error": str(exc)}, ensure_ascii=False), file=sys.stderr)
+        return 1
+
+    article_parser = ArticleTextParser()
+    article_parser.feed(html)
+    title = normalize_text(" ".join(article_parser.title_parts))
+    text = normalize_text(" ".join(article_parser.text_parts))
+
+    print(
+        json.dumps(
+            {
+                "url": args.url,
+                "title": title,
+                "text": text[: args.max_chars],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/news-digest-writer/scripts/extract_recent_report_items.py
+++ b/skills/news-digest-writer/scripts/extract_recent_report_items.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Extract titles and URLs from recent Word monitoring reports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+from docx import Document
+
+
+URL_RE = re.compile(r"https?://\S+")
+
+
+def extract_items(path: Path) -> list[dict[str, str]]:
+    doc = Document(str(path))
+    paragraphs = [p.text.strip() for p in doc.paragraphs if p.text.strip()]
+    items: list[dict[str, str]] = []
+
+    for index, text in enumerate(paragraphs):
+        if not URL_RE.match(text):
+            continue
+        title = ""
+        for previous in range(index - 1, -1, -1):
+            candidate = paragraphs[previous].strip()
+            if candidate and not candidate.startswith("近日，") and not URL_RE.match(candidate):
+                if candidate not in {
+                    "印度、东盟农业政策跟踪",
+                    "【本期导读】",
+                } and not candidate.startswith("总第") and "农业政策动态" not in candidate:
+                    title = candidate
+                    break
+        items.append({"title": title, "url": text, "file": str(path)})
+
+    return items
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Extract recent report item titles and URLs.")
+    parser.add_argument("paths", nargs="+", help="Docx files or directories to scan")
+    args = parser.parse_args()
+
+    files: list[Path] = []
+    for raw in args.paths:
+        path = Path(raw)
+        if path.is_dir():
+            files.extend(file for file in path.rglob("*.docx") if not file.name.startswith("~$"))
+        elif path.suffix.lower() == ".docx" and path.exists():
+            if not path.name.startswith("~$"):
+                files.append(path)
+
+    results: list[dict[str, str]] = []
+    for file in sorted(set(files)):
+        try:
+            results.extend(extract_items(file))
+        except Exception as exc:
+            results.append({"title": "", "url": "", "file": str(file), "error": str(exc)})
+
+    print(json.dumps(results, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
﻿## Summary

- Add the `news-digest-writer` skill under `skills/news-digest-writer`.
- Include its source list, selection rules, article template, OpenAI agent config, and helper scripts.
- Preserve the strengthened body-length rule: normal target 330-380 Chinese characters, about 350, with drafts below 320 requiring expansion, replacement, or source-limited justification.

## Validation

- Confirmed the local skill folder was copied into the repository layout under `skills/`.
- Removed local `.Rhistory` noise before publishing.
- No runtime tests were run; this is a skill/documentation addition.
