### PR TITLE
refactor(nature-writing): split into static layer + dynamic router

### DIFF
--- a/skills/nature-writing/SKILL.md
+++ b/skills/nature-writing/SKILL.md
@@ -1,159 +1,72 @@
 ---
 name: nature-writing
-description: Draft, restructure, or plan Nature-style manuscript sections from author-provided claims, results, figures, notes, or Chinese drafts. Use when the user wants to write or rebuild an abstract, introduction, results narrative, discussion, conclusion, title, or full manuscript argument rather than only polish finished prose.
-version: 0.2.0
-author: Community contribution based on curated Nature/Nature Communications writing patterns and open research-writing notes
+description: Draft, restructure, or plan Nature-style manuscript sections from author-provided claims, results, figures, notes, or Chinese drafts. Use when the user wants to write or rebuild an abstract, introduction, related-work, method, experiments, discussion, conclusion, title, or full manuscript argument rather than only polish finished prose.
+version: 1.0.0
+author: Community contribution, refactored into static/dynamic layers
 ---
 
-# Nature-Style Scientific Writing
+# Nature-Style Scientific Writing — Router
 
-Use this skill when the user needs help creating or rebuilding manuscript prose,
-not merely polishing existing sentences.
+This skill is split into two layers:
 
-## Core stance
+- A **static layer** under `static/` that holds versioned, reusable content fragments (core stance + workflow, paper-type playbooks, per-section drafting guidance, language-specific rules, per-journal style).
+- A **dynamic layer** (this file plus `manifest.yaml`) that detects the request's axes and loads only the fragments needed for the current job.
 
-- Author evidence comes first. Do not invent results, mechanisms, references,
-  methods, novelty, sample sizes, statistics or limitations.
-- Write the argument before writing the sentences.
-- Make the paper easy to judge: relevance, novelty, trust, reuse and meaning.
-- Use ambitious but bounded claims.
-- If essential evidence is missing, write a placeholder or ask for the missing
-  input instead of filling the gap.
+Do not try to apply the drafting logic from memory or from this router. Always load fragments from disk as described below.
 
-## When to open extra files
+## Routing protocol
 
-| File | Open when |
-|---|---|
-| [references/article-architecture.md](references/article-architecture.md) | You need section-level structure, argument order, or published-article writing patterns |
-| [references/abstract.md](references/abstract.md) | Drafting or revising an abstract, especially challenge-contribution and challenge-insight-contribution forms |
-| [references/introduction.md](references/introduction.md) | Drafting or revising an Introduction, task framing, technical challenge, contribution framing, or teaser/pipeline logic |
-| [references/related-work.md](references/related-work.md) | Rebuilding Related Work as topic synthesis instead of a paper-by-paper list |
-| [references/method.md](references/method.md) | Writing Method sections, pipeline modules, module motivation, technical advantages, or implementation details |
-| [references/experiments.md](references/experiments.md) | Planning or writing Experiments/Results around baselines, ablations, metrics, tables, figures, and claim support |
-| [references/conclusion.md](references/conclusion.md) | Writing a bounded conclusion with contribution, evidence, impact, limitation, and future direction |
-| [references/paragraph-flow.md](references/paragraph-flow.md) | User asks whether a paragraph flows, makes sense, or is clear; use reverse outlining and paragraph-message checks |
-| [references/paper-review.md](references/paper-review.md) | Final manuscript self-review, rejection-risk audit, claim-evidence alignment, or reviewer-facing critique |
-| [references/chinese-author-workflow.md](references/chinese-author-workflow.md) | The user's notes are Chinese, mixed Chinese-English, or organized as lab notes rather than manuscript prose |
-| [references/examples/index.md](references/examples/index.md) | You need concrete abstract, introduction, or method examples after choosing the relevant guide |
+Follow these five steps every time the skill is invoked.
 
-## Intake
+### 1. Load the manifest and the core layer
 
-Before drafting, identify:
+Read [manifest.yaml](manifest.yaml). It declares the axes (`paper_type`, `section`, `language`, `journal`), the allowed values, and the file paths each value maps to.
 
-- manuscript section: title, abstract, introduction, results, discussion,
-  conclusion, significance paragraph or full outline
-- paper type: mechanism, method, resource, device, model, clinical, materials,
-  computational or interdisciplinary
-- core claim: what the paper actually demonstrates
-- evidence: figures, measurements, comparisons, datasets, statistics or examples
-- boundary: where the claim stops
-- target journal or word limit, if provided
+Also read every file listed under `always_load`. These hold the default stance, writing workflow, and output format that apply to every drafting job.
 
-If any of `core claim`, `evidence` or `boundary` is absent, expose the gap before
-drafting. You may still produce a scaffold with explicit placeholders.
+### 2. Detect the axis values for this request
 
-## Writing workflow
+For each axis in the manifest, decide the value using the manifest's `detect:` hint and the user's input:
 
