### PR TITLE
feat: add Terminology Ledger to nature-writing and nature-polishing

### DIFF
--- a/skills/_shared/README.md
+++ b/skills/_shared/README.md
@@ -16,6 +16,7 @@ always_load:
 | `core/reader-workflow.md` | nature-polishing, nature-writing |
 | `core/paper-type-taxonomy.md` | nature-polishing, nature-writing |
 | `core/ethics.md` | nature-polishing, nature-writing |
+| `core/terminology-ledger.md` | nature-polishing, nature-writing |
 | `journal-formats/nat-comms.md` | nature-polishing, nature-writing |
 
 ## When to add a file here

--- a/skills/_shared/core/terminology-ledger.md
+++ b/skills/_shared/core/terminology-ledger.md
@@ -1,0 +1,58 @@
+# Terminology Ledger
+
+A manuscript must use one name for one thing. The same method, model, dataset,
+gene, metric, or concept must not drift across shifting names, spellings, or
+capitalisation. Reviewers read inconsistent terminology as careless work, and a
+term that changes between sections forces the reader to re-learn it.
+
+Build the ledger **before** drafting or polishing prose, and treat it as the
+single source of truth for the rest of the job. Consistency against a standard
+is impossible if the standard was never written down.
+
+## 1. Build the ledger on first contact
+
+When you first receive a manuscript, draft, or set of notes, extract every
+recurring domain term into a ledger before editing any prose:
+
+- methods, models, systems, algorithms, modules, frameworks
+- datasets, benchmarks, cohorts, materials, reagents
+- genes, proteins, species, cell lines (respect established field nomenclature)
+- metrics, units, statistical symbols, mathematical notation
+- abbreviations and acronyms, each with its full form
+- key concepts the paper defines or repeatedly relies on
+
+For each term, record its canonical form, its first-use expansion (for
+abbreviations), and any variants already present in the source.
+
+## 2. Present the ledger to the user
+
+Show a compact table before or alongside the first output:
+
+| Canonical term | First-use definition | Variants seen in source | Decision |
+|---|---|---|---|
+| scRNA-seq | single-cell RNA sequencing (scRNA-seq) | "single cell RNA-seq", "scRNAseq" | spell out once, then use "scRNA-seq" |
+
+Flag every collision explicitly: the same concept under different names, or one
+name reused for two different concepts. Ask the user to confirm the canonical
+choice only when the decision is genuinely ambiguous or domain-sensitive.
+Otherwise adopt the form the source uses most often and state that choice.
+
+## 3. Lock and enforce
+
+Once set, the ledger is fixed for the whole job:
+
+- Use only canonical forms in every output. Do not introduce synonyms to vary
+  the prose. Terminology consistency outranks lexical variety in scientific
+  writing.
+- Define each abbreviation once, at first use, then use the short form.
+- Keep units, symbols, and notation identical across every section.
+- When drafting or polishing a later section, reference the ledger built from
+  the earlier sections instead of re-deciding term by term.
+- If the user later renames a term, change every occurrence in the manuscript,
+  not just the current passage, and update the ledger.
+
+## 4. Do not invent terms
+
+Do not coin new names for the author's methods, modules, or concepts. If a term
+is missing, undefined, or used inconsistently in ways you cannot resolve from
+the source, ask the user or flag it. Never fill the gap with a guessed name.

--- a/skills/nature-polishing/manifest.yaml
+++ b/skills/nature-polishing/manifest.yaml
@@ -9,6 +9,7 @@ always_load:
   - ../_shared/core/reader-workflow.md
   - ../_shared/core/paper-type-taxonomy.md
   - ../_shared/core/ethics.md
+  - ../_shared/core/terminology-ledger.md
   # Skill-local core
   - static/core/stance.md
   - static/core/failure-modes.md

--- a/skills/nature-polishing/static/core/failure-modes.md
+++ b/skills/nature-polishing/static/core/failure-modes.md
@@ -9,6 +9,7 @@ Before rewriting, identify the main problem:
 - missing boundary or limitation
 - Results and Discussion mixed together
 - weak title or abstract signal
