### PR TITLE
refactor(nature-reader): migrate to router/static-dynamic architecture

### DIFF
--- a/skills/_shared/README.md
+++ b/skills/_shared/README.md
@@ -16,6 +16,7 @@ always_load:
 | `core/reader-workflow.md` | nature-polishing, nature-writing |
 | `core/paper-type-taxonomy.md` | nature-polishing, nature-writing |
 | `core/ethics.md` | nature-polishing, nature-writing |
+| `core/terminology-ledger.md` | nature-polishing, nature-writing |
 | `journal-formats/nat-comms.md` | nature-polishing, nature-writing |
 
 ## When to add a file here

--- a/skills/_shared/core/terminology-ledger.md
+++ b/skills/_shared/core/terminology-ledger.md
@@ -1,0 +1,58 @@
+# Terminology Ledger
+
+A manuscript must use one name for one thing. The same method, model, dataset,
+gene, metric, or concept must not drift across shifting names, spellings, or
+capitalisation. Reviewers read inconsistent terminology as careless work, and a
+term that changes between sections forces the reader to re-learn it.
+
+Build the ledger **before** drafting or polishing prose, and treat it as the
+single source of truth for the rest of the job. Consistency against a standard
+is impossible if the standard was never written down.
+
+## 1. Build the ledger on first contact
+
+When you first receive a manuscript, draft, or set of notes, extract every
+recurring domain term into a ledger before editing any prose:
+
+- methods, models, systems, algorithms, modules, frameworks
+- datasets, benchmarks, cohorts, materials, reagents
+- genes, proteins, species, cell lines (respect established field nomenclature)
+- metrics, units, statistical symbols, mathematical notation
+- abbreviations and acronyms, each with its full form
+- key concepts the paper defines or repeatedly relies on
+
+For each term, record its canonical form, its first-use expansion (for
+abbreviations), and any variants already present in the source.
+
+## 2. Present the ledger to the user
+
+Show a compact table before or alongside the first output:
+
+| Canonical term | First-use definition | Variants seen in source | Decision |
+|---|---|---|---|
+| scRNA-seq | single-cell RNA sequencing (scRNA-seq) | "single cell RNA-seq", "scRNAseq" | spell out once, then use "scRNA-seq" |
+
+Flag every collision explicitly: the same concept under different names, or one
+name reused for two different concepts. Ask the user to confirm the canonical
+choice only when the decision is genuinely ambiguous or domain-sensitive.
+Otherwise adopt the form the source uses most often and state that choice.
+
+## 3. Lock and enforce
+
+Once set, the ledger is fixed for the whole job:
+
+- Use only canonical forms in every output. Do not introduce synonyms to vary
+  the prose. Terminology consistency outranks lexical variety in scientific
+  writing.
+- Define each abbreviation once, at first use, then use the short form.
+- Keep units, symbols, and notation identical across every section.
+- When drafting or polishing a later section, reference the ledger built from
+  the earlier sections instead of re-deciding term by term.
+- If the user later renames a term, change every occurrence in the manuscript,
+  not just the current passage, and update the ledger.
+
+## 4. Do not invent terms
+
+Do not coin new names for the author's methods, modules, or concepts. If a term
+is missing, undefined, or used inconsistently in ways you cannot resolve from
+the source, ask the user or flag it. Never fill the gap with a guessed name.

--- a/skills/nature-polishing/manifest.yaml
+++ b/skills/nature-polishing/manifest.yaml
@@ -9,6 +9,7 @@ always_load:
   - ../_shared/core/reader-workflow.md
   - ../_shared/core/paper-type-taxonomy.md
   - ../_shared/core/ethics.md
+  - ../_shared/core/terminology-ledger.md
   # Skill-local core
   - static/core/stance.md
   - static/core/failure-modes.md

--- a/skills/nature-polishing/static/core/failure-modes.md
+++ b/skills/nature-polishing/static/core/failure-modes.md
@@ -9,6 +9,7 @@ Before rewriting, identify the main problem:
 - missing boundary or limitation
 - Results and Discussion mixed together
 - weak title or abstract signal
+- inconsistent terminology, abbreviations, units, or notation across sections
 - sentence-level clutter only
 
 Prioritize fixes in this order:
@@ -16,3 +17,5 @@ Prioritize fixes in this order:
 `paper type -> section job -> paragraph logic -> claim/evidence/boundary -> sentence polish`
 
 Do not sentence-polish a draft whose section job is wrong. Surface the structural problem first, then polish.
+
+Terminology consistency is a cross-cutting check that runs at every level: build the Terminology Ledger on first contact (see `../../../_shared/core/terminology-ledger.md`) and enforce its canonical forms throughout the polish.

