### PR TITLE
refactor(nature-academic-search): migrate to router/static-dynamic ar…

### DIFF
--- a/skills/nature-academic-search/SKILL.md
+++ b/skills/nature-academic-search/SKILL.md
@@ -6,118 +6,65 @@ description: >-
   (BibTeX, related articles, ID conversion) via MCP tools (PubMed, CrossRef, arXiv).
   Use when the user needs coordinated multi-step literature workflows beyond a
   single MCP call.
+version: 2.0.0
+author: Community contribution, refactored into static/dynamic layers
 ---
 
-# Academic Search
+# Academic Search — Router
 
-Multi-source literature search, citation verification, citation format conversion,
-and reference management via MCP tools.
+This skill is split into two layers:
 
-## MCP Tools
+- A **static layer** under `static/` that holds versioned, reusable content fragments (the MCP tool inventory and shared modules, and source routing plus operational rules).
+- A **dynamic layer** (this file plus `manifest.yaml`) that detects which workflow the user needs and loads that workflow, reaching for shared modules and scripts only when a step needs them.
 
-### Core Search
+Do not try to apply the search logic from memory or from this router. Always load fragments from disk as described below.
 
-| Tool | Source | Best For |
-|------|--------|----------|
-| `pubmed_search_articles` | PubMed MCP | Biomedical, MeSH, clinical trials |
-| `search_crossref` | paper-search MCP | Cross-disciplinary, citation counts |
-| `search_arxiv` | paper-search MCP | Preprints (physics, math, CS, biology) |
+## Routing protocol
 
-### Extended Search
+Follow these five steps every time the skill is invoked.
 
-| Tool | Source | Best For |
-|------|--------|----------|
-| `search_google_scholar` | paper-search MCP | Broad academic search (scraped) |
-| `search_semantic_scholar` | paper-search MCP | Citation graph, field-of-study filters |
-| `search_biorxiv` | paper-search MCP | Biology preprints |
-| `search_medrxiv` | paper-search MCP | Medical preprints |
-| `search_webofscience` | paper-search MCP | Curated index, citation reports |
-| `search_scopus` | paper-search MCP | Broad scholarly database |
+### 1. Load the manifest and the core layer
 
-### PubMed Utilities
+Read [manifest.yaml](manifest.yaml). It declares the `workflow` axis, the allowed values, and the file paths each value maps to.
 
-| Tool | Purpose |
-|------|---------|
-| `pubmed_fetch_articles` | Full metadata by PMID |
-| `pubmed_find_related` | Related article discovery |
-| `pubmed_format_citations` | APA / MLA / BibTeX / RIS formatting |
-| `pubmed_convert_ids` | DOI ↔ PMID ↔ PMCID conversion |
-| `pubmed_lookup_mesh` | MeSH term exploration and hierarchy |
-| `pubmed_lookup_citation` | Bibliographic citation → PMID lookup |
+Also read every file listed under `always_load`:
 
-## Source Routing
+- `static/core/tools.md` — the MCP tool inventory (core search, extended search, PubMed utilities) and the shared-module map.
+- `static/core/routing-and-ops.md` — the T1→T2→T3 source routing quick guide, environment setup, error handling, and limitations.
 
-See [Source Tiers & Reliability](references/source-tiers.md) for the complete reliability classification and fallback routing rules. The T1→T2→T3 fallback chain is the standard execution order across all workflows.
+### 2. Detect the workflow
 
-Quick guide:
+Map the user's need to one or more `workflow` values:
 
-| User need | Primary (T1) | Secondary (T2) | Last Resort (T3) |
-|-----------|-------------|-----------------|-------------------|
-| Medical / clinical | PubMed | Semantic Scholar | Google Scholar |
-| Cross-disciplinary | CrossRef | Semantic Scholar | Scopus |
-| Preprints / CS / physics | arXiv | bioRxiv / medRxiv | — |
-| Exhaustive review | PubMed + CrossRef + arXiv | Semantic Scholar + bioRxiv/medRxiv | WoS / Scopus |
-| Citation count sensitive | Semantic Scholar | CrossRef | — |
-| Chinese literature | — | — | CNKI / 万方 (manual) |
+- `multi-source-search` — find literature across sources.
+- `citation-verification` — verify citations extracted from a document.
+- `mesh-strategy` — build a MeSH/PubMed search strategy.
+- `citation-file-mgmt` — convert/manage `.nbib`/`.ris`/`.bib` files.
+- `reference-mgmt` — BibTeX, related-article discovery, ID conversion.
 
-## Workflows
+A combined request (for example search then export) may need more than one. State the detected workflow(s) in one short line before proceeding.
 