-1. Build a one-sentence argument: `In [system/problem], we show [advance] using
-   [approach], supported by [evidence], with [boundary].`
-2. Choose the section architecture from `references/article-architecture.md`.
-3. Map each paragraph to one job: context, gap, approach, result, comparison,
-   mechanism, implication or limitation.
-4. Draft from evidence outward. Keep claims near the data that support them.
-5. Calibrate verbs: `show`, `demonstrate`, `suggest`, `indicate`, `enable`,
-   `may`, `could`.
-6. Remove unsupported novelty and universal claims.
-7. Run a paragraph-flow check: one paragraph, one message, with a clear first
-   sentence and explicit sentence-to-sentence relation.
-8. Return prose plus concise notes on assumptions and missing inputs.
+- `paper_type` — research / methods / hypothesis / algorithmic / review. Default: research.
+- `section` — abstract / intro / related-work / method / experiments / discussion / conclusion / title. May be multiple. Ask the user if it is ambiguous and matters for the draft.
+- `language` — en or zh-to-en. Detect from the user's notes themselves.
+- `journal` — nature / nat-comms / generic. Default: generic. If the user names a Nature subjournal, treat it as `nature`.
 
-## Section defaults
+State the detected axis values in one short line to the user before drafting, so they can correct you cheaply.
 
-### Abstract
+### 3. Load the matching fragments
 
-Default Nature pattern:
+For each axis value, Read the file mapped in the manifest. Skip the `section` axis only when the user has explicitly asked for a free-floating argument paragraph with no section context.
 
-`context/problem -> gap -> approach -> key result -> implication -> boundary`
+Do **not** read every fragment in `static/`. Load only what step 2 selected.
 
-For technical AI, ML, CV or method-heavy manuscripts, open
-`references/abstract.md` and choose one of:
+### 4. Draft using the loaded material
 
-- `challenge -> contribution`
-- `challenge -> insight -> contribution`
-- `multiple contributions`
+Apply the loaded fragments in this priority order:
 
-Keep it compact. Include quantitative or comparative detail when the user
-provided it. End with what the work enables, not generic importance.
+1. Core stance + intake (`core/stance.md`) — surface missing claim / evidence / boundary before drafting.
+2. Paper-type playbook — argument chain, drafting order.
+3. Section-specific drafting rules and structure.
+4. Journal-specific framing and constraints.
+5. Language-specific sentence and paragraph rules (apply last).
 
-### Introduction
+Run the 8-step workflow in `core/workflow.md` end-to-end. Do not skip steps 1-3 (planning) just because the user asked for prose immediately — write the one-sentence argument first.
 
-Use:
+If essential evidence or boundary is missing, write a placeholder and list it under `Assumptions or missing inputs:` instead of inventing content.
 
-`field scale -> bottleneck -> prior attempts -> unresolved gap -> present study`
+### 5. Reach for references only when needed
 
-For method-heavy papers, open `references/introduction.md` and reason backward
-from the technical challenge and contribution before drafting forward.
+The files under `references/` are deep references and the example library, not defaults. Open them on demand per the `references.on_demand` table in the manifest. Typical triggers:
 
-Do not summarize all results. The final paragraph should state what this paper
-does and how it addresses the gap.
+- The user asks for a concrete example or template → `references/examples/index.md`.
+- A section's draft has structural problems that the section fragment alone does not explain → the matching `references/<section>.md`.
+- The user asks "does this paragraph flow?" → `references/paragraph-flow.md`.
+- The user asks for a self-review or rejection-risk audit → `references/paper-review.md`.
 
-### Results narrative
+## Why this split
 
-Use an evidence ladder:
-
-`system/workflow -> validation -> main result -> baseline comparison ->
-mechanism/diagnostic analysis -> application or generalization`
-
-Each subsection should have a claim-first opening and then data support.
-
-For ML/conference-style experiment sections, open `references/experiments.md`
-and make sure each major claim is backed by comparison, ablation, or stress-test
-evidence.
-
-### Related Work
-
-Use:
-
-`topic scope -> representative methods -> limitation tied to this paper ->
-distinction`
-
-Group prior work by technical topic and mechanism, not by publication year.
-
-### Discussion
-
-Use:
-
-`central advance -> evidence meaning -> relation to prior work -> constraints ->
-future use`
-
-This is where interpretation and limitations belong. Do not repeat the Results
-section figure by figure.
-
-### Conclusion
-
-Use:
-
-`contribution -> decisive evidence -> implication -> boundary`
-
-No new data. No unsupported promises.
-
-### Title
-
-Prefer concrete titles that combine:
-
-`system/object + action/capability + application or consequence`
-
-Avoid slogan titles, grant-style aims and overbroad field claims.
-
-## Output format
-
-Default output:
-
-1. `Draft:` with the requested prose.
-2. `Section outline:` with `3-7` compact bullets when the task involves a full section.
-3. `Assumptions or missing inputs:` with only material issues.
-4. `Claim-evidence map:` for major claims, using `Claim: ... | Evidence: ... | Status: supported/needs evidence`.
-5. `Why this structure:` with `2-4` short bullets.
-
-For Chinese author notes, provide polished English first, then brief Chinese
-notes explaining major structural choices.
+- The static layer is versioned and reviewable. Adding a new journal style, paper type, or section is one new file plus one manifest line.
+- The dynamic layer keeps each invocation cheap: only the fragments relevant to this draft enter context, instead of the full multi-thousand-line reference set.
+- The router itself is short on purpose. Update fragments, not this file, when adding scope.
+- This structure mirrors `nature-polishing` so shared content can later be lifted into a `_shared/` layer used by both skills.

