### PR TITLE
refactor(nature-polishing): split into static layer + dynamic router

### DIFF
--- a/skills/nature-polishing/SKILL.md
+++ b/skills/nature-polishing/SKILL.md
@@ -1,386 +1,64 @@
 ---
 name: nature-polishing
 description: Polish, restructure, or translate academic prose into Nature-leaning English using writing-strategy principles, curated Nature/Nature Communications article patterns, and phrase-level support from Academic Phrasebank. Use whenever the user asks to polish a manuscript paragraph, abstract, introduction, results, discussion, conclusion, title, methods section, or Chinese academic draft for publication-quality English.
-version: 5.0.2
-author: Yuan1z skill rebuilt from course notes plus Academic Phrasebank
+version: 6.0.0
+author: Yuan1z skill, refactored into static/dynamic layers
 ---
 
-# Nature-Style Academic Polishing
+# Nature-Style Academic Polishing — Router
 
-Use this skill to improve scientific writing at two levels:
+This skill is split into two layers:
 
-- `main strategy`: paper architecture, published-article patterns, section logic, reader workflow, evidence thresholds, and ethics
-- `reference support`: reusable phrase families, move patterns, transitions, and style checks
+- A **static layer** under `static/` that holds versioned, reusable content fragments (core principles, paper-type playbooks, per-section guidance, language-specific rules, per-journal style).
+- A **dynamic layer** (this file plus `manifest.yaml`) that detects the request's axes and loads only the fragments needed for the current job.
 
-The main strategy should come from the course notes in `Chapter1-Week1-7` and
-the curated article-pattern reference. The wording layer should come from
-`Academic Phrasebank`.
+Do not try to apply the polishing logic from memory or from this router. Always load fragments from disk as described below.
 
-## Default stance
+## Routing protocol
 
-- Language serves argument. Do not polish sentences while leaving the reasoning broken.
-- Write with empathy for the reader: relevance first, then novelty, then trust, then reuse, then meaning.
-- There should be no mystery for the writer, but there may be one for the reader.
-- Do not invent data, references, mechanisms, or novelty claims.
-- Do not let AI draft the paper's core scientific argument from scratch.
-- If the draft is Chinese or structurally rough, reconstruct the logic first and the prose second.
-- Avoid em dashes in polished output by default. Prefer commas, parentheses, or full stops. Use colons sparingly unless the user explicitly asks to preserve dash-based punctuation or wants a colon-led style.
+Follow these five steps every time the skill is invoked.
 
-## When to open extra files
+### 1. Load the manifest and the core layer
 
-These files are reference support. Use them after the section's rhetorical job is clear.
+Read [manifest.yaml](manifest.yaml). It declares the axes (`paper_type`, `section`, `language`, `journal`), the allowed values, and the file paths each value maps to.
 
-| File | Open when |
-|---|---|
-| [references/published-article-patterns.md](references/published-article-patterns.md) | You need Nature/Nature Communications article-level writing patterns for abstracts, introductions, Results, Discussion, conclusions, or titles |
-| [references/writing-strategy.md](references/writing-strategy.md) | You need paragraph- or section-level argument repair before sentence polishing |
-| [references/section-moves.md](references/section-moves.md) | You need section-specific move orders or phrase patterns derived from Academic Phrasebank |
-| [references/phrasebank-playbook.md](references/phrasebank-playbook.md) | You need hedging, transition, evidence, limitation, or future-work phrase families |
-| [references/style-guardrails.md](references/style-guardrails.md) | You need academic-style checks, paragraph/sentence checks, article use, register, or mechanics |
+Also read every file listed under `always_load`. These hold the default stance, failure-mode diagnosis, ethics, and output format that apply to every polish job.
 
-## Core architecture
+### 2. Detect the axis values for this request
 
-### 1. Identify the paper type first
+For each axis in the manifest, decide the value using the manifest's `detect:` hint and the user's input:
 
-Before editing, determine what kind of paper or section this is.
+- `paper_type` — research / methods / hypothesis / algorithmic / review. Default: research.
+- `section` — abstract / intro / results / discussion / conclusion / title / methods. May be multiple. Ask the user if it is ambiguous and matters for the polish.
+- `language` — en or zh-to-en. Detect from the draft itself.
+- `journal` — nature / nat-comms / generic. Default: generic. If the user names a Nature subjournal, treat it as `nature`.
 
-- `Research paper`: the reader asks why the phenomenon matters, what was done, what was found, and what it means.
-- `Methods paper`: the reader asks whether the method works, whether it is reproducible, and whether it is better under a fair comparison.
-- `Hypothesis-based work`: the argument tries to establish or rule out a causal explanation.
-- `Algorithmic or device work`: the argument proposes a procedure, tool, or system and must show that it performs reliably and advantageously.
+State the detected axis values in one short line to the user before proceeding, so they can correct you cheaply.
 
-Do not use one narrative logic for all paper types.
+### 3. Load the matching fragments
 
-For article-level rewrites, especially abstracts, introductions, Results openings,
-Discussion paragraphs, conclusions, and titles, also apply the writing patterns in
-`references/published-article-patterns.md`.
+For each axis value, Read the file mapped in the manifest. Skip the `section` axis only if the user has supplied free-floating prose with no section context.
 
