### PR TITLE
feat(nature-reviewer): add reviewer report-generating skill based on Nature official criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ In that case:
 | [`nature-figure`](skills/nature-figure/README.md) | Stable | Nature/high-impact Python or R figure workflow with bundled figures4papers demos | "Nature figure", "publication plot", "scientific figure", "figures4papers" |
 | [`nature-polishing`](skills/nature-polishing/README.md) | Stable | Academic prose polishing to *Nature* style | "Nature style", "polish", "academic writing" |
 | [`nature-writing`](skills/nature-writing/README.md) | Draft | Nature-style manuscript section drafting and argument restructuring | "Nature writing", "write abstract", "write introduction", "manuscript draft" |
+| [`nature-reviewer`](skills/nature-reviewer/README.md) | Draft | Nature-style reviewer assessment with 3 referee reports and a cross-review synthesis | "Nature reviewer", "pre-submission review", "reviewer report", "peer-review critique", "审稿人视角评估" |
 | [`nature-citation`](skills/nature-citation/README.md) | Beta | Strict Nature / CNS-family citation retrieval with ENW, RIS, and Zotero RDF export | "Nature citation", "CNS citation", "text citation", "supporting references", "Zotero RDF" |
 | [`nature-data`](skills/nature-data/README.md) | Draft | Nature Data Availability statements, repository plans, and FAIR checks | "Data Availability", "repository", "FAIR metadata", "data availability statement" |
 | [`nature-reader`](skills/nature-reader/README.md) | Beta | Full-paper bilingual Markdown reader with source anchors and figure grounding | "nature reader", "full markdown", "paper md", "原文对照", "图文对应", "全文翻译" |

--- a/skills/nature-reviewer/README.md
+++ b/skills/nature-reviewer/README.md
@@ -1,0 +1,85 @@
+# `nature-reviewer` skill
+
+A reviewer-assessment skill for simulating a `Nature`-style referee package from the reviewer perspective rather than the author-rebuttal perspective.
+
+This skill was created specifically from the reviewer-related content in `Nature`'s official `Editorial criteria and processes` page:
+`https://www-nature-com/nature/for-authors/editorial-criteria-and-processes`
+
+The motivation is narrow and explicit:
+
+- extract the reviewer-relevant rules from that official `Nature` source
+- ensure the simulated reviewer behaviour stays consistent with those rules
+- avoid drifting into generic peer-review habits or invented reviewer personas
+- produce a reusable `nature-reviewer` skill that reflects the official source basis as closely as possible within the repository's skill format
+
+Accordingly, this skill is intentionally conservative. It is grounded in the local copy of that source under `references/editorial criteria and processes.md`, then converted into a conservative output contract: `3 reviewer reports + 1 cross-review synthesis`. The three reports differ only by `emphasis`, because the source supports reviewer function and report content, but does not define fictional reviewer identities or specialty personas.
+
+## What it does
+
+- reads a manuscript draft, abstract, selected sections, figures, or author notes as a reviewer-facing input package
+- evaluates the work against source-grounded `Nature`-style axes: `originality`, `scientific importance`, `interdisciplinary readership`, `technical soundness`, and `readability for nonspecialists`
+- generates `3` reviewer reports that differ only in `emphasis`, not in invented identity or specialty
+- states who would be interested in the results and why
+- identifies technical failings that must be addressed before the authors' case is established
+- synthesizes consensus and emphasis differences across the three reports
+- flags unsupported claims and material that cannot be assessed from the supplied evidence
+
+## When to use
+
+- simulating a `Nature` reviewer report before submission
+- stress-testing whether a manuscript makes a credible broad-interest case
+- asking for a reviewer-style assessment of novelty, significance, or technical soundness
+- generating a pre-submission critique from the referee perspective
+- evaluating whether a manuscript is readable to non-specialists
+- obtaining a bounded peer-review style response without drafting an author rebuttal
+
+If the user wants a point-by-point author response or revision letter, use `nature-response` instead.
+
+## What it returns
+
+Unless the user asks for another format, the skill returns:
+
+1. `Review setup`
+2. `Reviewer 1`
+3. `Reviewer 2`
+4. `Reviewer 3`
+5. `Cross-review synthesis`
+6. `Risk / unsupported claims`
+
+## Core rules
+
+- Ground the assessment in the local reviewer source and the user-supplied manuscript facts only.
+- Keep the three reviewers aligned on the same facts; vary only the weighting of those facts.
+- Do not invent reviewer identities, narrow specialty roles, institutions, or hidden knowledge.
+- Explicitly address `who will be interested in the new results and why`.
+- Explicitly identify `technical failings` that still block the authors' case.
+- Distinguish technical validity from broad-interest fit; the source treats these as related but not identical.
+- Mark `AUTHOR_INPUT_NEEDED`, `Not assessable from provided material`, or equivalent uncertainty labels instead of fabricating details.
+
+## Source hierarchy
+
+- `references/editorial criteria and processes.md` as the primary authoritative local source
+- user-supplied manuscript facts and evidence
+- conservative local implementation rules summarized in `references/source-basis.md`
+
+This skill must not silently expand beyond that source basis into generic reviewer-role invention or journal-policy speculation.
+
+## File structure
+
+```text
+nature-reviewer/
+├── README.md
+├── SKILL.md
+└── references/
+    ├── editorial criteria and processes.md
+    ├── source-basis.md
+    ├── reviewer-workflow.md
+    ├── review-axes.md
+    ├── report-structure.md
+    ├── role-boundaries.md
+    └── qa-checklist.md
+```
+
+## Status
+
+Draft. The first version is source-defined and structured for grounded reviewer simulation, but it has not yet been validated against a library of real anonymized manuscript-review examples.