--- a/skills/nature-polishing/static/core/stance.md
+++ b/skills/nature-polishing/static/core/stance.md
@@ -6,6 +6,7 @@
 - Do not invent data, references, mechanisms, or novelty claims.
 - Do not let AI draft the paper's core scientific argument from scratch.
 - If the draft is Chinese or structurally rough, reconstruct the logic first and the prose second.
+- On first contact with the draft, build a Terminology Ledger and keep terms, abbreviations, units, and notation consistent across every section. Do not introduce synonyms to vary the prose. See `../../../_shared/core/terminology-ledger.md`.
 - Avoid em dashes in polished output by default. Prefer commas, parentheses, or full stops. Use colons sparingly unless the user explicitly asks to preserve dash-based punctuation or wants a colon-led style.
 
 ## Reader workflow

--- a/skills/nature-reader/SKILL.md
+++ b/skills/nature-reader/SKILL.md
@@ -1,254 +1,69 @@
 ---
 name: nature-reader
 description: Build full-paper Chinese-English side-by-side, figure/table-aware, source-grounded Markdown readers for journal or conference papers from PDF, DOI, arXiv, publisher HTML, or pasted text. Use whenever the user asks to translate or read a paper, make 中英文对照/原文对照/全文翻译解读, extract figures or tables into the right positions, preserve figure/table placement near relevant prose, or keep exact source anchors for every block. This skill must not degrade into a summary-only output unless the user explicitly asks for a summary.
+version: 2.0.0
+author: Community contribution, refactored into static/dynamic layers
 ---
 
-# Full-Paper Markdown Reader
+# Full-Paper Markdown Reader — Router
 
-Use this skill to turn a research paper into a complete Markdown reading artifact.
+This skill is split into two layers:
 
-The default output should read like a bilingual paper companion, not a summary dump:
+- A **static layer** under `static/` that holds versioned, reusable content fragments (core principles, the reading workflow, the output contract, and per-source-format extraction guidance).
+- A **dynamic layer** (this file plus `manifest.yaml`) that detects the request's source format and loads only the fragments needed for the current job.
 
-- keep the extractable prose, paragraph structure, and section flow
-- show original text and Chinese translation together at block level
-- extract figures and tables as assets and place them at the first substantive mention or interpretation point
-- keep captions attached to figures/tables with English caption text and Chinese caption translation
-- preserve stable page and block anchors for traceability
-- write a complete `paper.md` by default, plus `source_map.json`, `translation_notes.md`, and `assets/`
+Do not try to apply the reading logic from memory or from this router. Always load fragments from disk as described below.
 
-This skill is for papers, preprints, and conference proceedings across disciplines. It is not limited to Nature-family journals.
+## Routing protocol
 
-## When to use
+Follow these five steps every time the skill is invoked.
 
-Use this skill when the user wants any of the following:
+### 1. Load the manifest and the core layer
 
-- translate an entire paper into a complete Markdown document
-- make a paper easier to read without losing the original wording
-- generate a full-paper reading file with original/translation alignment
-- keep figures or tables visually close to the claims they support
-- preserve exact source locations for every substantive block
-- build a source-grounded markdown artifact rather than a slide deck or short summary
+Read [manifest.yaml](manifest.yaml). It declares the `source_format` axis, the allowed values, and the file paths each value maps to.
 
-If the user only wants a summary, use a summarization skill instead. If the user only wants citation search, use a citation skill instead.
+Also read every file listed under `always_load`. These hold the core principles, the reading workflow, and the output contract that apply to every reading job, plus the shared Terminology Ledger used to build the recurring-term table.
 
-## Non-negotiable defaults
+### 2. Detect the source format
 
-When the user asks for paper translation, reading, `nature-reader`, `中英文对照`, `原文对照`, `全文翻译`, or `翻译解读`, produce a paragraph-level bilingual reader by default.
+Decide the `source_format` value using the manifest's `detect:` hint and the user's input:
 
-Do not replace the reader with:
+- `pdf-text` — selectable-text PDF. Default.
+- `scanned-pdf` — image-only or OCR-required PDF.
+- `html` — publisher or preprint HTML page.
+- `doi-arxiv` — a bare DOI or arXiv link that must be resolved first.
+- `pasted-text` — pasted prose or notes with no retrievable original layout.
 
-- a Chinese-only summary
-- a paper review without original/translation alignment
-- figure captions without figure/table crops
-- a list of key points detached from source locations
-- only the abstract, introduction, or selected highlights
+State the detected value in one short line to the user before processing, so they can correct you cheaply. A source may map to more than one value (for example a DOI that resolves to a PDF); load the resolution fragment first, then the fragment for the resolved artifact.
 
-If constraints prevent full processing, still create a draft reader and clearly label missing pages, missing figures/tables, untranslated blocks, or low-confidence OCR/crops in `translation_notes.md`.
+### 3. Load the matching fragment(s)
 