-### 2. Write for the reader, not for the draft chronology
+Do **not** read every fragment in `static/`. Load only what step 2 selected.
 
-Most readers follow a stable sequence:
+### 4. Polish using the loaded material
 
-1. Is this relevant to me?
-2. What is new here?
-3. Do I trust it?
-4. Can I reuse it?
-5. What does it mean, and where are the boundaries?
+Apply the loaded fragments in this priority order, matching the `paper type -> section job -> paragraph logic -> claim/evidence/boundary -> sentence polish` rule from `core/failure-modes.md`:
 
-Polishing should help the paper answer these questions in this order.
+1. Paper-type playbook (architecture, writing order).
+2. Section-specific job and failure modes.
+3. Journal-specific framing and constraints.
+4. Language-specific sentence and paragraph rules (apply last).
+5. Core stance and ethics throughout.
 
-### 3. Use the hourglass structure
+If a paragraph's structural problem cannot be fixed without inventing content, flag it instead of papering over it.
 
-Strong papers often mirror an hourglass:
+### 5. Reach for references only when needed
 
-- `Introduction`: open broadly, then narrow to the specific gap, question, hypothesis, methods, and study
-- `Discussion/Conclusion`: widen again, connecting the findings back to the literature and explaining how the knowledge gap was filled
+The files under `references/` are deep references, not defaults. Open them on demand per the `references.on_demand` table in the manifest, for example when the user explicitly asks for phrasebank-style alternatives or a stricter style audit.
 
-If a paragraph or section violates this architecture, rebuild it before polishing wording.
+## Why this split
 