--- a/skills/nature-writing/manifest.yaml
+++ b/skills/nature-writing/manifest.yaml
@@ -1,0 +1,91 @@
+name: nature-writing
+version: 1.0.0
+description: >
+  Declarative manifest for the static/dynamic split. SKILL.md uses this to
+  decide which fragments to load for a given drafting or restructuring request.
+
+always_load:
+  - static/core/stance.md
+  - static/core/workflow.md
+  - static/core/output-format.md
+
+axes:
+  paper_type:
+    detect: |
+      Decide what kind of paper or section is being drafted. Default to research.
+      Use the user's stated framing first; fall back to inference from their
+      material. Map writing's older taxonomy (mechanism/method/resource/device/
+      model/clinical/materials/computational/interdisciplinary) onto these five.
+    values:
+      research:       static/fragments/paper_type/research.md
+      methods:        static/fragments/paper_type/methods.md
+      hypothesis:     static/fragments/paper_type/hypothesis.md
+      algorithmic:    static/fragments/paper_type/algorithmic.md
+      review:         static/fragments/paper_type/review.md
+    default: research
+    multi: false
+
+  section:
+    detect: |
+      Identify which section(s) the user wants drafted or rebuilt. The user
+      may name one or several. Ask before loading when ambiguous and load
+      cost matters. Title and abstract often need to be drafted last but
+      planned early.
+    values:
+      abstract:       static/fragments/section/abstract.md
+      intro:          static/fragments/section/intro.md
+      related-work:   static/fragments/section/related-work.md
+      method:         static/fragments/section/method.md
+      experiments:    static/fragments/section/experiments.md
+      discussion:     static/fragments/section/discussion.md
+      conclusion:     static/fragments/section/conclusion.md
+      title:          static/fragments/section/title.md
+    multi: true
+
+  language:
+    detect: |
+      Detect the source language of the user's notes. Use zh-to-en when the
+      input is Chinese, mixed Chinese-English, or organized as Chinese lab
+      notes. Otherwise use en.
+    values:
+      en:             static/fragments/language/en.md
+      zh-to-en:       static/fragments/language/zh-to-en.md
+    default: en
+    multi: false
+
+  journal:
+    detect: |
+      Use the journal value the user names. If the user says "Nature-family"
+      generically or names a Nature subjournal, use nature. If they name
+      Nature Communications, use nat-comms. Otherwise generic.
+    values:
+      nature:         static/fragments/journal/nature.md
+      nat-comms:      static/fragments/journal/nat-comms.md
+      generic:        static/fragments/journal/generic.md
+    default: generic
+    multi: false
+
+references:
+  on_demand:
+    - condition: needs section-level structure, argument order, or published-article patterns
+      path: references/article-architecture.md
+    - condition: drafting/revising abstract; especially challenge-contribution forms
+      path: references/abstract.md
+    - condition: drafting/revising introduction, task framing, technical challenge, contribution framing
+      path: references/introduction.md
+    - condition: rebuilding related work as topic synthesis
+      path: references/related-work.md
+    - condition: writing method sections, pipeline modules, module motivation, technical advantages
+      path: references/method.md
+    - condition: planning/writing experiments around baselines, ablations, metrics
+      path: references/experiments.md
+    - condition: writing a bounded conclusion with contribution, evidence, impact, limitation
+      path: references/conclusion.md
+    - condition: user asks whether a paragraph flows; use reverse outlining
+      path: references/paragraph-flow.md
+    - condition: final manuscript self-review, rejection-risk audit, claim-evidence alignment
+      path: references/paper-review.md
+    - condition: deeper Chinese-author repair patterns beyond the language fragment
+      path: references/chinese-author-workflow.md
+    - condition: user wants concrete abstract/introduction/method examples
+      path: references/examples/index.md

--- a/skills/nature-writing/static/core/output-format.md
+++ b/skills/nature-writing/static/core/output-format.md
@@ -1,0 +1,14 @@
+# Output format (writing)
+
+Default output:
+
+1. `Draft:` — the requested prose.
+2. `Section outline:` — `3-7` compact bullets when the task involves a full section.
+3. `Assumptions or missing inputs:` — only material issues; do not pad with style nits.
+4. `Claim-evidence map:` — for major claims, in the form:
+   `Claim: ... | Evidence: ... | Status: supported / needs evidence / inferred`
+5. `Why this structure:` — `2-4` short bullets on the structural choices made.
+
+For Chinese-author notes, provide polished English first, then brief Chinese notes explaining major structural choices.
+
+If essential evidence or boundary is missing, do not invent. Write a placeholder such as `[Evidence needed: comparator group accuracy on test set X]` and list it under `Assumptions or missing inputs:`.

--- a/skills/nature-writing/static/core/stance.md
+++ b/skills/nature-writing/static/core/stance.md
@@ -1,0 +1,38 @@
+# Default stance (writing)
+
+## Author evidence comes first
+
+- Do not invent results, mechanisms, references, methods, novelty, sample sizes, statistics, or limitations.
+- Write the argument before writing the sentences.
+- If essential evidence is missing, write a placeholder or ask for the missing input instead of filling the gap.
+
+## Reader workflow
+
+A strong manuscript helps the reader judge, in order:
+
+1. Relevance — is this for me?
+2. Novelty — what is new?
+3. Trust — do I believe it?
+4. Reuse — can I use it?
+5. Meaning — where are the boundaries?
+
+Draft and revise so the paper answers these questions in this order.
+
+## Claim discipline
+
+- Use ambitious but bounded claims.
+- Calibrate verbs: `show`, `demonstrate`, `suggest`, `indicate`, `enable`, `may`, `could`.
+- Remove unsupported novelty and universal claims (`first ever`, `unprecedented`, `revolutionary`) unless the evidence genuinely supports them.
+
+## Intake — required inputs before drafting
+
+Identify before writing:
+
+- **manuscript section**: title, abstract, introduction, related-work, method, results/experiments, discussion, conclusion, significance paragraph, or full outline
+- **paper type**: research / methods / hypothesis / algorithmic / review (see paper_type fragment)
+- **core claim**: what the paper actually demonstrates
+- **evidence**: figures, measurements, comparisons, datasets, statistics, or examples
+- **boundary**: where the claim stops
+- **target journal or word limit** if provided
+
+If any of `core claim`, `evidence`, or `boundary` is absent, expose the gap before drafting. You may still produce a scaffold with explicit placeholders.