-## Core principle
+Read the file mapped for the detected `source_format`. Do **not** read every fragment in `static/`. Load only what step 2 selected.
 
-Translate for meaning, not for style. Preserve the paper's structure, evidence, hedging, terminology, equations, units, and citation markers. Keep the output in prose paragraphs unless the source itself is tabular or list-like. Do not collapse the paper into keyword bullets or slide-style notes.
+### 4. Build the reader using the loaded material
 
-The reading file should help a reader move between:
+Apply the loaded fragments in this priority order:
 
-- original text
-- translated text
-- source location
-- figure or table evidence
+1. Core principles (`core/principles.md`) — bilingual reader by default, translate for meaning, never degrade to a summary, copyright caution.
+2. Source-format fragment — how to extract text, figures, and tables for this input.
+3. Reading workflow (`core/workflow.md`) — the six-step source-map-first process.
+4. Output contract (`core/output-contract.md`) — required files and the pre-response verification checklist.
 
-Each substantive source block should have a stable anchor and a visible bilingual pair:
+Build the Terminology Ledger as you translate (`../_shared/core/terminology-ledger.md`); it becomes the `paper.md` recurring-term table and the `source_map.json` glossary.
 
-```markdown
-<a id="S001"></a>
-**Source:** p.1 S001
+If constraints prevent full processing, still create a draft reader and label missing pages, figures, or low-confidence crops in `translation_notes.md`. Do not switch to summary mode.
 
-**Original:** [source paragraph]
+### 5. Reach for references only when needed
 
-**中文:** [faithful Chinese translation]
-```
+The files under `references/` are deep references, not defaults. Open them on demand per the `references.on_demand` table in the manifest:
 
-For copyrighted publisher PDFs, keep chat responses short and point to the local artifact. In local `paper.md`, include the bilingual reader only for the user-provided source file or clearly lawful open-access content; avoid reproducing large copyrighted text directly in chat.
+- detailed figure/table cropping and placement → `references/figure-extraction.md`.
+- exact field schema for `paper.md` / `source_map.json` → `references/output-spec.md`.
+- answering follow-up questions with source citations → `references/grounding-rules.md`.
 
-## Workflow
+## Why this split
 
