### PR TITLE
feat(nature-writing): Add Nature summary paragraph guidance to nature-writing skill

### DIFF
--- a/skills/nature-writing/README.md
+++ b/skills/nature-writing/README.md
@@ -45,6 +45,7 @@ nature-writing/
     ├── experiments.md
     ├── introduction.md
     ├── method.md
+    ├── nature-summary-paragraph.md
     ├── paper-review.md
     ├── paragraph-flow.md
     ├── related-work.md
@@ -57,7 +58,7 @@ nature-writing/
 |---|---|
 | Evidence first | Do not invent data, mechanisms, statistics, sample sizes or novelty |
 | Abstract | Context, gap, approach, key result, implication, boundary |
-| Introduction | Field scale, bottleneck, prior attempts, unresolved gap, present study |
+| Introduction | Field scale, bottleneck, prior attempts, unresolved gap, present study; for `Nature`, use a staged summary-paragraph funnel |
 | Method | Explain module motivation, design, forward process, and technical advantage |
 | Results | Build an evidence ladder, not a chronological lab diary |
 | Experiments | Tie every major claim to comparison, ablation, metric, or stress-test evidence |

--- a/skills/nature-writing/SKILL.md
+++ b/skills/nature-writing/SKILL.md
@@ -61,6 +61,7 @@ The files under `references/` are deep references and the example library, not d
 
 - The user asks for a concrete example or template → `references/examples/index.md`.
 - A section's draft has structural problems that the section fragment alone does not explain → the matching `references/<section>.md`.
+- The user needs a broad-audience `Nature` abstract opening or asks about a `summary paragraph` → `references/nature-summary-paragraph.md`.
 - The user asks "does this paragraph flow?" → `references/paragraph-flow.md`.
 - The user asks for a self-review or rejection-risk audit → `references/paper-review.md`.
 

--- a/skills/nature-writing/manifest.yaml
+++ b/skills/nature-writing/manifest.yaml
@@ -76,6 +76,8 @@ references:
       path: references/article-architecture.md
     - condition: drafting/revising abstract; especially challenge-contribution forms
       path: references/abstract.md
+    - condition: drafting/revising a Nature-family broad-audience summary paragraph or introduction opening
+      path: references/nature-summary-paragraph.md
     - condition: drafting/revising introduction, task framing, technical challenge, contribution framing
       path: references/introduction.md
     - condition: rebuilding related work as topic synthesis