--- a/skills/nature-writing/static/core/workflow.md
+++ b/skills/nature-writing/static/core/workflow.md
@@ -1,0 +1,43 @@
+# Writing workflow
+
+Run these eight steps for any drafting or restructuring task. Steps 1-3 are planning, 4-6 are drafting, 7-8 are checking.
+
+## 1. Build a one-sentence argument
+
+> In [system/problem], we show [advance] using [approach], supported by [evidence], with [boundary].
+
+Force every section to serve this sentence. If the sentence cannot be written, the paper does not yet have an argument — surface that to the user.
+
+## 2. Choose section architecture
+
+Pick the section structure from the relevant `section/*.md` fragment and, if needed, deeper patterns from `references/article-architecture.md`.
+
+## 3. Map each paragraph to one job
+
+Each paragraph must do exactly one job from: context, gap, approach, result, comparison, mechanism, implication, limitation.
+
+If a paragraph carries two jobs, split it before drafting.
+
+## 4. Draft from evidence outward
+
+Keep claims near the data that support them. Do not stack claims at the top of a section then leave evidence at the bottom.
+
+## 5. Calibrate verbs to evidence strength
+
+`show` / `demonstrate` need strong direct evidence. `suggest` / `indicate` are for trend-level or indirect evidence. `may` / `could` are for plausible but unverified mechanisms.
+
+## 6. Remove unsupported novelty and universal claims
+
+Sweep for `first`, `unique`, `unprecedented`, `comprehensive`, `complete`, `always`, `never`. Replace with bounded claims or delete.
+
+## 7. Run a paragraph-flow check
+
+- One paragraph, one message.
+- The first sentence is the topic / claim.
+- Each subsequent sentence has an explicit relation to the previous one (cause, comparison, restriction, example).
+
+For full reverse-outlining, open `references/paragraph-flow.md`.
+
+## 8. Return prose plus notes
+
+Output the draft together with explicit notes on assumptions, missing inputs, and where evidence is needed. See `output-format.md`.

--- a/skills/nature-writing/static/fragments/journal/generic.md
+++ b/skills/nature-writing/static/fragments/journal/generic.md
@@ -1,0 +1,16 @@
+# Journal: generic — writing
+
+Used when the user has not named a target journal, or the journal is not specifically modeled by another fragment.
+
+## Defaults
+
+- Apply Nature-leaning structure (argument chain, section jobs) without enforcing Nature's strictest length or significance-framing demands.
+- Keep em-dash and hedging defaults from `core/stance.md` and `language/en.md`.
+- If the user later names a journal, ask whether to re-draft under that journal's fragment rather than guess.
+
+## Things to ask the user before final draft
+
+- Target journal and section format (structured vs unstructured abstract; word limits; reference style).
+- Audience breadth: subfield vs broad readership.
+- Whether a "Significance" paragraph or "Author summary" is required.
+- Required submission elements (graphical abstract, highlights, key points) — these change drafting strategy.

--- a/skills/nature-writing/static/fragments/journal/nat-comms.md
+++ b/skills/nature-writing/static/fragments/journal/nat-comms.md
@@ -1,0 +1,18 @@
+# Journal: Nature Communications — writing
+
+## Audience
+
+Open-access. Broader than a subfield journal, more specialist-tolerant than Nature. The reader is typically an active researcher in an adjacent area.
+
+## Drafting priorities
+
+- Significance framing matters, but a less aggressive opening than Nature is acceptable.
+- Structured abstract not required; check the current guideline if the user names the target precisely.
+- Word count more forgiving than Nature, but tight prose is still preferred.
+- Methods can be more detailed in-line; reproducibility expectations are explicit.
+- Same em-dash and hedging defaults as Nature.
+
+## Common drafting calibration
+
+- A draft written for Nature can often be re-targeted to Nat Comms by relaxing the broadest-audience opening and restoring specialist detail that was cut.
+- A draft written for a specialist journal usually needs significance framing strengthened to land at Nat Comms.

--- a/skills/nature-writing/static/fragments/journal/nature.md
+++ b/skills/nature-writing/static/fragments/journal/nature.md
@@ -1,0 +1,25 @@
+# Journal: Nature (and Nature subjournals) — writing
+
+## Audience
+
+Broad, multi-disciplinary. A reader outside the immediate subfield must be able to grasp the claim, the gap, and the significance from the first paragraph of the introduction and from the abstract alone.
+
+## Drafting priorities
+
+- The opening sentence of the abstract and the introduction must signal significance for a non-specialist audience without overclaiming.
+- Avoid jargon that does not appear in a typical Nature News piece. Define or replace.
+- Word count is unforgiving. Prefer cuts to compressions when a section runs long.
+- No em dashes in body prose.
+- Hedging must be calibrated: avoid both overclaim (`proves`, `definitive`) and timidity (`might possibly suggest`).
+- The "Significance" framing matters. If the user's material does not naturally support broad significance, surface that before drafting around it.
+
+## Section format notes
+
+- Abstract is usually unstructured prose (no headed subsections) for many Nature titles. Check the specific journal guideline if named.
+- Methods often goes to the end and can be longer than in subfield journals; the main text is significance-driven.
+- References are typically capped (~50 for Articles). Plan citation budget early.
+
+## Things to flag rather than silently fix
+
+- If the manuscript leans on a specialist mechanism the broad audience cannot follow, flag it rather than over-translating.
+- If significance for a non-specialist is genuinely thin, surface that as a structural issue under `Assumptions or missing inputs:`.