-### 4. Use the correct writing order
-
-For a research article, a productive writing order is:
-
-1. Results
-2. Introduction and Conclusion
-3. Title
-4. Discussion
-5. Materials and Methods
-6. Authors
-7. Abstract
-
-For a methods paper, a productive writing order often begins with:
-
-1. Methods
-2. Results
-3. Introduction
-4. Conclusion
-5. Discussion
-6. Abstract
-
-The skill should follow the logic of evidence and argument, not the raw order in which the user drafted sentences.
-
-### 5. Protect the core argument
-
-The paper's core argument includes:
-
-- the scientific question the paper actually answers
-- why that question matters
-- how the work differs from existing research
-- what the results imply
-- how the main line of reasoning unfolds
-
-AI may help polish, structure, or compare phrasings. AI should not invent or author the core argument. If the argument is weak or unclear, expose that weakness rather than hiding it under polished language.
-
-### 6. Diagnose the failure mode before editing
-
-Before rewriting, identify the main problem:
-
-- wrong paper type logic
-- missing gap or poor positioning
-- claim without evidence
-- evidence without a clear claim
-- missing boundary or limitation
-- Results and Discussion mixed together
-- weak title or abstract signal
-- sentence-level clutter only
-
-Prioritize in this order:
-
-`paper type -> section job -> paragraph logic -> claim/evidence/boundary -> sentence polish`
-
-## Section responsibilities
-
-### Introduction
-
-The Introduction should:
-
-- tell the reader why the work matters
-- explain what gap it fills
-- explain why that gap matters
-- state what is already known
-- state what remains unresolved
-- state what question the paper asks
-- indicate how the study addresses it
-
-Do not summarize the Results section here. Do not summarize the Conclusion here.
-
-### Results
-
-Results are a summary of the data collected to address the problem stated in the Introduction.
-
-Results writing should:
-
-- stay mainly in past tense
-- report what was observed, under what conditions, and with what quantitative support
-- use statistics correctly and sparingly
-- use supplementary data sparingly
-
-Results should answer `what happened`, not `what it ultimately means`.
-
-### Discussion
-
-Discussion should answer:
-
-- how the work fits within the broader field
-- what has been added to understanding
-- who should be credited for earlier work
-- whether the findings support, complicate, or revise earlier results
-- how the findings are interpreted
-- when that interpretation may fail
-
-Short rule:
-
-- `Results = what we observed`
-- `Discussion = how we understand it, and when it may fail`
-
-### Conclusion
-
-Use the three-part close:
-
-1. restate the central contribution
-2. summarize the key evidence or outcome
-3. state the implication with a boundary
-
-Do not introduce new data in the conclusion. Always run an overclaim check here.
-
-### Title
-
-A strong title should:
-
-- tell the reader what to expect
-- avoid unnecessary technical language
-- be easy to search
-- be substantiated by data
-- create curiosity without sacrificing credibility
-
-Use `curiosity with credibility`, not empty cleverness. A hook is only acceptable if the claim remains fully defensible.
-
-### Materials and Methods
-
-Methods should be specific, complete, transparent, and reproducible.
-
-Another group should be able to determine:
-
-- whether the work conforms to ethical norms
-- what materials and conditions were used
-- which key parameters, controls, and replicates were used
-- how data were processed and analysed
-- which statistical tests and software versions were used
-
-It is acceptable to abbreviate by citing an earlier report only when that report truly contains the necessary detail.
-
-Never leave vague phrases such as:
-
-- `under standard conditions`
-- `using routine methods`
-- `data were analyzed statistically`
-- `differences were significant`
-- `samples were randomly assigned`
-- `the method was validated`
-
-Replace them with the actual reproducible information.
-
-### Methods-paper variant
-
-In a methods paper, the Results section must show the advantages of the method over existing methods. Typical questions are:
-
-- Is it more reliable?
-- Is it faster?
-- Does it require fewer resources?
-- Is the comparison fair and reproducible?
-
-The Methods section in a methods paper may need additional detail such as:
-
-- axioms, conditions, and assumptions
-- hardware and software environment
-- mathematical derivations
-- evaluation protocol
-- datasets, baselines, metrics, splits, and hyperparameters
-
-### Abstract
-
-The abstract is a mini-paper:
-
-`context/problem -> gap/objective -> approach -> key results -> implication`
-
-It should answer:
-
-1. What question was addressed?
-2. How was it addressed?
-3. What was found?
-4. Why should anyone care?
-
-Some journals require a strict abstract format. Follow the journal if it conflicts with the generic pattern.
-
-## Sentence and paragraph control
-
-### Sentence rules
-
-- In polished prose, aim for sentences in the `10-30` word range.
-- Keep every sentence at `<= 30` words.
-- Do not produce full sentences under `10` words unless the user explicitly asks for terse style or the item is a heading, label, or fixed technical expression.
-- If any sentence exceeds `20` words, check whether it contains more than one main proposition.
-- Split overloaded sentences rather than polishing them cosmetically.
-- The last sentence of a paragraph often becomes the longest and weakest. Check it explicitly.
-- Prefer one core subject-verb proposition per sentence.
-- Do not use em dashes as prose punctuation in the polished version unless the user explicitly requests them. Rewrite with commas, parentheses, or shorter sentences instead. Use colons only when they add clear structural value.
-
-### Paragraph rules
-
-- Each paragraph should have one controlling idea followed by support.
-- Supporting material may include data, comparison, explanation, consequence, literature, or limitation.
-- If a new idea appears, start a new paragraph instead of stacking it onto the old one.
-- Use thematic linking, not repetitive `This suggests ...` openings.
-
-### Results vs Discussion sentence types
-
-Results sentences usually report:
-
-- `was detected`
-- `increased`
-- `showed`
-- `enabled`
-- `achieved`
-
-Discussion sentences usually interpret:
-
-- `may reflect`
-- `suggests that`
-- `could indicate`
-- `is likely due to`
-- `may facilitate`
-
-Do not let a Results paragraph drift into Discussion syntax unless the transition is intentional.
-
-### Chinese-to-English mode
-
-When the source is Chinese or strongly Chinese-influenced English:
-
-- extract the core propositions first
-- do not translate clause-by-clause mechanically
-- reconstruct explicit logical links: contrast, cause, implication, limitation
-- verify terminology, causality, hedging, and disciplinary nuance
-- keep key technical terms stable
-
-## Citation, ethics, and AI boundaries
-
-### Intellectual debt
-
-Originality is usually an amendment, combination, or extension of prior knowledge. A careful writer acknowledges that debt openly.
-
-Do not minimize others' contributions just to make the present work seem more original.
-
-### Position attribution clearly
-
-Make it obvious:
-
-- how the paper builds on prior work
-- who was responsible for the earlier idea, method, data, or interpretation
-- where the reader can locate the source
-
-### Cite the source you actually read and verified
-
-- Cite paper `A` for `A`'s own data, methods, claims, or conclusions.
-- Cite paper `B` for `B`'s interpretation, comparison, critique, or commentary on `A`.
-- Avoid leaning on secondary sources when the source article can be cited directly.
-
-### What needs citation
-
-- someone else's ideas
-- data
-- methods
-- wording
-- structure
-- images
-- distinctive interpretation
-
-Do not assume internet material is public domain just because it is online.
-
-### Proofreading checks
-
-Always verify:
-
-- grammatical errors
-- typographical errors
-- figure numbering
-- missing citations
-- whether the paper is a pleasure or an ordeal to read
-
-### AI traffic-light boundary
-
-`Green`: generally acceptable with author verification
-
-- improve grammar, clarity, concision, or tone
-- generate outline options or paragraph structures
-- produce alternative titles or abstract phrasings
-- summarize literature for categorization, not as a substitute for reading
-- translate with terminology and hedging checks
-
-`Yellow`: allowed only with strong human control
-
-- explain methods or results for wording support
-- draft reviewer-response frameworks that are then checked line by line
-- help with code or statistics explanations only if outputs are reproduced and validated
-
-`Red`: generally inappropriate
-
-- ask AI to draft the paper's core argument from scratch
-- insert AI-generated references, data, or claims without checking them
-- upload unpublished manuscripts, sensitive data, or peer-review material to public models
-- use AI to fabricate, manipulate, or conceal substantive image creation
-
-The main danger is not that AI cannot write. The main danger is that it can write incorrectly with great confidence.
-
-## Output format
-
-Default output:
-
-1. The polished text as plain prose, not in a code block.
-2. `Revision notes:` with `3-5` short bullets on the major structural and stylistic changes.
-3. If the rewrite changed section logic, say so explicitly.
-
-If the user asks for side-by-side revision, provide:
-
-- `Original`
-- `Polished`
-- `Why changed`
+- The static layer is versioned and reviewable. Adding a new journal style or paper type is one new file plus one manifest line.
+- The dynamic layer keeps each invocation cheap: only the fragments relevant to this draft enter context, instead of the full 1000-line monolith.
+- The router itself is short on purpose. Update fragments, not this file, when adding scope.