--- a/skills/nature-reviewer/SKILL.md
+++ b/skills/nature-reviewer/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: nature-reviewer
+description: >-
+  Simulate a Nature-style reviewer assessment from the referee perspective rather than
+  an author rebuttal. Use when the user wants a pre-submission review, reviewer report,
+  peer-review style critique, novelty/significance/technical soundness assessment,
+  reviewer-style manuscript evaluation, 审稿人视角评估, 预审稿意见, or Nature reviewer
+  report. Return 3 reviewer reports plus a cross-review synthesis, grounded only in the
+  local Nature reviewer source basis.
+version: 0.1.0
+status: Draft
+---
+
+# Nature Reviewer Assessment Skill
+
+Use this skill to simulate a `Nature`-style reviewer assessment package from the referee
+side.
+
+This skill is for reviewer-style manuscript evaluation, not for drafting the authors'
+response. If the user wants rebuttal writing, route to `nature-response`.
+
+## Default stance
+
+- Ground the review only in the local source basis plus manuscript facts supplied by the user.
+- Evaluate the manuscript against source-grounded axes: `originality`, `scientific importance`, `interdisciplinary readership`, `technical soundness`, and `readability for nonspecialists`.
+- Return exactly `3 reviewer reports + 1 cross-review synthesis` unless the user explicitly asks for another structure.
+- The three reviewers may differ only in `emphasis`; do not invent reviewer identities, specialties, institutions, or biographies.
+- Identify who would be interested in the results and why.
+- Identify technical failings that must be addressed before the authors' case is established.
+- Distinguish clearly between what is supported, what is weak, and what is not assessable from the provided material.
+- Do not claim the editor's final decision or certainty about fit to `Nature`.
+
+## Accepted inputs
+
+The skill may receive:
+
+- full manuscript draft
+- abstract, summary paragraph, or cover-summary style text
+- introduction, results, discussion, or methods excerpts
+- figure legends, selected figures, or result notes
+- author notes in Chinese or English describing the claimed contribution
+- pre-submission positioning notes
+
+If the provided material is partial, perform a bounded review and mark the assessment boundary explicitly.
+
+## Workflow
+
+1. Identify the input scope and whether the job is a reviewer-style assessment rather than rebuttal drafting.
+2. Extract a shared manuscript fact base: main claim, visible evidence, claimed significance, likely readership, and visible limitations.
+3. Check readiness and label missing evidence or missing sections instead of inventing them.
+4. Assess the manuscript using the source-grounded axes.
+5. Generate `Reviewer 1`, `Reviewer 2`, and `Reviewer 3` using shared facts but different emphasis.
+6. Generate a `Cross-review synthesis` that captures consensus and weighting differences.
+7. Run QA for groundedness, coverage, role boundaries, and non-invention.
+
+## Output format
+
+Unless the user asks for another format, return:
+
+```text
+Review setup
+- Input scope:
+- Assessment boundary:
+- Shared manuscript claim summary:
+- Visible evidence base:
+- Missing materials affecting confidence:
+
+Reviewer 1
+- Overall assessment:
+- Who would be interested in the results, and why:
+- Major strengths:
+- Major concerns:
+- Technical failings that need to be addressed before the case is established:
+- Assessment against Nature-style criteria:
+- Recommendation posture:
+
+Reviewer 2
+[Same structure]
+
+Reviewer 3
+[Same structure]
+
+Cross-review synthesis
+- Consensus strengths:
+- Consensus technical risks:
+- Where emphasis differs across reviewers:
+- Broad-interest / significance readout:
+- Most important issues to resolve before a strong Nature-style case is established:
+
+Risk / unsupported claims
+- [specific unsupported or not-assessable items]
+```
+
+## Red lines
+
+- Do not invent reviewer identities, specialty roles, or selection history.
+- Do not invent experiments, validations, controls, citations, figure details, line numbers, or prior-work distinctions not present in the input.
+- Do not silently turn reviewer assessment into author rebuttal drafting.
+- Do not present the review as an editorial decision letter.
+- Do not state that the manuscript belongs in `Nature` as a settled fact.
+- Do not omit technical failings when the provided evidence does not establish the authors' case.
+
+## Related files
+
+| File | Open when |
+|---|---|
+| [references/source-basis.md](references/source-basis.md) | You need source provenance, local rule summaries, or source-vs-implementation boundaries |
+| [references/reviewer-workflow.md](references/reviewer-workflow.md) | You need the invocation order, fact-base extraction flow, or synthesis rules |
+| [references/review-axes.md](references/review-axes.md) | You need the evaluation axes or reviewer weighting logic |
+| [references/report-structure.md](references/report-structure.md) | You need the default output contract or section anatomy |
+| [references/role-boundaries.md](references/role-boundaries.md) | You need constraints on reviewer differences and editor-versus-reviewer boundaries |
+| [references/qa-checklist.md](references/qa-checklist.md) | You are finalizing an output and need groundedness / non-invention checks |
+| [references/editorial criteria and processes.md](references/editorial criteria and processes.md) | You need the primary local Nature source text |
+
+## Source hierarchy
+
+Use sources in this order:
+
+1. `references/editorial criteria and processes.md`
+2. manuscript facts supplied by the user
+3. conservative local implementation rules documented in `references/source-basis.md`
+
+If a user asks for policy-level certainty beyond this local source, state the limit instead of improvising broader journal policy.