--- a/skills/nature-writing/static/fragments/language/en.md
+++ b/skills/nature-writing/static/fragments/language/en.md
@@ -1,0 +1,23 @@
+# Language: English source (writing)
+
+When the source notes are already in English, default to standard scientific-English drafting conventions.
+
+## Sentence rules
+
+- Aim for `10-30` word sentences in drafts.
+- One main proposition per sentence; split if the sentence carries two.
+- Prefer subject-verb-object order. Avoid stacked prepositional chains.
+- Avoid em dashes as prose punctuation in drafts unless the user explicitly asks. Use commas, parentheses, or short sentences.
+
+## Paragraph rules
+
+- One paragraph, one message.
+- The first sentence is the topic or claim.
+- Each subsequent sentence has an explicit relation to the previous one: cause, comparison, restriction, example.
+- Do not stack two ideas into one paragraph. If a new idea appears, start a new paragraph.
+
+## Diction
+
+- Calibrate verbs to evidence strength (`show` / `suggest` / `may`).
+- Avoid marketing verbs (`leverages`, `enables`, `empowers`) unless they carry concrete information.
+- Avoid universal claims (`always`, `never`, `comprehensive`).

--- a/skills/nature-writing/static/fragments/language/zh-to-en.md
+++ b/skills/nature-writing/static/fragments/language/zh-to-en.md
@@ -1,0 +1,37 @@
+# Language: Chinese-to-English (writing)
+
+Use this when the user's notes are Chinese, mixed Chinese-English, or organized as lab notes rather than manuscript prose.
+
+## Translate intent, not syntax
+
+Chinese academic notes often pack background, motivation, method, and implication into one long sentence. Before drafting English, split each note into:
+
+- claim
+- evidence
+- condition
+- comparison
+- implication
+- limitation
+
+Then write English in the order required by the section, not in the order of the Chinese sentence.
+
+## Common repairs
+
+| Chinese-draft pattern | English repair |
+|---|---|
+| Broad importance before a clear object | Name the system or problem earlier |
+| Method list before research gap | Move the gap before the method |
+| `显著提高 / 明显改善` without baseline | Add the comparator or soften the verb |
+| `首次 / 创新性` without scope | Replace with a bounded novelty claim |
+| Mechanism inferred from correlation | Use `suggests`, `is consistent with`, or ask for mechanistic evidence |
+| Results mixed with implications | Put observation in Results, meaning in Discussion |
+| Repeated topic noun where English would use a pronoun | Replace or elide |
+| Strings of short clauses joined by commas | Split or add explicit connectives |
+
+## Output convention
+
+For Chinese-author notes, provide polished English **first**, then brief Chinese notes explaining major structural choices. This lets a Chinese author verify intent without re-reading the English from scratch.
+
+## Deeper reference
+
+For more repair patterns and edge cases, open `references/chinese-author-workflow.md`.

--- a/skills/nature-writing/static/fragments/paper_type/algorithmic.md
+++ b/skills/nature-writing/static/fragments/paper_type/algorithmic.md
@@ -1,0 +1,22 @@
+# Paper type: algorithmic or device
+
+A procedure, tool, or system is proposed; the paper must show it performs reliably and advantageously.
+
+## Argument chain
+
+`task definition + scope -> what the system is -> why it works (design rationale) -> how well it works (evaluation) -> ablations isolating the contribution -> failure modes + cost characteristics -> applicability boundary`
+
+## Drafting rules
+
+- Separate "what the system is" from "why it works" from "how well it works." Do not braid them. A common failure is mixing design rationale with evaluation results in the same paragraph.
+- Every performance claim must specify dataset, metric, baseline, and conditions. Bare numbers do not survive review.
+- Avoid marketing verbs (`leverages`, `enables`, `empowers`) unless they carry concrete information.
+- The Discussion must name the failure modes the experiments revealed, not only the wins. Reviewers trust papers that report their own limits.
+
+## Module / pipeline writing
+
+For module-level writing (each component of a pipeline), open `references/method.md` for:
+
+- the three-element pattern (motivation, mechanism, evidence)
+- module-motivation templates
+- overview-template for the pipeline figure caption + first paragraph

--- a/skills/nature-writing/static/fragments/paper_type/hypothesis.md
+++ b/skills/nature-writing/static/fragments/paper_type/hypothesis.md
@@ -1,0 +1,19 @@
+# Paper type: hypothesis-based
+
+The argument tries to establish or rule out a causal explanation.
+
+## Argument chain
+
+`phenomenon -> candidate explanation(s) -> hypothesis stated explicitly -> falsification path -> evidence for / against -> rival explanations addressed -> bounded conclusion`
+
+## Drafting rules
+
+- State the hypothesis explicitly and locatably. Do not bury it in the third paragraph of the Introduction.
+- State up front what observations would refute the hypothesis. This earns trust later.
+- Distinguish "supporting" evidence from "consistent but non-discriminating" evidence. Many drafts conflate them.
+- In Discussion, address rival explanations **before** generalizing. Skipping this is the most common rejection point for hypothesis papers.
+- Hedging must match causal strength. Correlational evidence cannot ground mechanism verbs (`drives`, `causes`).
+
+## Results vs Discussion
+
+Keep Results to direct observations and tests. All causal interpretation goes in Discussion. Reviewers will check this split aggressively.