--- a/skills/nature-polishing/manifest.yaml
+++ b/skills/nature-polishing/manifest.yaml
@@ -1,0 +1,76 @@
+name: nature-polishing
+version: 6.0.0
+description: >
+  Declarative manifest for the static/dynamic split. SKILL.md uses this to
+  decide which fragments to load for a given polishing request.
+
+always_load:
+  - static/core/stance.md
+  - static/core/failure-modes.md
+  - static/core/ethics.md
+  - static/core/output-format.md
+
+axes:
+  paper_type:
+    detect: |
+      Decide what kind of paper or section is being polished. Default to research.
+      Use the user's stated framing first; fall back to inference from the text.
+    values:
+      research:       static/fragments/paper_type/research.md
+      methods:        static/fragments/paper_type/methods.md
+      hypothesis:     static/fragments/paper_type/hypothesis.md
+      algorithmic:    static/fragments/paper_type/algorithmic.md
+      review:         static/fragments/paper_type/review.md
+    default: research
+    multi: false
+
+  section:
+    detect: |
+      Identify which section(s) the user wants polished. The user may name
+      one or several. If unclear, ask before loading. Skip this axis only
+      when the user provides standalone prose with no section context.
+    values:
+      abstract:       static/fragments/section/abstract.md
+      intro:          static/fragments/section/intro.md
+      results:        static/fragments/section/results.md
+      discussion:     static/fragments/section/discussion.md
+      conclusion:     static/fragments/section/conclusion.md
+      title:          static/fragments/section/title.md
+      methods:        static/fragments/section/methods.md
+    multi: true
+
+  language:
+    detect: |
+      Detect the source language of the draft. Use zh-to-en when the draft
+      is Chinese or shows strong Chinese-influenced English structure.
+      Otherwise use en.
+    values:
+      en:             static/fragments/language/en.md
+      zh-to-en:       static/fragments/language/zh-to-en.md
+    default: en
+    multi: false
+
+  journal:
+    detect: |
+      Use the journal value the user names. If the user says "Nature-family"
+      generically or names a Nature subjournal, use nature. If they name
+      Nature Communications, use nat-comms. Otherwise generic.
+    values:
+      nature:         static/fragments/journal/nature.md
+      nat-comms:      static/fragments/journal/nat-comms.md
+      generic:        static/fragments/journal/generic.md
+    default: generic
+    multi: false
+
+references:
+  on_demand:
+    - condition: needs Nature/Nature Communications article-level patterns for abstracts, intros, Results openings, Discussion, conclusions, titles
+      path: references/published-article-patterns.md
+    - condition: needs section-specific move orders or phrase patterns
+      path: references/section-moves.md
+    - condition: needs hedging, transition, evidence, limitation, future-work phrases
+      path: references/phrasebank-playbook.md
+    - condition: needs academic style, register, article use, or mechanics checks
+      path: references/style-guardrails.md
+    - condition: needs deeper writing-strategy principles
+      path: references/writing-strategy.md

--- a/skills/nature-polishing/static/core/ethics.md
+++ b/skills/nature-polishing/static/core/ethics.md
@@ -1,0 +1,66 @@
+# Citation, ethics, and AI boundaries
+
+## Intellectual debt
+
+Originality is usually an amendment, combination, or extension of prior knowledge. A careful writer acknowledges that debt openly. Do not minimize others' contributions just to make the present work seem more original.
+
+## Position attribution clearly
+
+Make it obvious:
+
+- how the paper builds on prior work
+- who was responsible for the earlier idea, method, data, or interpretation
+- where the reader can locate the source
+
+## Cite the source you actually read and verified
+
+- Cite paper `A` for `A`'s own data, methods, claims, or conclusions.
+- Cite paper `B` for `B`'s interpretation, comparison, critique, or commentary on `A`.
+- Avoid leaning on secondary sources when the source article can be cited directly.
+
+## What needs citation
+
+- someone else's ideas
+- data
+- methods
+- wording
+- structure
+- images
+- distinctive interpretation
+
+Do not assume internet material is public domain just because it is online.
+
+## Proofreading checks
+
+Always verify:
+
+- grammatical errors
+- typographical errors
+- figure numbering
+- missing citations
+- whether the paper is a pleasure or an ordeal to read
+
+## AI traffic-light boundary
+
+`Green`: generally acceptable with author verification
+
+- improve grammar, clarity, concision, or tone
+- generate outline options or paragraph structures
+- produce alternative titles or abstract phrasings
+- summarize literature for categorization, not as a substitute for reading
+- translate with terminology and hedging checks
+
+`Yellow`: allowed only with strong human control
+
+- explain methods or results for wording support
+- draft reviewer-response frameworks that are then checked line by line
+- help with code or statistics explanations only if outputs are reproduced and validated
+
+`Red`: generally inappropriate
+
+- ask AI to draft the paper's core argument from scratch
+- insert AI-generated references, data, or claims without checking them
+- upload unpublished manuscripts, sensitive data, or peer-review material to public models
+- use AI to fabricate, manipulate, or conceal substantive image creation
+
+The main danger is not that AI cannot write. The main danger is that it can write incorrectly with great confidence.