+- inconsistent terminology, abbreviations, units, or notation across sections
 - sentence-level clutter only
 
 Prioritize fixes in this order:
@@ -16,3 +17,5 @@ Prioritize fixes in this order:
 `paper type -> section job -> paragraph logic -> claim/evidence/boundary -> sentence polish`
 
 Do not sentence-polish a draft whose section job is wrong. Surface the structural problem first, then polish.
+
+Terminology consistency is a cross-cutting check that runs at every level: build the Terminology Ledger on first contact (see `../../../_shared/core/terminology-ledger.md`) and enforce its canonical forms throughout the polish.

--- a/skills/nature-polishing/static/core/stance.md
+++ b/skills/nature-polishing/static/core/stance.md
@@ -6,6 +6,7 @@
 - Do not invent data, references, mechanisms, or novelty claims.
 - Do not let AI draft the paper's core scientific argument from scratch.
 - If the draft is Chinese or structurally rough, reconstruct the logic first and the prose second.
+- On first contact with the draft, build a Terminology Ledger and keep terms, abbreviations, units, and notation consistent across every section. Do not introduce synonyms to vary the prose. See `../../../_shared/core/terminology-ledger.md`.
 - Avoid em dashes in polished output by default. Prefer commas, parentheses, or full stops. Use colons sparingly unless the user explicitly asks to preserve dash-based punctuation or wants a colon-led style.
 
 ## Reader workflow

--- a/skills/nature-writing/manifest.yaml
+++ b/skills/nature-writing/manifest.yaml
@@ -9,6 +9,7 @@ always_load:
   - ../_shared/core/reader-workflow.md
   - ../_shared/core/paper-type-taxonomy.md
   - ../_shared/core/ethics.md
+  - ../_shared/core/terminology-ledger.md
   # Skill-local core
   - static/core/stance.md
   - static/core/workflow.md

--- a/skills/nature-writing/static/core/stance.md
+++ b/skills/nature-writing/static/core/stance.md
@@ -26,5 +26,6 @@ Identify before writing:
 - **evidence**: figures, measurements, comparisons, datasets, statistics, or examples
 - **boundary**: where the claim stops
 - **target journal or word limit** if provided
+- **terminology**: on first contact with the material, extract the recurring methods, models, datasets, metrics, abbreviations, and notation into a Terminology Ledger and reuse the canonical forms across every section (see `../../../_shared/core/terminology-ledger.md`)
 
 If any of `core claim`, `evidence`, or `boundary` is absent, expose the gap before drafting. You may still produce a scaffold with explicit placeholders.

--- a/skills/nature-writing/static/core/workflow.md
+++ b/skills/nature-writing/static/core/workflow.md
@@ -8,6 +8,10 @@ Run these eight steps for any drafting or restructuring task. Steps 1-3 are plan
 
 Force every section to serve this sentence. If the sentence cannot be written, the paper does not yet have an argument — surface that to the user.
 
+## 1b. Build the Terminology Ledger
+
+On first contact with the material, extract the recurring terms, abbreviations, notation, and proper names into a Terminology Ledger before drafting any prose. Lock the canonical forms and reuse them across every section. See `../../../_shared/core/terminology-ledger.md`.
+
 ## 2. Choose section architecture
 
 Pick the section structure from the relevant `section/*.md` fragment and, if needed, deeper patterns from `references/article-architecture.md`.


### PR DESCRIPTION
Add a shared Terminology Ledger mechanism so that, on first contact with a manuscript, recurring terms, abbreviations, units, and notation are extracted into a canonical ledger and reused consistently across every section.

Previously terminology consistency only appeared as scattered after-the-fact review checklist items ("is terminology stable?"), with no step that actually builds the term list first. You cannot check consistency against a standard that was never established.

- Add _shared/core/terminology-ledger.md: extract -> present -> lock -> enforce, plus a "do not invent terms" rule. Shared by both skills, no duplication.
- Register it in always_load of both manifests so it applies every invocation.
- Wire it into nature-writing intake (stance.md) and planning (workflow.md).
- Wire it into nature-polishing stance.md and failure-modes.md as a cross-cutting check.
- Update _shared/README.md index.