-### 1. Identify the source and paper type
-
-Determine whether the source is:
-
-- selectable-text PDF
-- scanned PDF
-- publisher HTML
-- DOI or arXiv link
-- pasted text or notes
-
-Then identify the paper type at a high level:
-
-- discovery or mechanism paper
-- methods or algorithm paper
-- resource or dataset paper
-- conference paper
-- review or perspective
-
-This helps decide how tightly to couple text, figures, and captions.
-
-### 2. Build a full-document source map before translating
-
-If the user provides a full paper, process the entire document. Do not stop at the abstract, introduction, or a few representative pages unless the user explicitly asks for a preview.
-
-Create stable IDs for source blocks:
-
-- `S001`, `S002`, ... for body text
-- `C001`, `C002`, ... for captions
-- `F001`, `F002`, ... for figures
-- `T001`, `T002`, ... for tables
-
-For each block, capture:
-
-- page number
-- block type
-- original text
-- translation
-- reading-order index
-- nearby figure or table references
-- first substantive figure/table mention when applicable
-- confidence level when extraction is uncertain
-
-Keep the source map stable so later questions can point back to the same IDs.
-For long papers, add a page index so the reader can jump across the whole document without losing location.
-
-### 3. Translate conservatively
-
-Translate every extractable substantive block with these rules:
-
-- preserve technical terms unless a standard Chinese equivalent is clearly better
-- keep gene names, protein names, formulas, model names, and symbols intact
-- keep citations, superscripts, subscripts, and numeric values unchanged
-- do not collapse methods details into vague prose
-- keep paragraph order and section order unless the user asks for restructuring
-- mark uncertain text instead of guessing when OCR or layout extraction is weak
-- keep the source's paragraph form; do not convert dense prose into bullet-point keywords
-- do not silently skip Methods, limitations, data availability, code availability, competing interests, or extended captions
-- if the paper is too long for one pass, write `paper.md` incrementally by page/section and mark pending blocks rather than switching to summary mode
-
-If a sentence contains multiple claims, keep the translation readable but do not split away the original evidence chain.
-
-### 4. Extract and place figures and tables near the relevant discussion
-
-Do not try to recreate the PDF pixel-for-pixel. Preserve semantic proximity instead.
-
-Default placement rule:
-
-- crop each figure/table into `assets/` and show it near its first substantive mention in the body text
-- keep the caption attached to the figure/table
-- show both original caption and Chinese caption translation
-- if the caption contains critical details, keep caption and figure together
-- if a table is central to the claim, keep it near the paragraph that interprets it
-- if a figure/table appears before the body discussion in PDF layout, still place it where it best supports the reading flow and add `Placed near: p.X SYYY`
-- if a later section mentions the same figure/table again, link back to the already inserted figure/table block instead of duplicating it
-
-If the paper has a complex multi-column layout, prefer a clean reading layout over exact visual mimicry.
-
-### 4b. Crop figures and tables tightly
-
-When extracting a figure or table image:
-
-- crop only the figure or table content area, not the whole page
-- use the smallest rectangle that fully contains the visual object
-- exclude page headers, footers, surrounding prose, and unrelated margins
-- keep the caption separate unless the caption is part of the requested visual crop
-- if the crop box is uncertain, mark it as approximate instead of enlarging it
-
-Precision matters more than convenience here. A slightly smaller but correct crop is better than a wider crop that includes unrelated page content.
-
-Figure/table blocks in `paper.md` should use this shape:
-
-```markdown
-<a id="F001"></a>
-### Fig. 1. [short translated title]
-
-**Placed near:** p.3 S012
-**Source:** p.4 C001
-
-![Fig. 1](assets/fig1.png)
-
-**Original caption:** [caption text]
-
-**中文图注:** [caption translation]
-
-**Reading note:** [brief explanation of what to inspect in the figure]
-```
-
-### 5. Generate the Markdown file
-
-Default output is a single full-paper `paper.md` file.
-
-The Markdown must include:
-
-- metadata header
-- a short page/section index
-- page-level or section-level divisions for long papers
-- paragraph-level original/Chinese pairs for all extractable substantive text
-- figure and table blocks placed near the relevant discussion
-- source anchors on every substantive text, figure, caption, and table block
-- a terminology table for recurring technical terms
-- a short `阅读提示` / `critical reading notes` section only after the bilingual body, not as a replacement for it
-- short uncertainty notes only when extraction is weak
-
-Do not add an interactive Q&A panel or follow-up widget in the Markdown deliverable. If the user later asks a question, answer it in chat using the source map rather than embedding a conversational panel in the artifact.
-
-If a browser preview is explicitly requested, a companion `reader.html` can be generated as a secondary artifact, but the Markdown file remains the primary output.
-
-### 6. Answer follow-up questions with source grounding
-
-When the user asks a question after the file is created:
-
-- identify the most relevant source blocks first
-- answer from the paper, not from memory
-- cite the exact block IDs and page numbers
-- if the answer depends on a figure or table, cite that too
-- if the paper does not support the claim, say so plainly
-
-Every substantive answer should include a source pointer such as:
-
-- `p.4 S012-S013`
-- `Fig. 2 caption`
-- `Table 1`
-
-If the answer is a synthesis across several blocks, list all supporting locations.
-
-## Output contract
-
-Prefer these outputs:
-
-- `paper.md` for the full-paper Markdown artifact
-- `source_map.json` for stable source anchors
-- `translation_notes.md` for terminology, uncertainty, and layout notes
-- `assets/` for extracted figures or cropped snippets when needed
-- `reader.html` only when the user explicitly wants a browser preview
-
-Do not hide missing information. If the source is incomplete, label the output as draft mode.
-
-Before final response, verify:
-
-- `paper.md` contains `**Original:**` and `**中文:**` block pairs
-- every image/table link used in `paper.md` exists under `assets/`
-- every figure/table in `assets/` has a corresponding Markdown block and source pointer
-- `source_map.json` parses as JSON and includes source block IDs
-- `translation_notes.md` records skipped, uncertain, or draft-mode content
-
-## Tooling guidance
-
-If the input is a PDF, load the `pdf` skill first for extraction and OCR guidance.
-If the user asks for a richer browser view, use `web-artifacts-builder` or `frontend-design` only as a preview layer on top of the Markdown workflow.
-If the user wants citation-level grounding to original text, keep the source map explicit and do not lose the page or block IDs.
-
-## Quality bar
-
-Good output feels like a paper reader, not a machine translation dump.
-
-It should let a reader:
-
-- read the paper in two languages
-- see where a claim came from
-- inspect the nearby figure or table
-- move through a complete Markdown file without losing source traceability
+- The static layer is versioned and reviewable. Adding a new source format is one new fragment plus one manifest line.
+- The dynamic layer keeps each invocation cheap: only the fragment relevant to this input enters context.
+- The router itself is short on purpose. Update fragments, not this file, when adding scope.
+- This structure mirrors `nature-writing` and `nature-polishing` so shared content lives in `_shared/`.