--- a/skills/nature-polishing/static/core/failure-modes.md
+++ b/skills/nature-polishing/static/core/failure-modes.md
@@ -1,0 +1,18 @@
+# Diagnose failure mode before editing
+
+Before rewriting, identify the main problem:
+
+- wrong paper type logic
+- missing gap or poor positioning
+- claim without evidence
+- evidence without a clear claim
+- missing boundary or limitation
+- Results and Discussion mixed together
+- weak title or abstract signal
+- sentence-level clutter only
+
+Prioritize fixes in this order:
+
+`paper type -> section job -> paragraph logic -> claim/evidence/boundary -> sentence polish`
+
+Do not sentence-polish a draft whose section job is wrong. Surface the structural problem first, then polish.

--- a/skills/nature-polishing/static/core/output-format.md
+++ b/skills/nature-polishing/static/core/output-format.md
@@ -1,0 +1,15 @@
+# Output format
+
+Default output:
+
+1. The polished text as plain prose, not in a code block.
+2. `Revision notes:` with `3-5` short bullets on the major structural and stylistic changes.
+3. If the rewrite changed section logic, say so explicitly.
+
+If the user asks for side-by-side revision, provide:
+
+- `Original`
+- `Polished`
+- `Why changed`
+
+If any paragraph's structural problem could not be fixed without inventing content, say so under `Revision notes:` instead of papering over it.

--- a/skills/nature-polishing/static/core/stance.md
+++ b/skills/nature-polishing/static/core/stance.md
@@ -1,0 +1,33 @@
+# Default stance
+
+- Language serves argument. Do not polish sentences while leaving the reasoning broken.
+- Write with empathy for the reader: relevance first, then novelty, then trust, then reuse, then meaning.
+- There should be no mystery for the writer, but there may be one for the reader.
+- Do not invent data, references, mechanisms, or novelty claims.
+- Do not let AI draft the paper's core scientific argument from scratch.
+- If the draft is Chinese or structurally rough, reconstruct the logic first and the prose second.
+- Avoid em dashes in polished output by default. Prefer commas, parentheses, or full stops. Use colons sparingly unless the user explicitly asks to preserve dash-based punctuation or wants a colon-led style.
+
+## Reader workflow
+
+Most readers follow a stable sequence:
+
+1. Is this relevant to me?
+2. What is new here?
+3. Do I trust it?
+4. Can I reuse it?
+5. What does it mean, and where are the boundaries?
+
+Polishing should help the paper answer these questions in this order.
+
+## Protect the core argument
+
+The paper's core argument includes:
+
+- the scientific question the paper actually answers
+- why that question matters
+- how the work differs from existing research
+- what the results imply
+- how the main line of reasoning unfolds
+
+AI may help polish, structure, or compare phrasings. AI should not invent or author the core argument. If the argument is weak or unclear, expose that weakness rather than hiding it under polished language.

--- a/skills/nature-polishing/static/fragments/journal/generic.md
+++ b/skills/nature-polishing/static/fragments/journal/generic.md
@@ -1,0 +1,15 @@
+# Journal: generic
+
+Used when the user has not named a target journal, or the journal is not specifically modeled by another fragment.
+
+## Defaults
+
+- Apply Nature-leaning style without enforcing Nature's strictest length or significance-framing demands.
+- Keep the em-dash and hedging defaults from `core/stance.md`.
+- If the user later names a journal, ask whether to re-polish under that journal's fragment rather than guess.
+
+## Things to ask the user before final polish
+
+- Target journal and section format (structured vs unstructured abstract; word limits; reference style).
+- Audience breadth: subfield vs broad readership.
+- Whether the draft will go through a separate copy-edit pass (affects how aggressively to rewrite vs flag).

--- a/skills/nature-polishing/static/fragments/journal/nat-comms.md
+++ b/skills/nature-polishing/static/fragments/journal/nat-comms.md
@@ -1,0 +1,13 @@
+# Journal: Nature Communications
+
+## Audience
+
+Open-access, broader than a subfield journal but more specialist-tolerant than Nature. The reader is typically an active researcher in an adjacent area.
+
+## Polishing priorities
+
+- Significance framing matters, but a less aggressive opening is acceptable than for Nature.
+- Structured abstract is not required; check the target guideline if the user gives one.
+- Word count is more forgiving than Nature, but tight is still better than loose.
+- Methods can be more detailed in-line; reproducibility expectations are explicit.
+- Same em-dash and hedging defaults as Nature.