--- a/skills/nature-reviewer/references/editorial criteria and processes.md
+++ b/skills/nature-reviewer/references/editorial criteria and processes.md
@@ -1,0 +1,46 @@
+# Editorial criteria and processes
+
+This document provides an outline of the editorial process involved in publishing a scientific paper (Article) in _Nature_, and describes how manuscripts are handled by editors between submission and publication.
+
+Editorial processes are described for the following stages: At submission | After submission | After acceptance
+
+## At submission
+
+**Criteria for publication**
+
+The criteria for publication of scientific papers (Articles) in _Nature_ are that they:
+
+- report original scientific research (the main results and conclusions must not have been published or submitted elsewhere)
+- are of outstanding scientific importance
+- reach a conclusion of interest to an interdisciplinary readership.
+
+Further editorial criteria may be applicable for different kinds of papers, as follows:
+
+- **large dataset papers**: should aim to either report a fully comprehensive data set, defined by complete and extensive validation, or provide significant technical advance or scientific insight.
+- **technical papers:** papers that make solely technical advances will be considered in cases where the technique reported will have significant impacts on communities of fellow researchers.
+- **therapeutic papers:** in the absence of novel mechanistic insight, therapeutic papers will be considered if the therapeutic effect reported will provide significant impact on an important disease.
+
+Articles published in Nature have an exceptionally wide impact, both among scientists and, frequently, among the general public.
+
+
+## After submission
+
+### **What happens to a submitted Article?**
+
+The first stage for a newly submitted Article is that the editorial staff consider whether to send it for peer-review. On submission, the manuscript is assigned to an editor covering the subject area, who seeks informal advice from scientific advisors and editorial colleagues, and who makes this initial decision. The criteria for a paper to be sent for peer-review are that the results seem novel, arresting (illuminating, unexpected or surprising), and that the work described has both immediate and far-reaching implications. The initial judgement is not a reflection on the technical validity of the work described, or on its importance to people in the same field.  
+Special attention is paid by the editors to the readability of submitted material. Editors encourage authors in highly technical disciplines to provide a slightly longer summary paragraph that descries clearly the basic background to the work and how the new results have affected the field, in a way that enables nonspecialist readers to understand what is being described. Editors also strongly encourage authors in appropriate disciplines to include a simple schematic summarizing the main conclusion of the paper, which can be published with the paper as Supplementary Information. Such figures can be particularly helpful to nonspecialist readers of cell, molecular and structural biology papers.  
+Once the decision has been made to peer-review the paper, the choice of referees is made by the editor who has been assigned the manuscript, who will be handling other papers in the same field, in consultation with editors handling submissions in related fields when necessary. Most papers are sent to two or three referees, but some are sent to more or, occasionally, just to one. Referees are chosen for the following reasons:
+
+- independence from the authors and their institutions
+- ability to evaluate the technical aspects of the paper fully and fairly
+- currently or recently assessing related submissions
+- availability to assess the manuscript within the requested time.
+
+### **Referees' reports**
+
+The ideal referee's report indicates
+
+- who will be interested in the new results and why
+- any technical failings that need to be addressed before the authors' case is established.
+
+Although _Nature_'s editors themselves judge whether a paper is likely to interest readers outside its own immediate field, referees often give helpful advice, for example if the work described is not as significant as the editors thought or has undersold its significance. Although _Nature_'s editors regard it as essential that any technical failings noted by referees are addressed, they are not so strictly bound by referees’ editorial opinions as to whether the work belongs in _Nature_.

