### PR TITLE
fix: add 4 missing skills to plugin.json description

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nature-skills",
-  "description": "A growing collection of Claude skills for producing academic work at Nature-journal standard. Covers scientific figures (nature-figure), manuscript prose polishing (nature-polishing), citation retrieval and export (nature-citation), data availability statements and FAIR metadata (nature-data), and paper-to-PPTX presentation conversion (nature-paper2ppt). Future releases planned: statistical reporting, peer-review responses, methods writing, cover letters, and review articles. All rules derived from primary sources — published Nature papers, journal author guidelines, and structured writing curricula.",
+  "description": "A growing collection of Claude skills for producing academic work at Nature-journal standard. Covers scientific figures (nature-figure), manuscript prose polishing (nature-polishing), citation retrieval and export (nature-citation), data availability statements and FAIR metadata (nature-data), paper-to-PPTX presentation conversion (nature-paper2ppt), cross-database academic literature search (nature-academic-search), PDF paper reading and annotation (nature-reader), peer-review response drafting (nature-response), and methods/introduction section writing (nature-writing). Future releases planned: statistical reporting, cover letters, and review articles. All rules derived from primary sources — published Nature papers, journal author guidelines, and structured writing curricula.",
   "version": "1.0.0",
   "author": {
     "name": "Yuan1z0825",


### PR DESCRIPTION
> **Automated**: drive-by fix from [NLPM](https://github.com/xiaolai/nlpm-for-claude), an NL artifact linter. Reviewed and reproduced before submission.

**Bug**: `plugin.json` description lists 5 of 9 shipped skills; nature-academic-search, nature-reader, nature-response, and nature-writing are absent; nature-response and nature-writing are also mis-listed as future releases.

**Evidence**: `python3 -c "import json,os; d=json.load(open('.claude-plugin/plugin.json'))['description']; [print(s, s in d) for s in sorted(os.listdir('skills'))]"` → `nature-academic-search False`, `nature-reader False`, `nature-response False`, `nature-writing False` against 9 directories under `skills/`.

**Fix**: Expanded description to include all 9 shipped skills; removed nature-response and nature-writing from the "Future releases" clause; retained the 3 genuinely unshipped items (statistical reporting, cover letters, review articles).

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"CC-stale-count","fingerprint":"sha256:9c0aef17327329af98c0219edcedecef46b4c2c5962bab99763317d2795df3a8"}]}
nlpm-metadata-end -->