--- a/skills/nature-writing/references/nature-summary-paragraph.md
+++ b/skills/nature-writing/references/nature-summary-paragraph.md
@@ -1,0 +1,252 @@
+# Nature Summary Paragraph Guide
+
+## What this reference is for
+
+This file distills the widely circulated annotated `Nature` example on how to construct a summary paragraph for a broad-audience paper. In `Nature`-style journals, this "summary paragraph" usually refers to the abstract-like opening summary that must let a non-specialist reader understand:
+
+1. the field context,
+2. the specific problem,
+3. what this study shows,
+4. why the result matters now,
+5. and how far the claim should be generalized.
+
+Use this reference when:
+
+1. the target journal is `Nature` or a close Nature-family venue,
+2. the user is drafting or rebuilding an abstract / summary paragraph,
+3. the user asks for a broad-audience opening paragraph,
+4. the draft has results but lacks cross-disciplinary readability.
+
+## Core principle
+
+A strong `Nature` summary paragraph is not just a compressed abstract. It is a tightly staged reader funnel:
+
+1. start broad enough for scientists outside the subfield,
+2. narrow to the exact unresolved problem,
+3. state the main finding early and explicitly,
+4. spend several sentences interpreting what the result changes,
+5. end by widening back out to the broader scientific or practical context.
+
+In short:
+
+`broad field -> sharper background -> exact problem -> here we show -> what the result changes -> broader context / outlook`
+
+## Canonical sentence-level structure
+
+The annotated example in the image implies the following sentence jobs.
+
+### 1. Broad field introduction (1-2 sentences)
+
+Goal:
+
+1. orient any scientist, not just an expert,
+2. establish why the field/problem area matters,
+3. avoid dense terminology too early.
+
+Rule:
+
+1. If a reader from another discipline cannot follow the first 1-2 sentences, the paragraph is too specialized too early.
+
+### 2. More detailed background (2-3 sentences)
+
+Goal:
+
+1. move from field-scale context to the specific system/process/problem,
+2. introduce the minimum specialist concepts needed to understand the study,
+3. prepare the unresolved issue naturally.
+
+Rule:
+
+1. This layer may use subfield terminology, but each term must feel motivated by the sentence before it.
+2. Do not dump mechanism details here; only include what the reader needs to understand the problem.
+
+### 3. General problem statement (1 sentence)
+
+Goal:
+
+1. name the exact unresolved problem addressed by this study,
+2. create the hinge between background and contribution.
+
+Rule:
+
+1. This sentence should be unmistakable.
+2. It usually has the form `However, ... remains unknown`, `Yet whether ... is unclear`, or an equivalent unresolved-gap statement.
+
+### 4. Main result sentence (1 sentence)
+
+Goal:
+
+1. state the paper's central finding clearly,
+2. make the reader feel the paper has now "arrived".
+
+Rule:
+
+1. Use `Here we show`, `Here we demonstrate`, or a discipline-appropriate equivalent when the evidence is strong enough.
+2. This sentence should express the main claim, not the whole method pipeline.
+
+### 5. Direct implications of the result (2-3 sentences)
+
+Goal:
+
+1. explain what the main result reveals,
+2. compare it with what was previously believed or assumed,
+3. show how the result adds to prior knowledge.
+
+Rule:
+
+1. This is usually the intellectual center of the paragraph.
+2. Do not merely list more results; interpret the main result.
+3. If there are multiple supporting findings, arrange them so each one strengthens the same message.
+
+### 6. More general context (1-2 sentences)
+
+Goal:
+
+1. place the result back into a broader biological, physical, methodological, or translational context,
+2. show why the result matters beyond the immediate experiment.
+
+Rule:
+
+1. This expansion must still be anchored in what the study actually supports.
+2. Avoid hype that leaps beyond the evidence.
+
+### 7. Optional broader perspective (2-3 sentences)
+
+Goal:
+
+1. provide a final wider perspective for a non-specialist reader,
+2. connect the work to future models, applications, or downstream relevance.
+
+Rule:
+
+1. This section is optional and depends on editor tolerance for length and on whether accessibility truly improves.
+2. The example notes that under these conditions the paragraph may extend toward ~300 words.
+3. If included, the final perspective should feel earned by the prior evidence, not appended as a generic impact slogan.
+
+## Word-count and compression principle
+
+The image example implies a practical compression rule:
+
+1. the paragraph can be around ~190 words without the final broader-perspective section,
+2. and around ~250 words with that section,
+3. while still preserving the staged logic above.
+
+This means compression should happen by:
+
+1. removing repeated background,
+2. collapsing redundant result statements,
+3. keeping only the one or two most decision-relevant implications,
+
+not by deleting the problem sentence or the `here we show` hinge.
+
+## How to read the annotated example in the image
+
+The example paragraph progresses in a very deliberate order.
+
+### Segment A — broad introduction
+
+1. `During cell division, mitotic spindles are assembled by microtubule-based motor proteins.`
+2. `The bipolar organization of spindles is essential for proper segregation of chromosomes ...`
+
+What these lines do:
+
+1. They establish a broad cell-biology setting understandable to many scientists.
+2. They explain why the system matters before discussing the specific protein family.
+
+### Segment B — more detailed background
+
+1. The paragraph then introduces plus-end-directed homotetrameric motor proteins of the kinesin-5 (`BimC`) family.
+2. It also names an existing conceptual model, the `push-pull mitotic muscle` model, in which kinesin-5 and opposing motors act between overlapping microtubules.
+
+What these lines do:
+
+1. They narrow from general spindle function to the specific mechanistic actors.
+2. They provide enough conceptual scaffolding for the reader to understand the unresolved issue.
+
+### Segment C — exact unresolved problem
+
+1. `However, the precise roles of kinesin-5 during this process are unknown.`
+
+What this line does:
+
+1. It is the hinge sentence.
+2. It states the exact knowledge gap in one unmistakable move.
+
+### Segment D — main finding
+
+1. `Here we show that the vertebrate kinesin-5 Eg5 drives the sliding of microtubules depending on their relative orientation.`
+
+What this line does:
+
+1. It states the central claim directly.
+2. It uses the canonical `Here we show` signal to mark the paper's main advance.
+
+### Segment E — direct implications and supporting findings
+
+1. The following sentences explain that, in controlled `in vitro` assays, `Eg5` can move simultaneously toward the plus ends of both microtubules it crosslinks.
+2. They then infer that anti-parallel microtubules undergo relative sliding at rates comparable to spindle pole separation `in vivo`.
+3. They add that `Eg5` can tether microtubule plus-ends, suggesting an additional microtubule-binding mode.
+4. The authors then synthesize these findings into a mechanistic interpretation of how kinesin-5 family members may function in mitosis.
+
+What these lines do:
+
+1. They do not merely pile up facts.
+2. They show what the main result reveals about spindle organization and motor function.
+3. They connect observations to a revised mechanistic understanding.
+
+### Segment F — broader context and outlook
+
+1. The paragraph then says the assay may serve as a starting point for more sophisticated `in vitro` spindle models.
+2. It gives an example: testing the individual and combined action of multiple mitotic motors.
+3. It closes by linking `Eg5` inhibition to anti-cancer drug development and arguing that a quantitative assay for motor function is relevant to that development.
+
+What these lines do:
+
+1. They widen from the specific finding to broader methodological and translational significance.
+2. They remain concrete, rather than ending with vague claims about importance.
+
+## Practical writing rules for this skill
+
+When drafting a `Nature` summary paragraph:
+
+1. make the first two sentences survivable for a cross-disciplinary scientist,
+2. reserve the exact unresolved problem for one explicit hinge sentence,
+3. ensure the main result arrives no later than the middle of the paragraph,
+4. spend more space interpreting the result than naming method details,
+5. end with bounded significance, not slogan-like impact,
+6. if quantitative support exists, attach it to the strongest result sentence cluster,
+7. if the draft begins with `Here we show ...`, verify that enough field context appears before it.
+
+## Frequent failure modes
+
+### Failure mode 1 — opening too narrow
+
+1. Starts with gene/protein/material/model names before any field context.
+2. Non-specialists cannot tell why the study matters.
+
+### Failure mode 2 — no clear gap sentence
+
+1. Background slides directly into contribution.
+2. Readers cannot identify the exact unresolved problem.
+
+### Failure mode 3 — `Here we show` comes too early or too late
+
+1. Too early: the reader lacks enough setup.
+2. Too late: the paragraph feels like an introduction review rather than a summary paragraph.
+
+### Failure mode 4 — result listing without interpretation
+
+1. Several findings are listed sequentially.
+2. The paragraph never explains what they collectively change.
+
+### Failure mode 5 — overextended final significance
+
+1. The ending jumps to societal or clinical importance unsupported by the evidence.
+2. The paragraph sounds inflated rather than authoritative.
+
+## Relationship to other references in this skill
+
+1. Use this file together with `references/abstract.md` when the user is drafting an abstract for a broad-audience Nature-family venue.
+2. Use `static/fragments/journal/nature.md` for journal-level constraints such as audience and claim calibration.
+3. Use `static/fragments/section/abstract.md` for the compact default abstract movement.
+4. Use this file when the user specifically needs the stronger `Nature summary paragraph` logic rather than a generic abstract template.