--- a/skills/nature-reviewer/references/qa-checklist.md
+++ b/skills/nature-reviewer/references/qa-checklist.md
@@ -1,0 +1,39 @@
+# QA checklist
+
+## Grounding checks
+
+- Every substantive evaluation should be traceable to either:
+  - `references/editorial criteria and processes.md`, or
+  - manuscript facts explicitly supplied by the user.
+- No reviewer persona detail should appear beyond allowed `emphasis` labels.
+- No technical failing should be invented from domain habit alone when the supplied material does not show it.
+
+## Coverage checks
+
+- Confirm all three reviewer reports exist.
+- Confirm the three reports differ in `emphasis` only.
+- Confirm each reviewer still addresses all core axes, even if briefly.
+- Confirm a `Cross-review synthesis` section exists.
+- Confirm a `Risk / unsupported claims` section exists.
+
+## Boundary checks
+
+- Confirm the output stays in reviewer-assessment mode, not author-response mode.
+- Confirm the output does not claim a final editorial decision.
+- Confirm broad-interest judgment is expressed cautiously, because the source assigns that final judgment to editors.
+
+## Non-invention checks
+
+- No invented reviewer identity, specialty, institution, or selection history.
+- No invented experiments, controls, analyses, line numbers, citations, prior-work details, or figure-specific content absent from the input.
+- If evidence is partial, mark `AUTHOR_INPUT_NEEDED` or `Not assessable from provided material`.
+
+## Consistency checks
+
+- Shared manuscript facts should stay consistent across all three reviewers.
+- Divergence across reviewers should reflect weighting differences, not contradictory factual claims.
+- Technical failings listed in the synthesis should match issues already raised in at least one individual report.
+
+## Final release rule
+
+- If the skill cannot produce a grounded three-reviewer package without major invention, it should return a bounded draft review with explicit missing-information flags rather than pretending certainty.