-| # | Workflow | Reference |
-|---|----------|-----------|
-| 1 | Multi-Source Literature Search | [wf1](references/workflows/wf1-multi-source-search.md) |
-| 2 | Citation Verification | [wf2](references/workflows/wf2-citation-verification.md) |
-| 3 | MeSH Search Strategy | [wf3](references/workflows/wf3-mesh-strategy.md) |
-| 4 | Citation File Management | [wf4](references/workflows/wf4-citation-file-mgmt.md) |
-| 5 | Reference Management | [wf5](references/workflows/wf5-reference-mgmt.md) |
+### 3. Load the matching workflow fragment(s)
 
-## Shared Modules
+Read the file mapped for each detected workflow (under `references/workflows/`). Do **not** read every workflow. Each workflow file links to the shared modules it needs.
 
-| Module | Purpose |
-|--------|---------|
-| [Dedup Engine](references/dedup-engine.md) | Unified deduplication (WFs 1, 2, 5a) |
-| [Citation Parser](references/citation-parser.md) | Extract citations from documents (WF 2) |
-| [Search Strategy](references/search-strategy.md) | Query construction, source selection, ranking |
-| [RIS/BibTeX Format](references/ris-bibtex-format.md) | Format specifications and field mappings |
-| [Format Converter](scripts/format-converter.py) | Multi-source .nbib/.ris/.bib downloader |
+### 4. Run the workflow using the loaded material
 
-## Environment Setup
+Apply the loaded material in this order:
 
-### API Keys (optional but recommended)
+1. Core tools and routing (`core/tools.md`, `core/routing-and-ops.md`) — which MCP tool for which need, and the T1→T2→T3 fallback chain that is the standard execution order across all workflows.
+2. The workflow fragment — its specific steps.
+3. Shared modules and scripts on demand (dedup, citation parser, search strategy, RIS/BibTeX format, format converter).
 