--- a/skills/nature-polishing/static/fragments/journal/nature.md
+++ b/skills/nature-polishing/static/fragments/journal/nature.md
@@ -1,0 +1,19 @@
+# Journal: Nature (and Nature subjournals)
+
+## Audience
+
+A broad, multi-disciplinary readership. A reader outside the immediate subfield must be able to grasp the claim, the gap, and the significance from the first paragraph and the abstract.
+
+## Polishing priorities
+
+- The opening sentence must signal significance for a non-specialist audience without overclaiming.
+- Avoid jargon that does not appear in the headline of a typical Nature News piece. Define or replace.
+- Abstract is unstructured prose for many Nature titles; check the target journal's current guideline if the user names one.
+- Length discipline: Nature articles are unforgiving on word count. Prefer cuts to compressions.
+- No em dashes in body prose. Use commas, parentheses, or shorter sentences.
+- Hedging should be calibrated. Avoid both overclaim (`proves`, `definitive`) and timidity (`might possibly suggest`).
+
+## Things to flag, not silently fix
+
+- If the manuscript leans on a specialist mechanism the broad audience would not follow, flag it for the author rather than over-translate.
+- If significance for a non-specialist is genuinely thin, surface that as a structural problem in `Revision notes:`.

--- a/skills/nature-polishing/static/fragments/language/en.md
+++ b/skills/nature-polishing/static/fragments/language/en.md
@@ -1,0 +1,19 @@
+# Language: English source
+
+## Sentence rules
+
+- In polished prose, aim for sentences in the `10-30` word range.
+- Keep every sentence at `<= 30` words.
+- Do not produce full sentences under `10` words unless the user explicitly asks for terse style or the item is a heading, label, or fixed technical expression.
+- If any sentence exceeds `20` words, check whether it contains more than one main proposition.
+- Split overloaded sentences rather than polishing them cosmetically.
+- The last sentence of a paragraph often becomes the longest and weakest. Check it explicitly.
+- Prefer one core subject-verb proposition per sentence.
+- Do not use em dashes as prose punctuation in the polished version unless the user explicitly requests them. Rewrite with commas, parentheses, or shorter sentences instead. Use colons only when they add clear structural value.
+
+## Paragraph rules
+
+- Each paragraph should have one controlling idea followed by support.
+- Supporting material may include data, comparison, explanation, consequence, literature, or limitation.
+- If a new idea appears, start a new paragraph instead of stacking it onto the old one.
+- Use thematic linking, not repetitive `This suggests ...` openings.

--- a/skills/nature-polishing/static/fragments/language/zh-to-en.md
+++ b/skills/nature-polishing/static/fragments/language/zh-to-en.md
@@ -1,0 +1,19 @@
+# Language: Chinese-to-English
+
+When the source is Chinese or strongly Chinese-influenced English, do not translate clause-by-clause.
+
+## Workflow
+
+1. Extract the core propositions first. List them in plain English before drafting prose.
+2. Reconstruct explicit logical links: contrast, cause, implication, limitation. Chinese academic prose often elides these connectives — restore them.
+3. Verify terminology, causality, and hedging strength against the source.
+4. Keep technical terms, gene/protein names, model names, dataset names, and statistical terms stable; do not "translate" them into rough paraphrases.
+5. Apply the English sentence and paragraph rules from `language/en.md` only after the logic is rebuilt.
+
+## Common Chinese-influenced patterns to fix
+
+- Topic-comment chains rewritten as subject-verb sentences.
+- Strings of short clauses joined by commas — split or add connectives.
+- Vague generalizations (`many studies have shown`) — convert to specific citations or remove.
+- Hedging asymmetry: Chinese drafts often understate; English Nature-style asks for precise hedging matched to evidence strength, neither over- nor under-claiming.
+- Repetition of the topic noun where English would use a pronoun or omit it.

--- a/skills/nature-polishing/static/fragments/paper_type/algorithmic.md
+++ b/skills/nature-polishing/static/fragments/paper_type/algorithmic.md
@@ -1,0 +1,18 @@
+# Paper type: algorithmic or device
+
+The argument proposes a procedure, tool, or system and must show that it performs reliably and advantageously.
+
+## What the reader expects
+
+- a clear problem formulation and the precise scope being claimed
+- the proposed procedure or device, described to a level a peer could re-implement
+- a fair comparison against credible baselines under matched conditions
+- ablations or controls that isolate why the new approach works
+- failure modes, runtime/cost characteristics, and applicability boundaries
+
+## Polishing priorities
+
+- Separate "what the system is" from "why it works" from "how well it works"; do not braid them.
+- Performance claims must specify the dataset, metric, baseline, and conditions, not stand as bare numbers.
+- Avoid marketing verbs (`leverages`, `enables`, `empowers`) unless they carry information.
+- The Discussion should name the failure modes the experiments revealed, not only the wins.