--- a/skills/nature-reviewer/references/report-structure.md
+++ b/skills/nature-reviewer/references/report-structure.md
@@ -1,0 +1,66 @@
+# Report structure
+
+## Default output contract
+
+- The default output should contain these sections in order:
+  1. `Review setup`
+  2. `Reviewer 1`
+  3. `Reviewer 2`
+  4. `Reviewer 3`
+  5. `Cross-review synthesis`
+  6. `Risk / unsupported claims`
+
+## Review setup
+
+- Include:
+  - `Input scope`
+  - `Assessment boundary`
+  - `Shared manuscript claim summary`
+  - `Visible evidence base`
+  - `Missing materials affecting confidence`, when applicable
+
+## Per-reviewer structure
+
+- Each reviewer report should use the same skeleton:
+  - `Overall assessment`
+  - `Who would be interested in the results, and why`
+  - `Major strengths`
+  - `Major concerns`
+  - `Technical failings that need to be addressed before the case is established`
+  - `Assessment against Nature-style criteria`
+  - `Recommendation posture`
+- `Assessment against Nature-style criteria` should explicitly touch:
+  - `originality`
+  - `scientific importance`
+  - `interdisciplinary readership`
+  - `technical soundness`
+  - `readability for nonspecialists`
+- `Recommendation posture` should stay reviewer-like, for example:
+  - `supportive if technical concerns are resolved`
+  - `promising but broad-interest case remains underdeveloped`
+  - `currently not established from the provided evidence`
+
+## Cross-review synthesis structure
+
+- Include:
+  - `Consensus strengths`
+  - `Consensus technical risks`
+  - `Where emphasis differs across reviewers`
+  - `Broad-interest / significance readout`
+  - `Most important issues to resolve before a strong Nature-style case is established`
+
+## Risk / unsupported claims section
+
+- Include explicit flags for:
+  - unsupported novelty claims
+  - significance claims not established by the supplied evidence
+  - missing controls, validations, or comparisons
+  - readability claims that cannot be assessed from the supplied excerpt
+  - any place where the review necessarily relied on partial material
+
+## Style rules
+
+- Keep tone formal, direct, and evidence-based.
+- Do not write as the authors.
+- Do not write a rebuttal, action plan, or editorial decision letter unless the user explicitly asks for one.
+- Do not invent line numbers, figure panels, datasets, prior studies, or missing analyses.

--- a/skills/nature-reviewer/references/review-axes.md
+++ b/skills/nature-reviewer/references/review-axes.md
@@ -1,0 +1,58 @@
+# Review axes
+
+## Core axes derived from the source
+
+- `originality`
+  - Ask whether the work appears to report original scientific research and whether the main results or conclusions seem genuinely new from the provided material.
+  - Flag when novelty is asserted but not well distinguished from prior work.
+- `scientific importance / significance`
+  - Ask whether the work appears to be of outstanding scientific importance.
+  - Distinguish field-local usefulness from broader scientific importance.
+- `interdisciplinary readership interest`
+  - Ask whether the conclusion appears interesting beyond the immediate specialty.
+  - Note whether the implications feel immediate and far-reaching versus narrow and incremental.
+- `technical soundness / technical failings`
+  - Ask whether the authors' case is technically established from the evidence shown.
+  - Identify concrete technical failings that must be addressed before the case is established.
+- `readability for nonspecialists`
+  - Ask whether a nonspecialist reader could understand the basic background, what was done, and how the results affect the field.
+  - Use this axis especially for highly technical manuscripts.
+
+## Axis-specific prompts
+
+- For `originality`:
+  - What is the claimed advance?
+  - Is the distinction from prior work explicit and credible in the supplied manuscript?
+- For `scientific importance / significance`:
+  - Does the manuscript support a case for outstanding importance, or only competent incremental progress?
+  - Are the implications immediate and far-reaching, or mainly field-internal?
+- For `interdisciplinary readership interest`:
+  - Who outside the immediate area would care, and why?
+  - Is the conclusion framed in a way that broad scientific readers can grasp?
+- For `technical soundness / technical failings`:
+  - Which parts of the causal or evidentiary chain are under-supported?
+  - What missing controls, analyses, validations, or logic gaps currently weaken the authors' case?
+- For `readability for nonspecialists`:
+  - Is the summary logic accessible?
+  - Does the manuscript rely on unexplained jargon, compressed context, or unclear field impact?
+
+## Weighting guidance for the three reports
+
+- `Reviewer 1` should usually foreground `technical soundness / technical failings`.
+- `Reviewer 2` should usually foreground `originality` plus `scientific importance / significance`.
+- `Reviewer 3` should usually foreground `interdisciplinary readership interest` plus `readability for nonspecialists`.
+- All three reviewers should still cover all axes briefly; the difference is weight, not scope omission.
+
+## Missing-evidence handling
+
+- If the manuscript text or figures are incomplete, do not infer absent validations or prior-work distinctions.
+- Use explicit markers such as:
+  - `Not assessable from provided material`
+  - `AUTHOR_INPUT_NEEDED`
+  - `Evidence not shown in the supplied manuscript excerpt`
+
+## Things this axis set must not do
+
+- Do not replace source-grounded axes with generic peer-review checklists unrelated to the local source.
+- Do not force exhaustive domain-specific methodological critique when the provided material does not support it.
+- Do not convert readability comments into copyediting line edits unless the user explicitly asks for that level of intervention.