--- a/skills/nature-writing/static/fragments/paper_type/methods.md
+++ b/skills/nature-writing/static/fragments/paper_type/methods.md
@@ -1,0 +1,39 @@
+# Paper type: methods
+
+A methods paper proposes a technique and must convince the reader it works, is reproducible, and is better than alternatives under a fair test.
+
+## Argument chain
+
+`task / problem -> limits of existing methods -> proposed method -> evaluation showing advantage -> reproducibility evidence -> boundary`
+
+## Drafting order
+
+1. Methods — the technical core, written first
+2. Results — what comparisons and ablations show
+3. Introduction — frames the task and gap retrospectively
+4. Conclusion
+5. Discussion
+6. Abstract
+
+## Results section discipline
+
+In a methods paper, Results must answer:
+
+- Is it more reliable?
+- Is it faster / cheaper / smaller?
+- Does it require fewer resources or data?
+- Is the comparison fair and reproducible?
+
+Bare "we obtain higher accuracy" without baseline + setup + statistical handling is insufficient.
+
+## Methods section depth
+
+Be explicit about:
+
+- axioms, conditions, and assumptions
+- hardware and software environment
+- mathematical derivations
+- evaluation protocol: datasets, baselines, metrics, splits, hyperparameters
+- failure modes and out-of-scope conditions
+
+When drafting a method, also open `references/method.md` for module-motivation and three-elements patterns.

--- a/skills/nature-writing/static/fragments/paper_type/research.md
+++ b/skills/nature-writing/static/fragments/paper_type/research.md
@@ -1,0 +1,32 @@
+# Paper type: research
+
+A research paper answers: why this phenomenon matters, what was done, what was found, what it implies.
+
+## Full-paper argument chain
+
+`field-scale need -> unresolved bottleneck -> proposed move -> decisive evidence -> broader implication -> boundary`
+
+Before drafting, force the user's material into this chain. If one link is missing, mark it as missing rather than writing around it.
+
+## Drafting order
+
+For a research paper, draft in evidence-first order:
+
+1. Results — write what was observed before anything else
+2. Introduction and Conclusion — frame around the actual results
+3. Title — derived from the strongest result + scope
+4. Discussion — interpret in dialogue with prior work
+5. Methods — written for reproducibility, not narrative
+6. Authors — order and contributions
+7. Abstract — last, distilled from the rest
+
+Do not draft Introduction before Results. The Introduction's job is to set up the gap that Results actually fills.
+
+## Hourglass structure
+
+Strong research papers mirror an hourglass:
+
+- Introduction: broad → narrow to specific gap, question, hypothesis, methods
+- Discussion/Conclusion: narrow → broad, connecting findings back to the field
+
+If a draft violates this, rebuild architecture before drafting paragraphs.

--- a/skills/nature-writing/static/fragments/paper_type/review.md
+++ b/skills/nature-writing/static/fragments/paper_type/review.md
@@ -1,0 +1,19 @@
+# Paper type: review
+
+A review reports on the state of a field: what is known, where the disagreements are, what remains open.
+
+## Argument chain
+
+`scope statement -> organizing principle (mechanism / method / application) -> synthesis grouped by argument -> disagreements and gaps -> author's stance with reasoning -> outlook with informative open questions`
+
+## Drafting rules
+
+- A review is **not a survey list**. Replace `Author A reported X. Author B reported Y.` with synthesis grouped by mechanism, method, or conclusion.
+- Define scope precisely: which sub-area, which time window, which inclusion criteria. Vague scopes invite reviewer pushback.
+- Position the reviewer's own stance carefully. A review can take a view, but it must show its reasoning, not assert it.
+- Use connectives that signal logical relation: `in contrast`, `building on this`, `the remaining disagreement is`. Avoid generic `furthermore`, `additionally`.
+- The closing section should leave the reader with a usable map of the field, not a summary of what was just read.
+
+## Related work synthesis
+
+For topic-based grouping techniques and how to write distinctions without bashing prior work, open `references/related-work.md`.

--- a/skills/nature-writing/static/fragments/section/abstract.md
+++ b/skills/nature-writing/static/fragments/section/abstract.md
@@ -1,0 +1,38 @@
+# Section: Abstract (writing)
+
+The abstract is a mini-paper. Draft it last, when Results and Discussion are stable.
+
+## Default Nature pattern
+
+`context / problem -> gap -> approach -> key result -> implication -> boundary`
+
+## Paragraph movement (recommended)
+
+1. Field-scale context or problem.
+2. Why current routes do not fully solve it.
+3. What this paper introduces or demonstrates.
+4. The strongest result, with quantitative or comparative support.
+5. The mechanism, workflow, or practical consequence.
+6. Bounded implication.
+
+## Pattern variants for technical / method-heavy papers
+
+For ML, CV, materials, or method-heavy manuscripts, choose one variant from `references/abstract.md`:
+
+- `challenge -> contribution`
+- `challenge -> insight -> contribution`
+- `multiple contributions`
+
+Open `references/abstract.md` for templates and examples.
+
+## Diagnostics before submitting the draft
+
+- Beginning with `Here, we` may signal missing context.
+- Ending with a broad promise may need scope control.
+- No number, comparison, or concrete test may feel ungrounded.
+
+## Drafting discipline
+
+- Keep it compact. Cut sentences that re-summarize background the title already implies.
+- Include quantitative or comparative detail when the user provided it. Do not invent numbers.
+- End with what the work enables, not generic importance.