--- a/skills/nature-reader/manifest.yaml
+++ b/skills/nature-reader/manifest.yaml
@@ -1,0 +1,43 @@
+name: nature-reader
+version: 2.0.0
+description: >
+  Declarative manifest for the static/dynamic split. SKILL.md uses this to
+  decide which fragments to load for a given paper-reading request. The main
+  axis is the source format, which changes how text, figures, and tables are
+  extracted before the bilingual reader is built.
+
+always_load:
+  # Shared layer — common to the nature-* skills
+  - ../_shared/core/terminology-ledger.md
+  # Skill-local core
+  - static/core/principles.md
+  - static/core/workflow.md
+  - static/core/output-contract.md
+
+axes:
+  source_format:
+    detect: |
+      Determine the input form the user provided. Use pdf-text for a
+      selectable-text PDF, scanned-pdf for an image-only or OCR-required PDF,
+      html for a publisher or preprint HTML page, doi-arxiv for a bare DOI or
+      arXiv identifier/link that must be resolved first, and pasted-text when
+      the user pastes prose or notes with no retrievable original layout.
+      If several apply (for example a DOI that resolves to a PDF), load the
+      resolution fragment first, then the fragment for the resolved artifact.
+    values:
+      pdf-text:     static/fragments/source/pdf-text.md
+      scanned-pdf:  static/fragments/source/scanned-pdf.md
+      html:         static/fragments/source/html.md
+      doi-arxiv:    static/fragments/source/doi-arxiv.md
+      pasted-text:  static/fragments/source/pasted-text.md
+    default: pdf-text
+    multi: true
+
+references:
+  on_demand:
+    - condition: cropping figures/tables, placement near first mention, tight-crop rules
+      path: references/figure-extraction.md
+    - condition: exact paper.md / source_map.json field schema and block shapes
+      path: references/output-spec.md
+    - condition: answering follow-up questions with source-grounded citations
+      path: references/grounding-rules.md

--- a/skills/nature-reader/references/figure-extraction.md
+++ b/skills/nature-reader/references/figure-extraction.md
@@ -1,0 +1,51 @@
+# Figure and table extraction
+
+Open this reference when extracting and placing figures or tables. It expands step 4 of the reading workflow.
+
+## Placement near the relevant discussion
+
+Do not try to recreate the PDF pixel-for-pixel. Preserve semantic proximity instead.
+
+Default placement rule:
+
+- crop each figure/table into `assets/` and show it near its first substantive mention in the body text
+- keep the caption attached to the figure/table
+- show both original caption and Chinese caption translation
+- if the caption contains critical details, keep caption and figure together
+- if a table is central to the claim, keep it near the paragraph that interprets it
+- if a figure/table appears before the body discussion in PDF layout, still place it where it best supports the reading flow and add `Placed near: p.X SYYY`
+- if a later section mentions the same figure/table again, link back to the already inserted figure/table block instead of duplicating it
+
+If the paper has a complex multi-column layout, prefer a clean reading layout over exact visual mimicry.
+
+## Crop figures and tables tightly
+
+When extracting a figure or table image:
+
+- crop only the figure or table content area, not the whole page
+- use the smallest rectangle that fully contains the visual object
+- exclude page headers, footers, surrounding prose, and unrelated margins
+- keep the caption separate unless the caption is part of the requested visual crop
+- if the crop box is uncertain, mark it as approximate instead of enlarging it
+
+Precision matters more than convenience here. A slightly smaller but correct crop is better than a wider crop that includes unrelated page content.
+
+## Figure/table block shape
+
+Figure/table blocks in `paper.md` should use this shape:
+
+```markdown
+<a id="F001"></a>
+### Fig. 1. [short translated title]
+
+**Placed near:** p.3 S012
+**Source:** p.4 C001
+
+![Fig. 1](assets/fig1.png)
+
+**Original caption:** [caption text]
+
+**中文图注:** [caption translation]
+
+**Reading note:** [brief explanation of what to inspect in the figure]
+```

--- a/skills/nature-reader/static/core/output-contract.md
+++ b/skills/nature-reader/static/core/output-contract.md
@@ -1,0 +1,27 @@
+# Output contract
+
+Prefer these outputs:
+
+- `paper.md` for the full-paper Markdown artifact
+- `source_map.json` for stable source anchors
+- `translation_notes.md` for terminology, uncertainty, and layout notes
+- `assets/` for extracted figures or cropped snippets when needed
+- `reader.html` only when the user explicitly wants a browser preview
+
+Do not hide missing information. If the source is incomplete, label the output as draft mode.
+
+## Pre-response verification
+
+Before final response, verify:
+
+- `paper.md` contains `**Original:**` and `**中文:**` block pairs
+- every image/table link used in `paper.md` exists under `assets/`
+- every figure/table in `assets/` has a corresponding Markdown block and source pointer
+- `source_map.json` parses as JSON and includes source block IDs
+- `translation_notes.md` records skipped, uncertain, or draft-mode content
+
+## Tooling guidance
+
+- If the input is a PDF, load the `pdf` skill first for extraction and OCR guidance.
+- If the user asks for a richer browser view, use `web-artifacts-builder` or `frontend-design` only as a preview layer on top of the Markdown workflow.
+- If the user wants citation-level grounding to original text, keep the source map explicit and do not lose the page or block IDs.