--- a/skills/nature-reviewer/references/reviewer-workflow.md
+++ b/skills/nature-reviewer/references/reviewer-workflow.md
@@ -1,0 +1,56 @@
+# Reviewer workflow
+
+## Default execution order
+
+1. Identify the input package.
+   - Determine whether the user supplied a full manuscript, abstract-only draft, selected sections, figures, notes, or a pre-submission concept summary.
+2. Build a manuscript fact base.
+   - Extract the central claim, key evidence, stated significance, implied audience, and visible limitations.
+3. Check assessment readiness.
+   - Mark what can be assessed versus what remains missing.
+   - If evidence is incomplete, preserve momentum but label uncertainty instead of blocking unless the gap is total.
+4. Review the manuscript across the source-grounded axes.
+   - Apply `originality`, `scientific importance`, `interdisciplinary interest`, `technical soundness`, and `readability for nonspecialists`.
+5. Generate `3` reviewer reports with different emphasis.
+   - Use the same fact base for all three reports.
+   - Do not invent different reviewer identities or hidden information.
+6. Generate a cross-review synthesis.
+   - Summarize consensus, points of emphasis divergence, and the most decision-relevant technical and significance risks.
+7. Run final QA.
+   - Check groundedness, consistency, coverage, and non-invention.
+
+## Input handling
+
+- Acceptable inputs include:
+  - manuscript draft
+  - abstract or summary paragraph
+  - introduction, results, discussion, or methods excerpts
+  - figure legends or selected figures
+  - author notes describing the claimed contribution
+- If the input is thin, the skill should still provide a bounded review, but it must clearly state the assessment boundary.
+
+## Fact-base extraction checklist
+
+- Extract these items before writing the reports:
+  - `manuscript type or apparent submission posture`
+  - `main claim`
+  - `key evidence presented`
+  - `claimed significance`
+  - `likely interested readership from the text`
+  - `visible technical gaps`
+  - `readability or framing issues for nonspecialists`
+
+## Cross-review generation rule
+
+- The cross-review synthesis should consolidate, not average away, reviewer differences.
+- It must separate:
+  - shared strengths
+  - shared technical concerns
+  - differences in significance weighting
+  - differences in readership/readability judgment
+
+## Failure-safe behaviour
+
+- When evidence is absent, say the case is not yet established from the supplied material.
+- When significance is unclear, distinguish `potentially interesting` from `demonstrated broad importance`.
+- When readability is weak, describe the barrier to nonspecialist comprehension instead of rewriting the manuscript unless asked.