--- a/skills/nature-writing/static/fragments/journal/nature.md
+++ b/skills/nature-writing/static/fragments/journal/nature.md
@@ -7,6 +7,7 @@ Broad, multi-disciplinary. A reader outside the immediate subfield must be able 
 ## Drafting priorities
 
 - The opening sentence of the abstract and the introduction must signal significance for a non-specialist audience without overclaiming.
+- For a `Nature` summary paragraph, use a staged funnel: `broad field -> sharper background -> exact problem -> here we show -> what the result changes -> broader context / outlook`.
 - Avoid jargon that does not appear in a typical Nature News piece. Define or replace.
 - Word count is unforgiving. Prefer cuts to compressions when a section runs long.
 - No em dashes in body prose.
@@ -16,6 +17,7 @@ Broad, multi-disciplinary. A reader outside the immediate subfield must be able 
 ## Section format notes
 
 - Abstract is usually unstructured prose (no headed subsections) for many Nature titles. Check the specific journal guideline if named.
+- When the abstract is effectively a `Nature` summary paragraph, make sure the gap sentence and the `Here we show` sentence are both explicit and separated in function.
 - Methods often goes to the end and can be longer than in subfield journals; the main text is significance-driven.
 - References are typically capped (~50 for Articles). Plan citation budget early.
 

--- a/skills/nature-writing/static/fragments/section/intro.md
+++ b/skills/nature-writing/static/fragments/section/intro.md
@@ -4,6 +4,10 @@
 
 `field scale -> bottleneck -> prior attempts -> unresolved gap -> present study`
 
+For a broad-audience `Nature` summary paragraph, strengthen this into (See `references/nature-summary-paragraph.md`.):
+
+`broad field -> sharper background -> exact problem -> here we show -> what the result changes -> broader context / outlook`
+
 ## Paragraph jobs (typical 4-paragraph intro)
 
 1. Establish the field stake. Make it land for a non-specialist if the target is broad (Nature, Science).


### PR DESCRIPTION
## Summary

- add a `nature-summary-paragraph.md` reference (based on https://www-nature-com/documents/nature-summary-paragraph.pdf) under `references/`
- hook it into `nature-writing` with explicit routing and section/journal guidance
- provide the introduction instructions with reference to this file.

## Context

This change mainly comes from reading Nature's annotated summary paragraph reference.

I pulled the core writing principles from that document into a reusable markdown reference, then wired it into the parts of `nature-writing` where that guidance should actually matter.

## Changes

- add `skills/nature-writing/references/nature-summary-paragraph.md`
  - summarize the core structure and sentence roles from the annotated example
  - explain the example paragraph directly
  - capture practical drafting rules and common failure modes
- add explicit trigger points in `manifest.yaml` and `SKILL.md`
- update intro.md and Nature-specific guidance to reference this pattern


## Why this seems useful

More directly reflects and matches the writing approach recommended by official documents^^