--- a/skills/nature-reader/static/core/principles.md
+++ b/skills/nature-reader/static/core/principles.md
@@ -1,0 +1,61 @@
+# Core principles (reader)
+
+Use this skill to turn a research paper into a complete Markdown reading artifact. The default output should read like a bilingual paper companion, not a summary dump:
+
+- keep the extractable prose, paragraph structure, and section flow
+- show original text and Chinese translation together at block level
+- extract figures and tables as assets and place them at the first substantive mention or interpretation point
+- keep captions attached to figures/tables with English caption text and Chinese caption translation
+- preserve stable page and block anchors for traceability
+- write a complete `paper.md` by default, plus `source_map.json`, `translation_notes.md`, and `assets/`
+
+This skill is for papers, preprints, and conference proceedings across disciplines. It is not limited to Nature-family journals. If the user only wants a summary, use a summarization skill instead. If the user only wants citation search, use a citation skill instead.
+
+## Non-negotiable defaults
+
+When the user asks for paper translation, reading, `nature-reader`, `中英文对照`, `原文对照`, `全文翻译`, or `翻译解读`, produce a paragraph-level bilingual reader by default.
+
+Do not replace the reader with:
+
+- a Chinese-only summary
+- a paper review without original/translation alignment
+- figure captions without figure/table crops
+- a list of key points detached from source locations
+- only the abstract, introduction, or selected highlights
+
+If constraints prevent full processing, still create a draft reader and clearly label missing pages, missing figures/tables, untranslated blocks, or low-confidence OCR/crops in `translation_notes.md`.
+
+## Core principle
+
+Translate for meaning, not for style. Preserve the paper's structure, evidence, hedging, terminology, equations, units, and citation markers. Keep the output in prose paragraphs unless the source itself is tabular or list-like. Do not collapse the paper into keyword bullets or slide-style notes.
+
+The reading file should help a reader move between:
+
+- original text
+- translated text
+- source location
+- figure or table evidence
+
+Each substantive source block should have a stable anchor and a visible bilingual pair:
+
+```markdown
+<a id="S001"></a>
+**Source:** p.1 S001
+
+**Original:** [source paragraph]
+
+**中文:** [faithful Chinese translation]
+```
+
+## Copyright caution
+
+For copyrighted publisher PDFs, keep chat responses short and point to the local artifact. In local `paper.md`, include the bilingual reader only for the user-provided source file or clearly lawful open-access content; avoid reproducing large copyrighted text directly in chat.
+
+## Quality bar
+
+Good output feels like a paper reader, not a machine translation dump. It should let a reader:
+
+- read the paper in two languages
+- see where a claim came from
+- inspect the nearby figure or table
+- move through a complete Markdown file without losing source traceability

--- a/skills/nature-reader/static/core/workflow.md
+++ b/skills/nature-reader/static/core/workflow.md
@@ -1,0 +1,68 @@
+# Reading workflow
+
+Run these six steps for any paper-reading job. Steps 1-2 build the source map, 3-5 produce the artifact, 6 covers follow-up questions.
+
+## 1. Identify the source and paper type
+
+The source-format fragment loaded for this job covers how to extract from the specific input. At a high level, also identify the paper type so you know how tightly to couple text, figures, and captions:
+
+- discovery or mechanism paper
+- methods or algorithm paper
+- resource or dataset paper
+- conference paper
+- review or perspective
+
+## 2. Build a full-document source map before translating
+
+If the user provides a full paper, process the entire document. Do not stop at the abstract, introduction, or a few representative pages unless the user explicitly asks for a preview.
+
+Create stable IDs for source blocks:
+
+- `S001`, `S002`, ... for body text
+- `C001`, `C002`, ... for captions
+- `F001`, `F002`, ... for figures
+- `T001`, `T002`, ... for tables
+
+For each block, capture: page number, block type, original text, translation, reading-order index, nearby figure or table references, first substantive figure/table mention when applicable, and confidence level when extraction is uncertain.
+
+Keep the source map stable so later questions can point back to the same IDs. For long papers, add a page index so the reader can jump across the whole document without losing location.
+
+## 3. Translate conservatively
+
+Translate every extractable substantive block with these rules:
+
+- preserve technical terms unless a standard Chinese equivalent is clearly better
+- keep gene names, protein names, formulas, model names, and symbols intact
+- keep citations, superscripts, subscripts, and numeric values unchanged
+- do not collapse methods details into vague prose
+- keep paragraph order and section order unless the user asks for restructuring
+- mark uncertain text instead of guessing when OCR or layout extraction is weak
+- keep the source's paragraph form; do not convert dense prose into bullet-point keywords
+- do not silently skip Methods, limitations, data availability, code availability, competing interests, or extended captions
+- if the paper is too long for one pass, write `paper.md` incrementally by page/section and mark pending blocks rather than switching to summary mode
+
+If a sentence contains multiple claims, keep the translation readable but do not split away the original evidence chain. Build the Terminology Ledger (`../../../_shared/core/terminology-ledger.md`) as you translate so recurring terms stay consistent across the whole document.
+
+## 4. Extract and place figures and tables near the relevant discussion
+
+Crop each figure/table into `assets/` and place it near its first substantive mention, keeping the caption attached with both original and Chinese caption text. For the full placement and tight-crop rules, and the figure/table block shape, open `references/figure-extraction.md`.
+
+## 5. Generate the Markdown file
+
+Default output is a single full-paper `paper.md` file. It must include:
+
+- metadata header
+- a short page/section index
+- page-level or section-level divisions for long papers
+- paragraph-level original/Chinese pairs for all extractable substantive text
+- figure and table blocks placed near the relevant discussion
+- source anchors on every substantive text, figure, caption, and table block
+- a terminology table for recurring technical terms (from the Terminology Ledger)
+- a short `阅读提示` / `critical reading notes` section only after the bilingual body, not as a replacement for it
+- short uncertainty notes only when extraction is weak
+
+Do not add an interactive Q&A panel or follow-up widget in the Markdown deliverable. If a browser preview is explicitly requested, a companion `reader.html` can be generated as a secondary artifact, but the Markdown file remains the primary output.
+
+## 6. Answer follow-up questions with source grounding
+
+When the user asks a question after the file is created, answer from the paper, not from memory, and cite exact block IDs and page numbers. For the full grounding rules, open `references/grounding-rules.md`.