--- a/skills/nature-polishing/static/fragments/paper_type/hypothesis.md
+++ b/skills/nature-polishing/static/fragments/paper_type/hypothesis.md
@@ -1,0 +1,17 @@
+# Paper type: hypothesis-based
+
+The argument tries to establish or rule out a causal explanation.
+
+## What the reader expects
+
+- a clearly stated hypothesis, framed before the evidence
+- a falsification path: what observations would refute it
+- evidence presented in support, against, or as boundary conditions
+- alternative explanations addressed, not ignored
+
+## Polishing priorities
+
+- Make the hypothesis statement explicit and locatable; do not bury it in the third paragraph of the Introduction.
+- Distinguish supporting evidence from consistent-but-non-discriminating evidence.
+- In the Discussion, address rival explanations before generalizing.
+- Hedging should match the strength of the causal claim. Avoid overclaiming mechanism from correlational data.

--- a/skills/nature-polishing/static/fragments/paper_type/methods.md
+++ b/skills/nature-polishing/static/fragments/paper_type/methods.md
@@ -1,0 +1,35 @@
+# Paper type: methods
+
+The reader of a methods paper asks:
+
+- whether the method works
+- whether it is reproducible
+- whether it is better under a fair comparison
+
+## Results section job
+
+The Results section must show the advantages of the method over existing methods. Typical questions are:
+
+- Is it more reliable?
+- Is it faster?
+- Does it require fewer resources?
+- Is the comparison fair and reproducible?
+
+## Methods section detail
+
+The Methods section in a methods paper may need additional detail such as:
+
+- axioms, conditions, and assumptions
+- hardware and software environment
+- mathematical derivations
+- evaluation protocol
+- datasets, baselines, metrics, splits, and hyperparameters
+
+## Productive writing order
+
+1. Methods
+2. Results
+3. Introduction
+4. Conclusion
+5. Discussion
+6. Abstract

--- a/skills/nature-polishing/static/fragments/paper_type/research.md
+++ b/skills/nature-polishing/static/fragments/paper_type/research.md
@@ -1,0 +1,29 @@
+# Paper type: research
+
+The reader of a research paper asks:
+
+- why the phenomenon matters
+- what was done
+- what was found
+- what it means
+
+## Hourglass structure
+
+Strong research papers mirror an hourglass:
+
+- `Introduction`: open broadly, then narrow to the specific gap, question, hypothesis, methods, and study
+- `Discussion/Conclusion`: widen again, connecting the findings back to the literature and explaining how the knowledge gap was filled
+
+If a paragraph or section violates this architecture, rebuild it before polishing wording.
+
+## Productive writing order
+
+1. Results
+2. Introduction and Conclusion
+3. Title
+4. Discussion
+5. Materials and Methods
+6. Authors
+7. Abstract
+
+Follow the logic of evidence and argument, not the raw order in which the user drafted sentences.

--- a/skills/nature-polishing/static/fragments/paper_type/review.md
+++ b/skills/nature-polishing/static/fragments/paper_type/review.md
@@ -1,0 +1,17 @@
+# Paper type: review
+
+The reader asks: what is the state of the field, where is the disagreement, and what is the path forward.
+
+## What the reader expects
+
+- a clear scope statement (which sub-area, which time window, which inclusion criteria)
+- a synthesis that organizes the literature by argument, not by paper
+- explicit positioning of disagreements and gaps
+- an outlook that names the most informative open questions
+
+## Polishing priorities
+
+- A review is not a survey list. Replace `Author A reported X. Author B reported Y.` with synthesis that groups claims by mechanism, method, or conclusion.
+- Position the reviewer's own stance carefully: a review can take a view, but it must show its reasoning.
+- Avoid generic transitions (`furthermore`, `additionally`). Use connectives that signal the logical relation (`in contrast`, `building on this`, `the remaining disagreement is`).
+- The closing section should leave the reader with a usable map, not a summary of what was just read.

--- a/skills/nature-polishing/static/fragments/section/abstract.md
+++ b/skills/nature-polishing/static/fragments/section/abstract.md
@@ -1,0 +1,20 @@
+# Section: Abstract
+
+The abstract is a mini-paper:
+
+`context/problem -> gap/objective -> approach -> key results -> implication`
+
+It should answer:
+
+1. What question was addressed?
+2. How was it addressed?
+3. What was found?
+4. Why should anyone care?
+
+Some journals require a strict abstract format. Follow the journal if it conflicts with the generic pattern. (See the loaded `journal/*.md` fragment for journal-specific constraints.)
+
+## Polishing priorities
+
+- Cut sentences that summarize background that the title already implies.
+- Make the gap and the contribution one short, locatable sentence each.
+- The last sentence should state significance, not repeat the result.

--- a/skills/nature-polishing/static/fragments/section/conclusion.md
+++ b/skills/nature-polishing/static/fragments/section/conclusion.md
@@ -1,0 +1,15 @@
+# Section: Conclusion
+
+Use the three-part close:
+
+1. restate the central contribution
+2. summarize the key evidence or outcome
+3. state the implication with a boundary
+
+Do not introduce new data in the conclusion. Always run an overclaim check here.
+
+## Overclaim check
+
+- Does each claim trace back to evidence in this paper?
+- Are mechanism words (`demonstrates`, `proves`, `establishes`) backed by the right study design?
+- Is the scope of the implication narrower than or equal to the scope of the evidence?