--- a/skills/nature-writing/static/fragments/section/conclusion.md
+++ b/skills/nature-writing/static/fragments/section/conclusion.md
@@ -1,0 +1,25 @@
+# Section: Conclusion (writing)
+
+## Default structure
+
+`contribution -> decisive evidence -> implication -> boundary`
+
+## Drafting rules
+
+- No new data. No unsupported promises.
+- Restate the central contribution in one sentence. Do not summarize each Result figure.
+- The implication must be narrower than or equal to the scope of the evidence.
+- A bounded future-work pointer is acceptable, but generic "more work is needed" is not.
+
+## Overclaim check
+
+Before finalizing, run the check:
+
+- Does each claim trace back to evidence in this paper?
+- Are mechanism words (`demonstrates`, `proves`, `establishes`) backed by the right study design?
+- Is the scope of the implication narrower than or equal to the scope of the evidence?
+- Is any "first" claim genuinely first within a stated scope?
+
+## Deeper reference
+
+For full conclusion structure (contribution-evidence-impact-limitation-future), open `references/conclusion.md`.

--- a/skills/nature-writing/static/fragments/section/discussion.md
+++ b/skills/nature-writing/static/fragments/section/discussion.md
@@ -1,0 +1,34 @@
+# Section: Discussion (writing)
+
+## Default structure
+
+`central advance -> what the evidence means -> relation to prior work -> constraints / limitations -> future use or open questions`
+
+## Drafting rules
+
+- Discussion **interprets**, it does not repeat Results figure by figure.
+- Address rival explanations before generalizing. Reviewers look for this.
+- Hedging strength must match evidence strength. Do not promote a "consistent with" finding to "demonstrates" wording.
+- Limitations come from inside the paper, not from generic disclaimers. Name the specific condition or dataset where the result stops holding.
+
+## Sentence syntax
+
+Discussion sentences interpret:
+
+- `may reflect`
+- `suggests that`
+- `could indicate`
+- `is likely due to`
+- `may facilitate`
+
+## Common failure modes when drafting
+
+- Re-summarizing Results instead of interpreting them.
+- Skipping rival explanations.
+- Omitting boundaries — when does the interpretation stop holding?
+- Future-work statements that read as marketing, not as honest open questions.
+
+## Short rule to memorize
+
+- Results = what we observed
+- Discussion = how we understand it, and when it may fail

--- a/skills/nature-writing/static/fragments/section/experiments.md
+++ b/skills/nature-writing/static/fragments/section/experiments.md
@@ -1,0 +1,34 @@
+# Section: Experiments / Results (writing)
+
+## Default evidence ladder
+
+`system / workflow validation -> main result -> baseline comparison -> ablation / mechanism analysis -> application or generalization -> stress tests / failure modes`
+
+Each subsection has a claim-first opening, then data support.
+
+## Drafting rules
+
+- Stay mainly in past tense.
+- Report what was observed, under what conditions, with what quantitative support.
+- Use statistics correctly and sparingly. Every test needs a stated hypothesis.
+- Use supplementary data sparingly. If a result belongs in the main text, do not hide it in supplements.
+- **Each major claim needs comparison, ablation, or stress-test evidence.** If a claim has none, mark it for follow-up rather than drafting around it.
+
+## Results syntax (vs Discussion)
+
+Results sentences usually report:
+
+- `was detected` / `increased` / `showed` / `enabled` / `achieved`
+
+Do not drift into Discussion syntax (`may reflect`, `suggests`, `is likely due to`) unless the transition is intentional.
+
+## Common failure modes when drafting
+
+- Mixing observation and interpretation in the same paragraph.
+- Citing supplementary data when the result should be in the main text.
+- Vague comparisons (`higher than control`) without effect size, sample size, or test.
+- Per-paragraph claims without per-paragraph evidence.
+
+## Deeper reference
+
+For ML/conference-style experiment sections — baselines, ablations, metrics, tables, figures — open `references/experiments.md`.

--- a/skills/nature-writing/static/fragments/section/intro.md
+++ b/skills/nature-writing/static/fragments/section/intro.md
@@ -1,0 +1,32 @@
+# Section: Introduction (writing)
+
+## Default funnel
+
+`field scale -> bottleneck -> prior attempts -> unresolved gap -> present study`
+
+## Paragraph jobs (typical 4-paragraph intro)
+
+1. Establish the field stake. Make it land for a non-specialist if the target is broad (Nature, Science).
+2. Identify the bottleneck in existing practice.
+3. Summarize what prior work has and has not solved. Synthesize, do not list.
+4. State what this paper does and how it addresses the gap. Preview the contribution, not the results in detail.
+
+## Pipeline variants — pick one based on the material
+
+For method-heavy papers, the introduction often follows a different pattern. Common variants from curated examples (open `references/introduction.md` and `references/examples/introduction-examples.md` for full versions):
+
+- **task-then-application** — define a task abstractly, then show its applications
+- **application-first** — open with a concrete application or pain point, narrow to the task
+- **general-to-specific-setting** — broad field → specific subproblem
+- **open-with-challenge** — lead with the unsolved difficulty
+- **novel-task-challenge-decomposition** — define a new task, decompose its challenges
+- **technical-challenge** (1-3 variants) — frame around the technical bottleneck, then the move
+- **pipeline-version** (1-4 variants) — for module/pipeline papers, frame contribution as one or several modules
+
+Tell the user which variant you picked and why.
+
+## Drafting rules
+
+- Do not summarize results in detail. The final paragraph states the contribution and approach, not the numbers.
+- Cite prior work to position, not to demonstrate breadth. Each citation should earn its place.
+- The transition from "what is known" to "what this paper does" must be explicit, not implied.