--- a/skills/nature-reader/static/fragments/source/doi-arxiv.md
+++ b/skills/nature-reader/static/fragments/source/doi-arxiv.md
@@ -1,0 +1,12 @@
+# Source: DOI or arXiv identifier
+
+The user gave a bare DOI or arXiv id/link that must be resolved before reading.
+
+- Resolve the identifier to the actual article first:
+  - arXiv → the abstract page, then the PDF (and HTML/LaTeX source when available).
+  - DOI → the publisher landing page, then the open-access PDF or HTML if lawfully available.
+- After resolving, this becomes a `pdf-text`, `scanned-pdf`, or `html` job — load that fragment and follow it for extraction. This fragment only covers retrieval.
+- Capture bibliographic metadata (title, authors, venue, year, DOI/arXiv id) for the `paper.md` metadata header.
+- Prefer the open-access version (arXiv, author copy, PMC) when the version of record is paywalled. Note which version was read in `translation_notes.md`, since arXiv and published versions can differ.
+- If the identifier cannot be resolved or only the abstract is reachable, build a draft reader from what is available and clearly mark the rest as not retrieved. Do not fabricate body text.
+- Apply the copyright caution to the resolved artifact.

--- a/skills/nature-reader/static/fragments/source/html.md
+++ b/skills/nature-reader/static/fragments/source/html.md
@@ -1,0 +1,10 @@
+# Source: publisher or preprint HTML
+
+The source is an HTML page (publisher site, preprint server, or similar).
+
+- Extract the article body; strip site navigation, cookie banners, related-article rails, reference-manager widgets, and advertisements.
+- Keep the section structure and paragraph order from the article markup.
+- Figures and tables are usually separate image/HTML elements — capture each figure image and its caption, and place per `references/figure-extraction.md`. Reconstruct HTML tables faithfully rather than screenshotting them when the markup is clean.
+- Preserve inline math (MathML/LaTeX/images), superscript citation markers, and links to the reference list.
+- Respect the copyright caution: for paywalled or all-rights-reserved pages, keep chat output short and point to the local artifact. Reproduce full bilingual text only for clearly lawful open-access content.
+- If the page is JavaScript-rendered and content is missing, note what could not be retrieved instead of inventing it.

--- a/skills/nature-reader/static/fragments/source/pasted-text.md
+++ b/skills/nature-reader/static/fragments/source/pasted-text.md
@@ -1,0 +1,10 @@
+# Source: pasted text or notes
+
+The user pasted prose or notes directly, with no retrievable original layout or page images.
+
+- Treat the pasted text as the source of truth. Build the source map and bilingual pairs from it.
+- Page numbers may be unknown. Use sequential block IDs (`S001`, `S002`, ...) and, where the paste shows section headings, use section-level anchors instead of page anchors. Note in `translation_notes.md` that page anchors are unavailable.
+- There are usually no figure/table images. Do not invent crops. If the text references figures/tables, keep the references and captions as text blocks and note that the visual assets were not provided.
+- If the paste is clearly partial (for example abstract and intro only), build the reader for what was given and label it draft mode; do not backfill missing sections from memory.
+- Preserve any citation markers, equations, and symbols exactly as pasted.
+- Keep the bilingual reader format; do not collapse pasted prose into a summary just because layout metadata is missing.