--- a/skills/nature-polishing/static/fragments/section/discussion.md
+++ b/skills/nature-polishing/static/fragments/section/discussion.md
@@ -1,0 +1,33 @@
+# Section: Discussion
+
+Discussion should answer:
+
+- how the work fits within the broader field
+- what has been added to understanding
+- who should be credited for earlier work
+- whether the findings support, complicate, or revise earlier results
+- how the findings are interpreted
+- when that interpretation may fail
+
+Short rule:
+
+- `Results = what we observed`
+- `Discussion = how we understand it, and when it may fail`
+
+## Sentence syntax
+
+Discussion sentences usually interpret:
+
+- `may reflect`
+- `suggests that`
+- `could indicate`
+- `is likely due to`
+- `may facilitate`
+
+Hedging strength should match evidence strength. Do not promote a "consistent with" finding to "demonstrates" wording.
+
+## Common failure modes
+
+- Re-summarizing Results instead of interpreting them.
+- Skipping rival explanations.
+- Omitting boundaries: when does the interpretation stop holding?

--- a/skills/nature-polishing/static/fragments/section/intro.md
+++ b/skills/nature-polishing/static/fragments/section/intro.md
@@ -1,0 +1,20 @@
+# Section: Introduction
+
+The Introduction should:
+
+- tell the reader why the work matters
+- explain what gap it fills
+- explain why that gap matters
+- state what is already known
+- state what remains unresolved
+- state what question the paper asks
+- indicate how the study addresses it
+
+Do not summarize the Results section here. Do not summarize the Conclusion here.
+
+## Common failure modes
+
+- Opening paragraph reads as a textbook rather than a positioning move.
+- The gap is implied but never explicitly named.
+- The transition from "what is known" to "what this paper does" is missing.
+- Methods are previewed in detail; keep that for Methods.

--- a/skills/nature-polishing/static/fragments/section/methods.md
+++ b/skills/nature-polishing/static/fragments/section/methods.md
@@ -1,0 +1,26 @@
+# Section: Materials and Methods
+
+Methods should be specific, complete, transparent, and reproducible.
+
+Another group should be able to determine:
+
+- whether the work conforms to ethical norms
+- what materials and conditions were used
+- which key parameters, controls, and replicates were used
+- how data were processed and analysed
+- which statistical tests and software versions were used
+
+It is acceptable to abbreviate by citing an earlier report only when that report truly contains the necessary detail.
+
+## Forbidden vague phrases
+
+Never leave wording such as:
+
+- `under standard conditions`
+- `using routine methods`
+- `data were analyzed statistically`
+- `differences were significant`
+- `samples were randomly assigned`
+- `the method was validated`
+
+Replace them with the actual reproducible information.

--- a/skills/nature-polishing/static/fragments/section/results.md
+++ b/skills/nature-polishing/static/fragments/section/results.md
@@ -1,0 +1,30 @@
+# Section: Results
+
+Results are a summary of the data collected to address the problem stated in the Introduction.
+
+Results writing should:
+
+- stay mainly in past tense
+- report what was observed, under what conditions, and with what quantitative support
+- use statistics correctly and sparingly
+- use supplementary data sparingly
+
+Results should answer `what happened`, not `what it ultimately means`.
+
+## Sentence syntax (Results vs Discussion)
+
+Results sentences usually report:
+
+- `was detected`
+- `increased`
+- `showed`
+- `enabled`
+- `achieved`
+
+Do not let a Results paragraph drift into Discussion syntax (`may reflect`, `suggests that`, `is likely due to`) unless the transition is intentional.
+
+## Common failure modes
+
+- Interpreting findings inline instead of in Discussion.
+- Citing supplementary data when the result should stand in the main text.
+- Vague comparisons (`higher than control`) without effect size or test.

--- a/skills/nature-polishing/static/fragments/section/title.md
+++ b/skills/nature-polishing/static/fragments/section/title.md
@@ -1,0 +1,17 @@
+# Section: Title
+
+A strong title should:
+
+- tell the reader what to expect
+- avoid unnecessary technical language
+- be easy to search
+- be substantiated by data
+- create curiosity without sacrificing credibility
+
+Use `curiosity with credibility`, not empty cleverness. A hook is only acceptable if the claim remains fully defensible.
+
+## Polishing approach
+
+- If asked for alternatives, generate 3-5 candidates spanning declarative, question, and finding-led patterns; mark the most defensible.
+- Strip jargon that the target journal's general audience would not recognize.
+- Verify every quantitative claim in the title against the manuscript.


### PR DESCRIPTION
Reorganize the nature-polishing skill into two layers so each invocation loads only the content it needs and new scope (paper types, journals, languages) can be added as discrete fragments instead of edits to a monolithic SKILL.md.

- static/core/: stance, failure-modes, ethics, output-format (always loaded)
- static/fragments/: per-axis content
    - paper_type: research, methods, hypothesis, algorithmic, review
    - section: abstract, intro, results, discussion, conclusion, title, methods
    - language: en, zh-to-en
    - journal: nature, nat-comms, generic
- manifest.yaml: declares axes, values, fragment paths, and detection hints
- SKILL.md: rewritten as a thin router that reads manifest.yaml, detects axis values, and loads only the matching fragments

References under references/ are unchanged and remain on-demand.