--- a/skills/nature-writing/static/fragments/section/method.md
+++ b/skills/nature-writing/static/fragments/section/method.md
@@ -1,0 +1,40 @@
+# Section: Method (writing)
+
+## Default structure
+
+`task formulation -> overview (pipeline / system / approach) -> per-module detail -> implementation notes -> assumptions and boundary`
+
+## The three-element pattern (per module)
+
+Each module should answer:
+
+1. **Motivation** — what problem this module solves, and why the obvious alternative fails
+2. **Mechanism** — what the module actually does, to a level a peer could re-implement
+3. **Evidence / role** — how this module contributes to the overall result (ablation hook)
+
+If any element is missing, the module reads as a black box. Flag the gap.
+
+## Pre-writing checklist
+
+Before drafting Method, confirm with the user:
+
+- Task formulation: inputs, outputs, scope.
+- Overview figure / pipeline diagram: does one exist? It anchors the section.
+- Notation: defined once and consistent.
+- Reproducibility scope: code, weights, data — what will be released.
+
+## Forbidden vague phrases
+
+Never leave:
+
+- `under standard conditions`
+- `using routine methods`
+- `data were analyzed statistically`
+- `the method was validated`
+- `samples were randomly assigned` (without saying how)
+
+Replace with the actual reproducible information.
+
+## Deeper reference
+
+For module-motivation templates, three-elements examples, and overview-template patterns, open `references/method.md` and `references/examples/method/`.

--- a/skills/nature-writing/static/fragments/section/related-work.md
+++ b/skills/nature-writing/static/fragments/section/related-work.md
@@ -1,0 +1,22 @@
+# Section: Related Work (writing)
+
+## Default structure
+
+`topic scope -> representative methods grouped by mechanism -> limitation tied to this paper -> distinction`
+
+## Drafting rules
+
+- **Group by technical topic and mechanism, not by publication year or author.** A paragraph titled "Graph-based approaches" with three contrasting methods is stronger than three single-paper paragraphs.
+- Each subsection ends with a limitation that **this paper addresses**. If a subsection's limitation does not connect back to your contribution, the subsection probably does not belong.
+- Avoid both extremes: do not bash prior work, do not flatter it. State what prior work showed and where its scope ended.
+- Cite the source you actually read. Do not chain-cite review papers as if they were primary sources.
+
+## When Related Work is a separate section vs folded into Introduction
+
+- Separate Related Work is common in CS/ML conference style.
+- Folded into Introduction is common in Nature-family style.
+- The user's target venue decides. Ask if unclear.
+
+## When to open the deep reference
+
+For topic-based synthesis techniques and concrete patterns, open `references/related-work.md`.

--- a/skills/nature-writing/static/fragments/section/title.md
+++ b/skills/nature-writing/static/fragments/section/title.md
@@ -1,0 +1,25 @@
+# Section: Title (writing)
+
+## Default pattern
+
+Prefer concrete titles that combine:
+
+`system / object + action / capability + application or consequence`
+
+## Drafting rules
+
+- Tell the reader what to expect; do not be a slogan.
+- Be searchable: include terms a researcher would search for.
+- Be substantiated by data — if a number or quantitative word appears, verify it against the manuscript.
+- Create curiosity without sacrificing credibility. A hook is only acceptable if the claim remains fully defensible.
+
+## Things to avoid
+
+- Grant-style aims (`Toward …`, `A study of …`).
+- Overbroad field claims (`A new era of …`, `Revolutionizing …`).
+- Question titles unless the paper genuinely answers the question.
+- Jargon a non-specialist in the target audience would not recognize.
+
+## When asked for alternatives
+
+Generate 3-5 candidates spanning declarative, finding-led, and (rarely) question patterns. Mark the most defensible one. Verify any quantitative claim in each candidate.


### PR DESCRIPTION
Reorganize the nature-writing skill into two layers, mirroring the nature-polishing refactor. This sets up both skills with parallel structures so shared content (stance, ethics, Chinese-mode, paper-type taxonomy, section jobs) can later be lifted into a shared layer.

- static/core/: stance, workflow, output-format (always loaded)
- static/fragments/: per-axis content
    - paper_type: research, methods, hypothesis, algorithmic, review
    - section: abstract, intro, related-work, method, experiments, discussion, conclusion, title
    - language: en, zh-to-en
    - journal: nature, nat-comms, generic
- manifest.yaml: declares axes, values, fragment paths, detection hints, and on_demand references including the examples library
- SKILL.md: rewritten as a thin router that reads manifest.yaml, detects axis values, and loads only the matching fragments

References under references/ (including the examples/ library) are unchanged and remain on-demand.