--- a/skills/nature-reader/static/fragments/source/pdf-text.md
+++ b/skills/nature-reader/static/fragments/source/pdf-text.md
@@ -1,0 +1,10 @@
+# Source: selectable-text PDF
+
+The PDF has an extractable text layer. Load the `pdf` skill first for extraction guidance.
+
+- Extract the text layer directly; do not OCR text that is already selectable.
+- Process the whole document, not just the first pages. Build the source map (step 2) across every page.
+- Watch for multi-column layouts: recover natural reading order rather than top-to-bottom raw stream order.
+- Keep ligatures, hyphenated line breaks, superscripts, subscripts, and math intact; rejoin words split across line breaks.
+- Figures and tables are images embedded in the page — crop them per `references/figure-extraction.md`; do not paste the page text of a table where the table image belongs.
+- If some pages have a text layer and others are scanned, treat the scanned pages with the `scanned-pdf` rules and mark them with a confidence note.

--- a/skills/nature-reader/static/fragments/source/scanned-pdf.md
+++ b/skills/nature-reader/static/fragments/source/scanned-pdf.md
@@ -1,0 +1,10 @@
+# Source: scanned PDF (OCR required)
+
+The PDF is image-only or has an unreliable text layer. Load the `pdf` skill first for OCR guidance.
+
+- OCR every page; do not assume a usable text layer exists.
+- Record a confidence level for each block in the source map, and mark low-confidence blocks explicitly in `translation_notes.md` rather than guessing.
+- Preserve the original wording where OCR is confident; flag, do not silently "correct", garbled text.
+- Be careful with numerals, units, symbols, gene/protein names, and chemical formulas — OCR errors here change meaning. Cross-check against context and mark uncertainty.
+- Figures and tables are page regions: crop them per `references/figure-extraction.md`. For low-quality scans, a tight correct crop still beats a wide noisy one.
+- If pages are skewed, rotated, or partly cut off, note the affected pages and translate only what is legible.

--- a/skills/nature-writing/manifest.yaml
+++ b/skills/nature-writing/manifest.yaml
@@ -9,6 +9,7 @@ always_load:
   - ../_shared/core/reader-workflow.md
   - ../_shared/core/paper-type-taxonomy.md
   - ../_shared/core/ethics.md
+  - ../_shared/core/terminology-ledger.md
   # Skill-local core
   - static/core/stance.md
   - static/core/workflow.md

--- a/skills/nature-writing/static/core/stance.md
+++ b/skills/nature-writing/static/core/stance.md
@@ -26,5 +26,6 @@ Identify before writing:
 - **evidence**: figures, measurements, comparisons, datasets, statistics, or examples
 - **boundary**: where the claim stops
 - **target journal or word limit** if provided
+- **terminology**: on first contact with the material, extract the recurring methods, models, datasets, metrics, abbreviations, and notation into a Terminology Ledger and reuse the canonical forms across every section (see `../../../_shared/core/terminology-ledger.md`)
 
 If any of `core claim`, `evidence`, or `boundary` is absent, expose the gap before drafting. You may still produce a scaffold with explicit placeholders.

--- a/skills/nature-writing/static/core/workflow.md
+++ b/skills/nature-writing/static/core/workflow.md
@@ -8,6 +8,10 @@ Run these eight steps for any drafting or restructuring task. Steps 1-3 are plan
 
 Force every section to serve this sentence. If the sentence cannot be written, the paper does not yet have an argument — surface that to the user.
 
+## 1b. Build the Terminology Ledger
+
+On first contact with the material, extract the recurring terms, abbreviations, notation, and proper names into a Terminology Ledger before drafting any prose. Lock the canonical forms and reuse them across every section. See `../../../_shared/core/terminology-ledger.md`.
+
 ## 2. Choose section architecture
 
 Pick the section structure from the relevant `section/*.md` fragment and, if needed, deeper patterns from `references/article-architecture.md`.


### PR DESCRIPTION
Migrate `nature-reader` from a 254-line monolithic SKILL.md to the router + manifest + static-fragments + on-demand-references architecture used by nature-writing/nature-polishing.

- 69-line router SKILL.md; manifest with a real `source_format` axis (pdf-text / scanned-pdf / html / doi-arxiv / pasted-text).
- `static/core/` = principles, 6-step workflow, output contract; per-format extraction fragments; figure-crop rules to a reference.
- Wires in the shared Terminology Ledger (reader builds the glossary — a natural fit).
- Behaviour preserved (bilingual-by-default, never summary-only); existing evals map onto the axis.

⚠️ **Stacked on #43.** This branch contains the terminology-ledger commit too (it uses `_shared/core/terminology-ledger.md`). Please merge #43 first; this PR then narrows to just the reader changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)