-| Service | Env Var | Register At | Free Tier |
-|---------|---------|-------------|-----------|
-| Semantic Scholar | `SEMANTIC_SCHOLAR_API_KEY` | [api.semanticscholar.org](https://api.semanticscholar.org/) | 100 req/s with key (1/s without) |
-| NCBI E-utilities | `NCBI_API_KEY` | [ncbi.nlm.nih.gov/account](https://www.ncbi.nlm.nih.gov/account/) | 10 req/s with key (3/s without) |
+Report specific tool failures and continue with remaining tools; broaden terms when there are no results; fall back to manual generation from MCP-fetched metadata if a script fails twice.
 
-Set via `export` or `.env` file.
+### 5. Reach for references only when needed
 
-### Proxy (if behind firewall)
+The files under `references/` (and `scripts/`) are deep references, not defaults. Open them on demand per the `references.on_demand` table in the manifest — for example `references/source-tiers.md` for the full reliability classification, `references/dedup-engine.md` / `references/citation-parser.md` / `references/search-strategy.md` / `references/ris-bibtex-format.md` for the shared modules, and `scripts/format-converter.py` / `scripts/preflight.py` for the tooling.
 
-```bash
-export http_proxy=http://127.0.0.1:7890
-export https_proxy=http://127.0.0.1:7890
-```
+## Why this split
 
-### Pre-flight Check
-
-```bash
-python scripts/preflight.py
-```
-
-Run before batch operations to verify API endpoints are reachable.
-
-### Format Converter Dependencies
-
-The format converter (`scripts/format-converter.py`) uses Python stdlib only — no extra dependencies. Run `python scripts/format-converter.py --test` to verify the conversion pipeline.
-
-## Error Handling
-
-- **MCP tool unavailable**: report specific failure, continue with remaining tools.
-- **No results**: broaden terms, try alternative sources, suggest user refine query.
-- **Script failure (2x)**: fall back to manual generation from MCP-fetched metadata.
-
-## Limitations
-
-- Google Scholar and Semantic Scholar are scraped (not API-backed) — results may vary.
-- Chinese literature (CNKI / 万方) not indexed by CrossRef or PubMed.
-- Citation counts may be delayed (CrossRef updates monthly).
+- The static layer is versioned and reviewable; the workflow files and shared modules were already factored this way.
+- The dynamic layer keeps each invocation cheap: only the workflow the user needs enters context, instead of all five plus every module.
+- The router itself is short on purpose. Update fragments and references, not this file, when adding scope.
+- This structure mirrors the other nature-* skills (`nature-writing`, `nature-polishing`, `nature-reader`, `nature-paper2ppt`, `nature-figure`, `nature-citation`, `nature-response`, `nature-data`).

--- a/skills/nature-academic-search/manifest.yaml
+++ b/skills/nature-academic-search/manifest.yaml
@@ -1,0 +1,52 @@
+name: nature-academic-search
+version: 2.0.0
+description: >
+  Declarative manifest for the static/dynamic split. SKILL.md uses this to
+  decide which fragments to load for a literature-search request. The main axis
+  is the workflow: the user's need maps to one of five coordinated workflows,
+  each already a self-contained file.
+
+# Note on axis paths: the five workflow files live in references/workflows/ and
+# cross-reference the shared modules with ../ relative links. The workflow axis
+# therefore points at them in place rather than moving them into
+# static/fragments/, which would break those internal links. nature-academic-
+# search does not use the prose-oriented _shared layer.
+
+always_load:
+  - static/core/tools.md
+  - static/core/routing-and-ops.md
+
+axes:
+  workflow:
+    detect: |
+      Map the user's need to one workflow. Multiple may apply for a combined
+      request (for example search then export); load each that applies.
+        multi-source-search   — find literature across PubMed/CrossRef/arXiv and more
+        citation-verification — verify or check citations extracted from a document
+        mesh-strategy         — build a MeSH/PubMed search strategy
+        citation-file-mgmt    — convert/manage .nbib/.ris/.bib citation files
+        reference-mgmt        — BibTeX, related-article discovery, ID conversion
+    values:
+      multi-source-search:   references/workflows/wf1-multi-source-search.md
+      citation-verification: references/workflows/wf2-citation-verification.md
+      mesh-strategy:         references/workflows/wf3-mesh-strategy.md
+      citation-file-mgmt:    references/workflows/wf4-citation-file-mgmt.md
+      reference-mgmt:        references/workflows/wf5-reference-mgmt.md
+    multi: true
+
+references:
+  on_demand:
+    - condition: full source reliability tiers (T1/T2/T3) and fallback routing rules
+      path: references/source-tiers.md
+    - condition: deduplication across sources (used by WFs 1, 2, 5a)
+      path: references/dedup-engine.md
+    - condition: extracting citations from documents (WF 2)
+      path: references/citation-parser.md
+    - condition: query construction, source selection, and result ranking
+      path: references/search-strategy.md
+    - condition: RIS/BibTeX format specifications and field mappings
+      path: references/ris-bibtex-format.md
+    - condition: multi-source .nbib/.ris/.bib downloading and conversion
+      path: scripts/format-converter.py
+    - condition: pre-flight check that API endpoints are reachable before batch operations
+      path: scripts/preflight.py

--- a/skills/nature-academic-search/static/core/routing-and-ops.md
+++ b/skills/nature-academic-search/static/core/routing-and-ops.md
@@ -1,0 +1,58 @@
+# Source routing and operations
+
+## Source routing
+
+See [Source Tiers & Reliability](../../references/source-tiers.md) for the complete reliability classification and fallback routing rules. The T1→T2→T3 fallback chain is the standard execution order across all workflows.
+
+Quick guide:
+
+| User need | Primary (T1) | Secondary (T2) | Last Resort (T3) |
+|-----------|-------------|-----------------|-------------------|
+| Medical / clinical | PubMed | Semantic Scholar | Google Scholar |
+| Cross-disciplinary | CrossRef | Semantic Scholar | Scopus |
+| Preprints / CS / physics | arXiv | bioRxiv / medRxiv | — |
+| Exhaustive review | PubMed + CrossRef + arXiv | Semantic Scholar + bioRxiv/medRxiv | WoS / Scopus |
+| Citation count sensitive | Semantic Scholar | CrossRef | — |
+| Chinese literature | — | — | CNKI / 万方 (manual) |
+
+## Environment setup
+
+### API keys (optional but recommended)
+
+| Service | Env Var | Register At | Free Tier |
+|---------|---------|-------------|-----------|
+| Semantic Scholar | `SEMANTIC_SCHOLAR_API_KEY` | [api.semanticscholar.org](https://api.semanticscholar.org/) | 100 req/s with key (1/s without) |
+| NCBI E-utilities | `NCBI_API_KEY` | [ncbi.nlm.nih.gov/account](https://www.ncbi.nlm.nih.gov/account/) | 10 req/s with key (3/s without) |
+
+Set via `export` or `.env` file.
+
+### Proxy (if behind firewall)
+
+```bash
+export http_proxy=http://127.0.0.1:7890
+export https_proxy=http://127.0.0.1:7890
+```
+
+### Pre-flight check
+
+```bash
+python scripts/preflight.py
+```
+
+Run before batch operations to verify API endpoints are reachable.
+
+### Format converter dependencies
+
+The format converter (`scripts/format-converter.py`) uses Python stdlib only — no extra dependencies. Run `python scripts/format-converter.py --test` to verify the conversion pipeline.
+
+## Error handling
+
+- **MCP tool unavailable**: report specific failure, continue with remaining tools.
+- **No results**: broaden terms, try alternative sources, suggest user refine query.
+- **Script failure (2x)**: fall back to manual generation from MCP-fetched metadata.
+
+## Limitations
+
+- Google Scholar and Semantic Scholar are scraped (not API-backed) — results may vary.
+- Chinese literature (CNKI / 万方) not indexed by CrossRef or PubMed.
+- Citation counts may be delayed (CrossRef updates monthly).

--- a/skills/nature-academic-search/static/core/tools.md
+++ b/skills/nature-academic-search/static/core/tools.md
@@ -1,0 +1,45 @@
+# MCP tools and shared modules
+
+Multi-source literature search, citation verification, citation format conversion, and reference management via MCP tools.
+
+## MCP tools
+
+### Core search
+
+| Tool | Source | Best For |
+|------|--------|----------|
+| `pubmed_search_articles` | PubMed MCP | Biomedical, MeSH, clinical trials |
+| `search_crossref` | paper-search MCP | Cross-disciplinary, citation counts |
+| `search_arxiv` | paper-search MCP | Preprints (physics, math, CS, biology) |
+
+### Extended search
+
+| Tool | Source | Best For |
+|------|--------|----------|
+| `search_google_scholar` | paper-search MCP | Broad academic search (scraped) |
+| `search_semantic_scholar` | paper-search MCP | Citation graph, field-of-study filters |
+| `search_biorxiv` | paper-search MCP | Biology preprints |
+| `search_medrxiv` | paper-search MCP | Medical preprints |
+| `search_webofscience` | paper-search MCP | Curated index, citation reports |
+| `search_scopus` | paper-search MCP | Broad scholarly database |
+
+### PubMed utilities
+
+| Tool | Purpose |
+|------|---------|
+| `pubmed_fetch_articles` | Full metadata by PMID |
+| `pubmed_find_related` | Related article discovery |
+| `pubmed_format_citations` | APA / MLA / BibTeX / RIS formatting |
+| `pubmed_convert_ids` | DOI ↔ PMID ↔ PMCID conversion |
+| `pubmed_lookup_mesh` | MeSH term exploration and hierarchy |
+| `pubmed_lookup_citation` | Bibliographic citation → PMID lookup |
+
+## Shared modules
+
+| Module | Purpose |
+|--------|---------|
+| [Dedup Engine](../../references/dedup-engine.md) | Unified deduplication (WFs 1, 2, 5a) |
+| [Citation Parser](../../references/citation-parser.md) | Extract citations from documents (WF 2) |
+| [Search Strategy](../../references/search-strategy.md) | Query construction, source selection, ranking |
+| [RIS/BibTeX Format](../../references/ris-bibtex-format.md) | Format specifications and field mappings |
+| [Format Converter](../../scripts/format-converter.py) | Multi-source .nbib/.ris/.bib downloader |


### PR DESCRIPTION
…chitecture

Convert nature-academic-search to the router + manifest + static-fragments + on-demand-references architecture shared by the other nature-* skills. This skill was already the most router-like monolith (a short SKILL.md of tables plus on-demand workflow/module references), so the migration mostly formalizes that structure and makes its real workflow axis explicit.

Why
---
Unlike the other linear nature-* skills, academic-search has a genuine content axis: the user's need maps to one of five coordinated workflows (multi-source-search, citation-verification, mesh-strategy, citation-file-mgmt, reference-mgmt), and each is already a self-contained file under references/workflows/. Promoting that to a manifest axis lets a job load only the workflow it needs instead of all five plus every shared module.

Architecture
------------
- SKILL.md is now a 70-line router (was 123): load core, detect the workflow(s), load those workflow files, run them, reach for shared modules/scripts on demand.
- manifest.yaml declares always_load core, the workflow axis (5 values, multi: true so combined search-then-export requests can load more than one), and the shared modules + scripts as on_demand references.

Content mapping (nothing dropped, only redistributed) -----------------------------------------------------
- static/core/tools.md          <- the MCP Tools tables (Core Search, Extended
                                   Search, PubMed Utilities) and the Shared
                                   Modules map.
- static/core/routing-and-ops.md <- Source Routing (T1/T2/T3 quick guide),
                                   Environment Setup (API keys, proxy, pre-flight,
                                   converter deps), Error Handling, and
                                   Limitations.

Design decisions
----------------
- The workflow axis points at the five files in place under references/workflows/, rather than moving them into static/fragments/: the workflow files cross-reference the shared modules with ../ relative links, and moving them would break ~15 internal links for no benefit. Documented in the manifest.
- No _shared layer (academic-search drives MCP literature tools; it does not process manuscript prose).
- Left all workflow files, shared modules, scripts, the MCP server, and config unchanged.

Verification
------------
- manifest.yaml is valid YAML; all 14 declared paths (2 core + 5 workflows + 7 references/scripts) resolve on disk.
- The ../../ relative links from the new core fragments to the shared modules and scripts all resolve.
- Tool inventory, T1→T2→T3 routing, env setup, error handling, and limitations preserved across the new structure.