### PR TITLE
refactor(nature-citation): migrate to router/static-dynamic architecture

### DIFF
--- a/skills/nature-citation/README.md
+++ b/skills/nature-citation/README.md
@@ -26,11 +26,20 @@ This skill is bilingual-aware. It accepts Chinese manuscript text and citation r
 
 ## File structure
 
+The skill uses a router/static-dynamic split (like the other nature-* skills): a short `SKILL.md` router plus a `manifest.yaml`. nature-citation is a linear workflow with no content axis, so the split is core (always loaded) plus on-demand references.
+
 ```text
 nature-citation/
-├── SKILL.md
+├── SKILL.md                     # short router
+├── manifest.yaml                # always_load core + on-demand references (no axis)
 ├── README.md
-├── references/
+├── static/
+│   └── core/                    # always loaded
+│       ├── principles.md        # what it produces, journal scope, source hierarchy, search rules
+│       ├── chinese-mode.md      # Chinese-user operating mode
+│       └── workflow.md          # the 7-step workflow + report format
+├── references/                  # opened on demand
+│   ├── script-usage.md          # nature_citation.py flags + long-article batch strategy
 │   ├── journal-scope.md
 │   ├── ris-endnote.md
 │   └── search-strategy.md

--- a/skills/nature-citation/SKILL.md
+++ b/skills/nature-citation/SKILL.md
@@ -8,266 +8,59 @@ description: >-
   automatically get references, add citations to a paragraph/manuscript, find Nature-series or CNS
   support for statements, create text-to-reference correspondence, "分段引用", "自动给出引用",
   "Nature系列引用", "CNS及子刊", "支撑文献", "补引用", "找引用", or export EndNote/RIS/ENW/Zotero RDF.
+version: 2.0.0
+author: Yuan1z skill, refactored into static/dynamic layers
 ---
 
-# Nature Citation
+# Nature Citation — Router
 
-Use this skill to turn manuscript text into a defensible citation export:
+This skill is split into two layers:
 
-- segmented text with citation candidates for each segment
-- a reference-manager import file in `.enw`, `.ris`, or Zotero `.rdf`
-- conservative evidence notes explaining whether each candidate truly supports the segment
+- A **static layer** under `static/` that holds versioned, reusable content fragments (core principles and scope, the Chinese-user operating mode, and the citation workflow).
+- A **dynamic layer** (this file plus `manifest.yaml`) that loads the core every time and reaches for heavier material only when a step needs it.
 
-## Chinese-user operating mode
-
-When the user writes in Chinese, asks for "Nature系列", "CNS及其子刊", "支撑文献",
-"补引用", "自动给出引用", "分段引用", "导出EndNote", "RIS", "Zotero", "RDF", or provides Chinese manuscript text:
+Do not try to apply the citation logic from memory or from this router. Always load fragments from disk as described below.
 
-- Accept the text in Chinese, but search using English concept queries unless the topic is explicitly
-  China-specific or Chinese-language scholarship.
-- Return segment notes and evidence notes in Chinese by default.
-- Preserve the exact source segment and translate it into one or more English search claims.
-- Flag overclaiming clearly in Chinese: `强支撑`, `部分支撑`, `背景支撑`, `不建议引用为该句支撑`.
-- Do not present a paper as supporting the claim merely because its title is related.
+## Routing protocol
 
-## Default scope
+Follow these four steps every time the skill is invoked.
 
-Interpret journal scope from the user's wording, but keep the filter strict:
+### 1. Load the manifest and the core layer
 
-- `Nature系列`: search Nature Portfolio first. Include `Nature`, `Nature [field]`,
-  `Nature Communications`, `Communications [field]`, `Scientific Reports`, and `npj` journals.
-- `CNS`: search `Cell`, `Nature`, and `Science` plus their major sister journals.
-- `CNS及其子刊` or `CNS/sister journals`: search only accepted flagship and subjournal titles in
-  Nature Portfolio, the AAAS Science family, and Cell Press.
-- `只要Nature/Science/Cell正刊`: restrict to the flagship journals `Nature`, `Science`, and `Cell`.
+Read [manifest.yaml](manifest.yaml). Then read every file listed under `always_load`:
 
-Do not treat merely related journals as in-scope. A title is valid only if it is in the accepted
-publisher-family whitelist or clearly matches the official naming pattern for that family. If the
-user needs an exhaustive or submission-critical boundary, verify current official journal pages
-before finalizing because journal portfolios change.
-
-## Source hierarchy
-
-Use sources in this order:
-
-1. Structured bibliographic metadata: Crossref, PubMed/NCBI E-utilities, DOI metadata.
-2. Publisher pages: `nature.com`, `science.org`, `cell.com`, and official journal pages.
-3. Full text or abstract pages, if accessible.
-4. Secondary databases such as Google Scholar, Semantic Scholar, Web of Science, or Scopus only
-   as discovery aids, not as the sole support basis.
-
-Prefer structured APIs for metadata and publisher pages for claim verification. If metadata and
-publisher page disagree, preserve the DOI and journal-page facts and flag the discrepancy.
-
-## Long-article strategy
-
-When the input text is longer than roughly 3000 characters (about 10+ segments), the skill must
-switch to a batched workflow to avoid timeout, context overflow, or incomplete results:
-
-1. **Auto-detect length.** Count segments after segmentation. If there are more than 10 segments,
-   switch to batch mode automatically.
-2. **Split by section.** Prefer splitting at paragraph double-line breaks or explicit section
-   headings (`Introduction`, `Results`, etc.) so each batch is a coherent unit, not arbitrary
-   sentence groups.
-3. **Process each batch independently.** Run the Python script once per batch using
-   `--batch-size` or `--max-segments`, OR split the text externally and call the script once per
-   chunk. Each call writes its own intermediate export file.
-4. **Merge results at the end.** After all batches finish, combine the intermediate files into one
-   final export. Deduplicate by DOI.
-5. **Minimize inline analysis.** For long articles, do NOT write detailed support-grade notes for
-   every single segment inline. Instead:
-   - Write a compact summary table (segment ID → best candidate → support grade).
-   - Point the user to the HTML visualization for full browsing.
-   - Only elaborate on segments where no candidate was found or evidence is contradictory.
-
-### Quick guide for Claude
-
-| Segments | Strategy |
-|---|---|
-| 1–10 | Run once, full inline analysis is fine. |
-| 11–25 | Use `--batch-size 10`. Write a compact summary table. Point to HTML. |
-| 26+ | Split by section. Run script per section with `--batch-size 10`. Compact summary + HTML only. |
-
-## Workflow
-
-### 1. Segment the text
-
-For each input text:
+- `static/core/principles.md` — what the skill produces, the strict journal scope, the source hierarchy, and the search-quality rules.
+- `static/core/chinese-mode.md` — how to operate when the user writes in Chinese or asks for `Nature系列`/`CNS及子刊` style support.
+- `static/core/workflow.md` — the seven-step workflow and the final report format.
 
-- Split long text into citable segments. Prefer paragraph boundaries first, then sentence boundaries.
-- Keep each segment focused on one citable idea when possible.
-- Preserve original order and stable segment IDs such as `S001`, `S002`, `S003`.
-- Skip obvious non-citable connective sentences unless the user asks to cite every sentence.
-- For very long text, process in batches but keep a single final mapping table.
-- If the input has more than about 10 segments, prefer batch mode.
+### 2. No content axis — confirm scope and language inline
 
-Default segmentation rules:
+Unlike the other nature-* skills, nature-citation has no fragment axis. Its variation is runtime parameters, not different content bodies:
 
-- Use blank lines as paragraph boundaries.
-- If a paragraph is longer than about 700 characters or contains multiple claims, split into sentences.
-- Merge very short fragments into neighboring text unless they contain a distinct claim.
-- Keep section headings as labels, not as citable segments.
+- **journal scope** — `Nature系列` / `CNS` / `CNS及子刊` / flagship-only. Read it from the user's wording (see `core/principles.md`) and pass it to the script as `--scope`.
+- **user language** — if the user writes Chinese, follow `core/chinese-mode.md` (Chinese notes, English search queries).
+- **input length** — if there are more than ~10 segments, switch to the batched long-article strategy in `references/script-usage.md`.
 
-### 2. Parse each segment
+State the detected scope and date limits in one short line before searching.
 
-For each citable segment:
+### 3. Run the workflow
 
-- Extract the core claim in one sentence.
-- Identify claim type: `mechanism`, `association`, `method`, `clinical`, `epidemiology`,
-  `background`, `definition`, or `review-context`.
-- Identify entities, intervention/exposure, outcome, population/model, directionality, and boundary.
-- Convert the claim into 2-4 English search queries:
-  - one precise query with all key terms
-  - one synonym query
-  - one broader background query
-  - one methods or model query if relevant
+Follow the seven steps in `core/workflow.md`: segment, parse, search, evaluate support conservatively, export one reference-manager file, generate review artifacts when useful, and report with the HTML browser path first. Prefer `scripts/nature_citation.py` for the search/export when internet access is available; open `references/script-usage.md` for its full flag list and the long-article batch strategy.
 
-If the claim is too broad, split it into citable subclaims rather than searching the whole sentence.
+Never present a paper as support merely because its title is related, and never cite a metadata-only candidate without checking the abstract or publisher page. Do not invent missing bibliographic fields.
 
-### 3. Search candidate papers
+### 4. Reach for references only when needed
 
-Start with `scripts/nature_citation.py` when internet access is available:
+The files under `references/` are deep references, not defaults. Open them on demand per the `references.on_demand` table in the manifest:
 
-```bash
-python scripts/nature_citation.py \
-  --text "PASTE MANUSCRIPT TEXT HERE" \
-  --scope cns \
-  --outdir /tmp/nature-citation \
-  --format enw \
-  --with-artifacts
-```
+- running the script, full flags, long-article batching → `references/script-usage.md`.
+- turning a claim into search queries and support grades → `references/search-strategy.md`.
+- the exact Nature/CNS journal-family boundary → `references/journal-scope.md`.
+- RIS / EndNote / Zotero RDF export details → `references/ris-endnote.md`.
 
-Useful options:
+## Why this split
 
-- `--text-file manuscript.txt`: read long text from a file.
-- `--claim "CLAIM TEXT"` or `--claim-file claims.txt`: treat each claim as a segment.
-- `--doi 10.xxxx/xxxxx` or `--doi-file dois.txt`: export known DOI records after screening.
-- `--scope nature`: Nature Portfolio-style journals only.
-- `--scope flagship`: Nature, Science, and Cell only.
-- `--from-year 2018 --to-year 2026`: constrain publication dates.
-- `--rows 40`: raise for broad searches; keep top candidates manageable.
-- `--per-segment 3`: number of citation candidates to keep per segment.
-- `--batch-size 2`: process long text in smaller batches.
-- `--max-segments 12`: cap the number of segments processed in one run.
-- `--max-retries 2`: retry transient Crossref failures before skipping a query.
-- `--format enw|ris|zotero-rdf`: export format. If omitted and `--output-file` is set, infer from suffix.
-- `--mailto you@example.com`: use Crossref's polite pool.
-- `--batch-size 10`: process segments in batches of N. Each batch writes an incremental export file.
-- `--max-segments 20`: only process the first N segments. Useful for testing or section-by-section workflows.
-- `--sleep 0.3`: seconds between Crossref requests. Default is 0.3; raise to 1.0 if rate-limited.
-
-Long-article strategy:
-
-- 1-10 segments: run normally.
-- 11-25 segments: use batch mode and keep the HTML browser open for screening.
-- 26+ segments: split by section or subsection first, then run each part separately if needed.
-- For long texts, prefer the HTML browser for review and selection instead of relying only on inline notes.
-
-When the topic is biomedical or PubMed-indexed, also search PubMed with journal filters and
-compare results against Crossref. Use NCBI E-utilities rate limits and include `tool`/`email`
-parameters if running repeated searches.
-
-### 4. Evaluate whether each paper supports the segment
-
-Use a conservative support scale:
-
-- `strong support`: the paper directly tests the same relationship/mechanism/method and the result supports the segment.
-- `partial support`: the paper supports part of the segment, a related model, or a narrower condition.
-- `background support`: the paper supports field context, not the specific claim.
-- `contradictory/limiting`: the paper conflicts with or narrows the claim.
-- `metadata-only candidate`: title/metadata suggest relevance, but abstract/full text has not been checked.
-
-Never cite a `metadata-only candidate` as support without checking the abstract or publisher page.
-If a paper is a review, label it as review/context and avoid using it as primary evidence for an
-experimental claim when primary articles are available.
-
-### 5. Export reference-manager file
-
-Default behavior:
-
-- write one reference-manager file
-- support publication time filters with `--from-year` and `--to-year`
-- for long or ambiguous texts, use `--with-artifacts` so the HTML browser is available
-
-Default file:
-
-- `references.enw`: EndNote tagged export
-
-Optional:
-
-- `references.ris`: if the user requests RIS instead of ENW
-- `references.rdf`: if the user requests Zotero RDF
-- review artifacts only when explicitly requested
-
-If the user asks to choose the download format, treat `ENW`, `RIS`, and `Zotero RDF` as the
-supported options and return only one export file unless they explicitly ask for multiple formats.
-
-Do not invent missing fields. If DOI, pages, volume, or issue are missing, leave them absent rather
-than fabricating them.
-
-### 6. Optional review artifacts
-
-Generate review artifacts (HTML/TSV/JSON/report) for long or ambiguous runs. They are the primary
-way the user browses, filters, and selects candidates:
-
-- Use `--with-artifacts` when the text is long, the query is broad, or the user needs manual curation.
-- Report the HTML visualization path prominently in your final answer when artifacts are enabled.
-- Generate TSV/JSON/report alongside the HTML so the user has multiple views.
-
-### 7. Report results
-
-Unless the user asks for a different format, return:
-
-```text
-交互式引用浏览器
-- [absolute path to citation_visualization.html]  ← 在浏览器中打开此文件，可筛选/选择/下载引用
-
-检索范围
-- [Nature Portfolio / Science family / Cell Press / flagship only, plus date limits]
-
-分段引用对应关系
-S001: [source segment]
-  - [Author, year, title, journal, DOI]
-  - 支撑等级: [strong/partial/background/limiting/metadata-only]
-  - 插入建议: [e.g. after sentence / after clause]
-
-导出文件
-- [absolute path to references.enw / references.ris / references.rdf]
-
-风险和缺口
-- [missing full-text check, contradictory evidence, no direct CNS literature, etc.]
-```
-
-Put the HTML browser path FIRST in the report, above everything else, so the user can immediately
-open and browse candidates. If no suitable CNS/Nature-series paper exists, say so plainly and
-suggest the best nearby options from non-CNS literature only if the user wants broader coverage.
-
-If the text is long, mention the batch strategy used, especially when you limited the run with
-`--batch-size` or `--max-segments`.
-
-## Search quality rules
-
-- Prefer precision over volume. A useful answer is usually 3-8 candidates, not 50 loosely related papers.
-- Use exact phrase searches only for distinctive terms; otherwise use concept terms and synonyms.
-- Check journal identity. Many journals contain the word "nature" but are not Nature Portfolio journals.
-- Treat citation count as a tie-breaker, not evidence of support.
-- Capture retractions, corrections, and expressions of concern when visible in Crossref or publisher metadata.
-- Date-sensitive topics require current searching and explicit search date.
-- For medical, clinical, or safety claims, search current literature and state that citations do not replace
-  clinical guidance or systematic review.
-
-## Related files
-
-| File | Open when |
-|---|---|
-| [references/search-strategy.md](references/search-strategy.md) | You need help translating a manuscript claim into search queries and support grades |
-| [references/journal-scope.md](references/journal-scope.md) | You need the default Nature/CNS journal-family boundary and official source notes |
-| [references/ris-endnote.md](references/ris-endnote.md) | You need RIS, EndNote, or Zotero RDF export guidance |
-| [scripts/nature_citation.py](scripts/nature_citation.py) | You need to segment text, search Crossref, export ENW/RIS/RDF, and generate HTML |
-
-## Source notes
-
-This skill is based on public bibliographic APIs and official publisher/import documentation:
-Crossref REST API and filters, NCBI E-utilities, EndNote RIS import options, Nature Portfolio,
-AAAS Science journals, and Cell Press portfolio descriptions. Verify pages at use time when exact
-journal coverage or current import behavior matters.
+- The static layer is versioned and reviewable; the core stays small for a normal short run.
+- The dynamic layer keeps each invocation cheap: the script flag dump and long-article strategy load only when actually running a search.
+- The router itself is short on purpose. Update fragments and references, not this file, when adding scope.
+- This structure mirrors `nature-writing`, `nature-polishing`, `nature-reader`, `nature-paper2ppt`, and `nature-figure`.

--- a/skills/nature-citation/manifest.yaml
+++ b/skills/nature-citation/manifest.yaml
@@ -1,0 +1,33 @@
+name: nature-citation
+version: 2.0.0
+description: >
+  Declarative manifest for the static/dynamic split. SKILL.md uses this to
+  decide which fragments to load for a citation request.
+
+# Design note: nature-citation is a linear, parameterised workflow (segment ->
+# parse -> search -> evaluate -> export -> report). Its variation — journal
+# scope, user language, input length — is handled at runtime by inline rules and
+# by the nature_citation.py flags (--scope, --batch-size, ...), not by loading
+# different large content fragments. There is therefore no content axis; the
+# split is core (always loaded) plus on-demand references. Heavy, only-sometimes-
+# needed material (the script flag reference and long-article batching strategy)
+# lives in references so a normal short run stays cheap. nature-citation does not
+# use the prose-oriented _shared layer.
+
+always_load:
+  - static/core/principles.md
+  - static/core/chinese-mode.md
+  - static/core/workflow.md
+
+references:
+  on_demand:
+    - condition: running nature_citation.py — full flag list, long-article batch strategy, quick-guide tables
+      path: references/script-usage.md
+    - condition: translating a manuscript claim into search queries and support grades
+      path: references/search-strategy.md
+    - condition: the default Nature/CNS journal-family boundary and official source notes
+      path: references/journal-scope.md
+    - condition: RIS, EndNote, or Zotero RDF export guidance
+      path: references/ris-endnote.md
+    - condition: segment text, search Crossref, export ENW/RIS/RDF, and generate the HTML browser
+      path: scripts/nature_citation.py

--- a/skills/nature-citation/references/script-usage.md
+++ b/skills/nature-citation/references/script-usage.md
@@ -1,0 +1,56 @@
+# Script usage and long-article strategy
+
+Open this reference when running `scripts/nature_citation.py` or when the input is long enough to need batching. It expands step 3 of the workflow.
+
+## Running the script
+
+Start with `scripts/nature_citation.py` when internet access is available:
+
+```bash
+python scripts/nature_citation.py \
+  --text "PASTE MANUSCRIPT TEXT HERE" \
+  --scope cns \
+  --outdir /tmp/nature-citation \
+  --format enw \
+  --with-artifacts
+```
+
+### Useful options
+
+- `--text-file manuscript.txt`: read long text from a file.
+- `--claim "CLAIM TEXT"` or `--claim-file claims.txt`: treat each claim as a segment.
+- `--doi 10.xxxx/xxxxx` or `--doi-file dois.txt`: export known DOI records after screening.
+- `--scope nature`: Nature Portfolio-style journals only.
+- `--scope flagship`: Nature, Science, and Cell only.
+- `--from-year 2018 --to-year 2026`: constrain publication dates.
+- `--rows 40`: raise for broad searches; keep top candidates manageable.
+- `--per-segment 3`: number of citation candidates to keep per segment.
+- `--max-retries 2`: retry transient Crossref failures before skipping a query.
+- `--format enw|ris|zotero-rdf`: export format. If omitted and `--output-file` is set, infer from suffix.
+- `--mailto you@example.com`: use Crossref's polite pool.
+- `--batch-size 10`: process segments in batches of N. Each batch writes an incremental export file.
+- `--max-segments 20`: only process the first N segments. Useful for testing or section-by-section workflows.
+- `--sleep 0.3`: seconds between Crossref requests. Default is 0.3; raise to 1.0 if rate-limited.
+
+## Long-article strategy
+
+When the input text is longer than roughly 3000 characters (about 10+ segments), switch to a batched workflow to avoid timeout, context overflow, or incomplete results:
+
+1. **Auto-detect length.** Count segments after segmentation. If there are more than 10 segments, switch to batch mode automatically.
+2. **Split by section.** Prefer splitting at paragraph double-line breaks or explicit section headings (`Introduction`, `Results`, etc.) so each batch is a coherent unit, not arbitrary sentence groups.
+3. **Process each batch independently.** Run the script once per batch using `--batch-size` or `--max-segments`, OR split the text externally and call the script once per chunk. Each call writes its own intermediate export file.
+4. **Merge results at the end.** After all batches finish, combine the intermediate files into one final export. Deduplicate by DOI.
+5. **Minimize inline analysis.** For long articles, do NOT write detailed support-grade notes for every single segment inline. Instead:
+   - Write a compact summary table (segment ID → best candidate → support grade).
+   - Point the user to the HTML visualization for full browsing.
+   - Only elaborate on segments where no candidate was found or evidence is contradictory.
+
+### Quick guide
+
+| Segments | Strategy |
+|---|---|
+| 1–10 | Run once, full inline analysis is fine. |
+| 11–25 | Use `--batch-size 10`. Write a compact summary table. Point to HTML. |
+| 26+ | Split by section. Run script per section with `--batch-size 10`. Compact summary + HTML only. |
+
+For long texts, prefer the HTML browser for review and selection instead of relying only on inline notes.

--- a/skills/nature-citation/static/core/chinese-mode.md
+++ b/skills/nature-citation/static/core/chinese-mode.md
@@ -1,0 +1,9 @@
+# Chinese-user operating mode
+
+When the user writes in Chinese, asks for "Nature系列", "CNS及其子刊", "支撑文献", "补引用", "自动给出引用", "分段引用", "导出EndNote", "RIS", "Zotero", "RDF", or provides Chinese manuscript text:
+
+- Accept the text in Chinese, but search using English concept queries unless the topic is explicitly China-specific or Chinese-language scholarship.
+- Return segment notes and evidence notes in Chinese by default.
+- Preserve the exact source segment and translate it into one or more English search claims.
+- Flag overclaiming clearly in Chinese: `强支撑`, `部分支撑`, `背景支撑`, `不建议引用为该句支撑`.
+- Do not present a paper as supporting the claim merely because its title is related.

--- a/skills/nature-citation/static/core/principles.md
+++ b/skills/nature-citation/static/core/principles.md
@@ -1,0 +1,43 @@
+# Core principles (citation)
+
+Use this skill to turn manuscript text into a defensible citation export:
+
+- segmented text with citation candidates for each segment
+- a reference-manager import file in `.enw`, `.ris`, or Zotero `.rdf`
+- conservative evidence notes explaining whether each candidate truly supports the segment
+
+## Default scope
+
+Interpret journal scope from the user's wording, but keep the filter strict:
+
+- `Nature系列`: search Nature Portfolio first. Include `Nature`, `Nature [field]`, `Nature Communications`, `Communications [field]`, `Scientific Reports`, and `npj` journals.
+- `CNS`: search `Cell`, `Nature`, and `Science` plus their major sister journals.
+- `CNS及其子刊` or `CNS/sister journals`: search only accepted flagship and subjournal titles in Nature Portfolio, the AAAS Science family, and Cell Press.
+- `只要Nature/Science/Cell正刊`: restrict to the flagship journals `Nature`, `Science`, and `Cell`.
+
+Do not treat merely related journals as in-scope. A title is valid only if it is in the accepted publisher-family whitelist or clearly matches the official naming pattern for that family. If the user needs an exhaustive or submission-critical boundary, verify current official journal pages before finalizing because journal portfolios change. The exact boundary and official source notes are in `references/journal-scope.md`.
+
+## Source hierarchy
+
+Use sources in this order:
+
+1. Structured bibliographic metadata: Crossref, PubMed/NCBI E-utilities, DOI metadata.
+2. Publisher pages: `nature.com`, `science.org`, `cell.com`, and official journal pages.
+3. Full text or abstract pages, if accessible.
+4. Secondary databases such as Google Scholar, Semantic Scholar, Web of Science, or Scopus only as discovery aids, not as the sole support basis.
+
+Prefer structured APIs for metadata and publisher pages for claim verification. If metadata and publisher page disagree, preserve the DOI and journal-page facts and flag the discrepancy.
+
+## Search quality rules
+
+- Prefer precision over volume. A useful answer is usually 3-8 candidates, not 50 loosely related papers.
+- Use exact phrase searches only for distinctive terms; otherwise use concept terms and synonyms.
+- Check journal identity. Many journals contain the word "nature" but are not Nature Portfolio journals.
+- Treat citation count as a tie-breaker, not evidence of support.
+- Capture retractions, corrections, and expressions of concern when visible in Crossref or publisher metadata.
+- Date-sensitive topics require current searching and an explicit search date.
+- For medical, clinical, or safety claims, search current literature and state that citations do not replace clinical guidance or systematic review.
+
+## Source notes
+
+This skill is based on public bibliographic APIs and official publisher/import documentation: Crossref REST API and filters, NCBI E-utilities, EndNote RIS import options, Nature Portfolio, AAAS Science journals, and Cell Press portfolio descriptions. Verify pages at use time when exact journal coverage or current import behavior matters.

--- a/skills/nature-citation/static/core/workflow.md
+++ b/skills/nature-citation/static/core/workflow.md
@@ -1,0 +1,87 @@
+# Workflow
+
+Run these seven steps for any citation job. For runs with more than ~10 segments, switch to the batched long-article strategy in `references/script-usage.md`.
+
+## 1. Segment the text
+
+- Split long text into citable segments. Prefer paragraph boundaries first, then sentence boundaries.
+- Keep each segment focused on one citable idea when possible.
+- Preserve original order and stable segment IDs such as `S001`, `S002`, `S003`.
+- Skip obvious non-citable connective sentences unless the user asks to cite every sentence.
+- For very long text, process in batches but keep a single final mapping table.
+
+Default segmentation rules: use blank lines as paragraph boundaries; if a paragraph is longer than about 700 characters or contains multiple claims, split into sentences; merge very short fragments into neighboring text unless they contain a distinct claim; keep section headings as labels, not as citable segments. If the input has more than about 10 segments, prefer batch mode.
+
+## 2. Parse each segment
+
+For each citable segment:
+
+- Extract the core claim in one sentence.
+- Identify claim type: `mechanism`, `association`, `method`, `clinical`, `epidemiology`, `background`, `definition`, or `review-context`.
+- Identify entities, intervention/exposure, outcome, population/model, directionality, and boundary.
+- Convert the claim into 2-4 English search queries: one precise query with all key terms; one synonym query; one broader background query; one methods or model query if relevant.
+
+If the claim is too broad, split it into citable subclaims rather than searching the whole sentence. For deeper help turning a claim into queries and support grades, open `references/search-strategy.md`.
+
+## 3. Search candidate papers
+
+Prefer `scripts/nature_citation.py` when internet access is available. The full flag list, polite-pool/rate-limit options, and the long-article batch strategy are in `references/script-usage.md`. A minimal run:
+
+```bash
+python scripts/nature_citation.py \
+  --text "PASTE MANUSCRIPT TEXT HERE" \
+  --scope cns \
+  --outdir /tmp/nature-citation \
+  --format enw \
+  --with-artifacts
+```
+
+When the topic is biomedical or PubMed-indexed, also search PubMed with journal filters and compare results against Crossref. Use NCBI E-utilities rate limits and include `tool`/`email` parameters if running repeated searches.
+
+## 4. Evaluate whether each paper supports the segment
+
+Use a conservative support scale:
+
+- `strong support`: the paper directly tests the same relationship/mechanism/method and the result supports the segment.
+- `partial support`: the paper supports part of the segment, a related model, or a narrower condition.
+- `background support`: the paper supports field context, not the specific claim.
+- `contradictory/limiting`: the paper conflicts with or narrows the claim.
+- `metadata-only candidate`: title/metadata suggest relevance, but abstract/full text has not been checked.
+
+Never cite a `metadata-only candidate` as support without checking the abstract or publisher page. If a paper is a review, label it as review/context and avoid using it as primary evidence for an experimental claim when primary articles are available.
+
+## 5. Export reference-manager file
+
+Default behavior: write one reference-manager file; support publication time filters with `--from-year` and `--to-year`; for long or ambiguous texts, use `--with-artifacts` so the HTML browser is available.
+
+Default file is `references.enw` (EndNote tagged export). Optionally `references.ris` (if the user requests RIS) or `references.rdf` (Zotero RDF). If the user asks to choose the download format, treat `ENW`, `RIS`, and `Zotero RDF` as the supported options and return only one export file unless they explicitly ask for multiple. Do not invent missing fields: if DOI, pages, volume, or issue are missing, leave them absent. See `references/ris-endnote.md` for format details.
+
+## 6. Optional review artifacts
+
+Generate review artifacts (HTML/TSV/JSON/report) for long or ambiguous runs — they are the primary way the user browses, filters, and selects candidates. Use `--with-artifacts` when the text is long, the query is broad, or the user needs manual curation. Report the HTML visualization path prominently when artifacts are enabled, and generate TSV/JSON/report alongside the HTML.
+
+## 7. Report results
+
+Unless the user asks for a different format, return:
+
+```text
+交互式引用浏览器
+- [absolute path to citation_visualization.html]  ← 在浏览器中打开此文件，可筛选/选择/下载引用
+
+检索范围
+- [Nature Portfolio / Science family / Cell Press / flagship only, plus date limits]
+
+分段引用对应关系
+S001: [source segment]
+  - [Author, year, title, journal, DOI]
+  - 支撑等级: [strong/partial/background/limiting/metadata-only]
+  - 插入建议: [e.g. after sentence / after clause]
+
+导出文件
+- [absolute path to references.enw / references.ris / references.rdf]
+
+风险和缺口
+- [missing full-text check, contradictory evidence, no direct CNS literature, etc.]
+```
+
+Put the HTML browser path FIRST, above everything else, so the user can immediately open and browse candidates. If no suitable CNS/Nature-series paper exists, say so plainly and suggest the best nearby options from non-CNS literature only if the user wants broader coverage. If the text is long, mention the batch strategy used, especially when you limited the run with `--batch-size` or `--max-segments`.


### PR DESCRIPTION
Convert nature-citation from a 273-line monolithic SKILL.md to the router + manifest + static-fragments + on-demand-references architecture shared by the other nature-* skills, for structural consistency and cheaper per-invocation context.

Why
---
nature-citation is a linear, parameterised workflow: segment -> parse -> search -> evaluate -> export -> report. Unlike nature-writing (section axis) or nature-figure (backend gate), its variation is runtime parameters — journal scope, user language, input length — handled by inline rules and the nature_citation.py flags (--scope, --batch-size, ...), not by loading different large content bodies. So this migration deliberately introduces NO content axis; the split is core (always loaded) plus on-demand references. The heaviest, only-sometimes-needed material (the full script flag list and the long-article batch strategy) moves to a reference so a normal short run stays cheap.

Architecture
------------
- SKILL.md is now a 66-line router (was 273): load core, confirm scope/language inline, run the 7-step workflow, reach for references on demand. The router explicitly documents that this skill has no axis and why.
- manifest.yaml declares always_load core and references.on_demand, with a design note explaining the no-axis decision. No _shared layer (citation searches literature; it does not process manuscript prose).

Content mapping (nothing dropped, only redistributed) -----------------------------------------------------
- static/core/principles.md   <- overview of the deliverable, Default Scope
                                 (Nature系列/CNS/CNS及子刊/flagship), Source
                                 Hierarchy, Search Quality Rules, Source Notes.
- static/core/chinese-mode.md <- the Chinese-user operating mode (Chinese notes,
                                 English search queries, Chinese support grades).
- static/core/workflow.md     <- the 7 steps (segment, parse, search, evaluate,
                                 export, artifacts, report) and the final report
                                 template; the script flag dump and long-article
                                 detail are delegated to references.
- references/script-usage.md  <- NEW: the nature_citation.py invocation, the full
                                 --flag list, and the Long-article strategy plus
                                 the segment-count quick-guide table (extracted
                                 from the monolith's batching sections).

Unchanged: references/search-strategy.md, references/journal-scope.md, references/ris-endnote.md, scripts/nature_citation.py, evals/evals.json. Updated README.md "File structure" to document the new layout.

Verification
------------
- manifest.yaml is valid YAML; all 8 declared paths (3 core + 4 references + the script) resolve on disk.
- Spot-checked that the conservative support scale, metadata-only rule, Chinese support grades (强支撑/部分支撑/...), --batch-size long-article strategy, the 交互式引用浏览器-first report format, and the Crossref/PubMed source hierarchy all survive in the new structure.