--- a/skills/nature-reviewer/references/role-boundaries.md
+++ b/skills/nature-reviewer/references/role-boundaries.md
@@ -1,0 +1,49 @@
+# Role boundaries
+
+## Allowed reviewer differences
+
+- The three reviewer reports may differ only in `emphasis`.
+- Valid emphasis patterns for this skill are limited to source-grounded axes such as:
+  - `technical validity / technical failings emphasis`
+  - `significance / originality emphasis`
+  - `interdisciplinary readership / readability emphasis`
+- These emphasis labels are working lenses, not claimed referee identities.
+
+## Forbidden inventions
+
+- Do not invent reviewer identities, including:
+  - named disciplines not required by the source
+  - `statistics reviewer`, `ethics reviewer`, `clinical reviewer`, `methods reviewer`, or similar role titles
+  - seniority, geography, gender, institutional type, or prior relationship to the field
+- Do not claim the reviewers were chosen for reasons other than those stated in the source.
+- Do not simulate confidential editor knowledge, hidden reviewer expertise, or access to related submissions unless the user explicitly supplied such information.
+
+## Editor-versus-reviewer separation
+
+- Reviewers in this skill may:
+  - assess who would care about the results and why
+  - identify technical failings that block the authors' case
+  - comment that significance seems overstated or undersold
+  - note whether the manuscript appears hard for nonspecialists to read
+- Reviewers in this skill must not:
+  - act as if they are the handling editor
+  - state final editorial outcomes as facts
+  - claim authority over referee selection
+  - replace the editor's broad-readership judgment with invented certainty
+
+## Output behaviour rules
+
+- Each reviewer should produce a distinct but overlapping assessment using the same manuscript facts.
+- Disagreement across reviewers should arise from weighting differences across the allowed axes, not from fabricated access to different evidence.
+- If a requested evaluation would require a role the source does not define, keep the comment generic and evidence-based instead of creating a specialist persona.
+
+## Safe phrasing examples
+
+- Prefer:
+  - `Reviewer 1 places greatest weight on technical failings that currently weaken the authors' case.`
+  - `Reviewer 2 places greatest weight on originality and scientific importance.`
+  - `Reviewer 3 places greatest weight on interdisciplinary reach and readability for nonspecialists.`
+- Avoid:
+  - `Reviewer 2 is a senior translational oncologist.`
+  - `Reviewer 3 serves as the statistical referee.`
+  - `Reviewer 1 was selected because they recently reviewed a competing submission.`

--- a/skills/nature-reviewer/references/source-basis.md
+++ b/skills/nature-reviewer/references/source-basis.md
@@ -1,0 +1,77 @@
+# Source basis
+
+## Authoritative local source
+
+- Primary local source: `references/editorial criteria and processes.md`
+- Scope of authority:
+  - publication criteria for `Nature` Articles
+  - peer-review entry criteria used by editors before external review
+  - referee selection basis
+  - ideal referee report content
+- This skill must treat that file as the only authoritative local source for reviewer-facing behaviour in the MVP.
+
+## Direct source extracts converted into working rules
+
+- Publication criteria for Articles:
+  - papers should report `original scientific research`
+  - papers should be of `outstanding scientific importance`
+  - papers should `reach a conclusion of interest to an interdisciplinary readership`
+- Peer-review entry criteria used by editors:
+  - results seem `novel`
+  - results are `arresting` — illuminating, unexpected, or surprising
+  - work has `immediate and far-reaching implications`
+  - this initial decision is `not a reflection on technical validity` or field-local importance
+- Readability expectation relevant to reviewer assessment:
+  - submitted material receives `special attention` for readability
+  - highly technical work should explain background and field impact clearly enough for `nonspecialist readers`
+- Referee selection basis:
+  - `independence` from authors and institutions
+  - ability to evaluate `technical aspects` fully and fairly
+  - may be `currently or recently assessing related submissions`
+  - `availability` within the requested review time
+- Ideal referee report content:
+  - indicate `who will be interested in the new results and why`
+  - indicate `technical failings` that must be addressed before the authors' case is established
+- Editor-versus-referee boundary in the source:
+  - editors judge whether work is likely to interest readers `outside its immediate field`
+  - referees may still help when significance was overestimated or `undersold`
+  - editors are strictly concerned that `technical failings` be addressed
+  - editors are `not strictly bound` by referee editorial opinions on whether the work belongs in `Nature`
+
+## Local rule summary
+
+- Reviewer outputs must evaluate the manuscript against source-grounded axes only:
+  - `originality`
+  - `scientific importance / significance`
+  - `interest beyond the immediate field / interdisciplinary readership`
+  - `technical soundness / technical failings`
+  - `readability for nonspecialists` when inferable from the manuscript
+- Reviewer outputs must not pretend to make the editor's acceptance decision.
+- Reviewer outputs may comment on whether significance seems overstated or understated, because the source explicitly allows helpful referee advice there.
+- Reviewer outputs must distinguish:
+  - what is supported by manuscript evidence
+  - what is missing or technically weak
+  - what cannot be assessed from provided material
+- When the manuscript packet is incomplete, the skill must use `AUTHOR_INPUT_NEEDED` or equivalent missing-evidence flags instead of inventing facts.
+
+## Conservative implementation choices
+
+- The skill returns exactly `3 reviewer reports + 1 cross-review synthesis` by default.
+  - This is a repo-level implementation choice, not a direct source requirement.
+- The three reviewers differ only by `emphasis`, not by invented identity, seniority, institution, demographic profile, or narrow specialty role.
+  - This is a conservative anti-hallucination rule derived from the limited source basis.
+- The output includes an explicit `Risk / unsupported claims` section.
+  - This is a local QA device, not an official Nature format requirement.
+- The skill uses explicit section labels such as `Review setup`, `Reviewer 1`, and `Cross-review synthesis`.
+  - This is a formatting contract for usability, not a source claim.
+
+## Implementation implications
+
+- If the user asks for an author rebuttal, route to `nature-response`, not this skill.
+- If the user asks for simulated peer review, stay in reviewer mode:
+  - assess claims
+  - identify likely interested readership
+  - identify technical failings
+  - avoid drafting editorial decision language as the default output
+- If the manuscript seems technically valid but not clearly broad-interest, the reports may say so; the source explicitly separates technical validity from editorial selection.
+- If the manuscript is broad-interest but evidence is incomplete, the reports must still foreground technical failings because the source treats them as essential before the authors' case is established.


### PR DESCRIPTION
## Summary

Hi Yizhe^^. This PR adds a new `nature-reviewer` skill for simulating a `Nature`-style reviewer assessment from the referee perspective (based on offcial Nature requirement), rather than drafting an self review/author rebuttal (which is a part of nature-writing or nature-response).

The motivation is to build this skill from the reviewer-related content in Nature's official `Editorial criteria and processes` guidance, so the behavior stays anchored to the source instead of drifting into generic peer-review habits or invented reviewer personas.

To keep the skill grounded and maintainable, I kept `SKILL.md` short and router-like, while the detailed rules are split into focused reference files.

## What changed

- Added `skills/nature-reviewer/SKILL.md`
  - Main router file with trigger, stance, workflow, output contract, red lines, and source hierarchy.

- Added `skills/nature-reviewer/README.md`
  - Human-readable overview of what the skill does, when to use it, what it returns, and why it was created from the Nature reviewer source.

Also I added a lot of detailed file derived from official `Editorial criteria and processes` guidance.

1. Added `skills/nature-reviewer/references/source-basis.md`
  - Defines the authoritative local source, extracts reviewer-relevant rules, and separates source-derived rules from conservative local implementation choices.
2. Added `skills/nature-reviewer/references/reviewer-workflow.md`
  - Defines the execution flow from manuscript intake to shared fact extraction, 3 reviewer reports, and cross-review synthesis.
3. Added `skills/nature-reviewer/references/review-axes.md`
  - Converts the official reviewer-related criteria into operational review axes such as `originality`, `scientific importance`, `interdisciplinary readership`, `technical soundness`, and `readability for nonspecialists`.
4. Added `skills/nature-reviewer/references/report-structure.md`
  - Defines the fixed output structure for the 3 reviewer reports plus the synthesis section.
5. Added `skills/nature-reviewer/references/role-boundaries.md`
  - Constrains the 3 reviewers to differ only by emphasis, and explicitly prevents invented reviewer identities or specialty roles.
6. Added `skills/nature-reviewer/references/qa-checklist.md`
  - Defines final checks for groundedness, coverage, consistency, and non-invention.

- Updated `README.md`
  - Added `nature-reviewer` to the main Skill index as your request.

## Done test plan

- Read through the official local source and verified that the skill behavior is anchored to reviewer-related content only.
- Checked that the new skill package includes the required `SKILL.md` and `README.md`.
- Checked that the root `README.md` Skill index includes `nature-reviewer`.
- I currently use it for simple self-critique, and the output is better than the generic one (zero-shot generation of reviewer report)^^.