### PR TITLE
Add scripts/update-codex-skills.sh for manual Codex installs

### DIFF
--- a/scripts/update-codex-skills.sh
+++ b/scripts/update-codex-skills.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# update-codex-skills.sh — install / update Nature Skills into Codex.
+#
+# Codex loads skills from ~/.codex/skills/. This script copies every skill
+# folder shipped in this repository's skills/ directory (the 10 nature-*
+# skills plus the shared _shared/ dir) into that location.
+#
+# It is intended for users who install the skills by manual copy rather than
+# via the Codex plugin marketplace. Running it again later updates an existing
+# install to the current contents of this checkout.
+#
+# Safety: it syncs ONLY the skill folders found in this repo, each in isolation.
+# Any other skills you keep in ~/.codex/skills/ (e.g. pdf, playwright) are left
+# completely untouched.
+#
+# Usage:
+#   scripts/update-codex-skills.sh           # copy this checkout's skills into Codex
+#   PULL=1 scripts/update-codex-skills.sh    # `git pull --ff-only` first, then copy
+#   CODEX_SKILLS_DIR=/path scripts/update-codex-skills.sh   # override destination
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SRC="$REPO_ROOT/skills"
+DST="${CODEX_SKILLS_DIR:-$HOME/.codex/skills}"
+
+if [ ! -d "$SRC" ]; then
+  echo "error: skills directory not found at $SRC" >&2
+  exit 1
+fi
+
+# Optionally refresh this checkout to the latest commit before copying.
+if [ "${PULL:-0}" = "1" ] && git -C "$REPO_ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+  echo "==> Pulling latest (git pull --ff-only) ..."
+  git -C "$REPO_ROOT" pull --ff-only
+fi
+
+if ! command -v rsync >/dev/null 2>&1; then
+  echo "error: rsync is required but not installed" >&2
+  exit 1
+fi
+
+mkdir -p "$DST"
+echo "==> Syncing skills from $SRC"
+echo "    into $DST"
+for path in "$SRC"/*/; do
+  d="$(basename "$path")"
+  mkdir -p "$DST/$d"
+  rsync -a --delete "$path" "$DST/$d/"
+  echo "    ✓ $d"
+done
+
+echo "==> Done. Other skills in $DST were left untouched."


### PR DESCRIPTION
## What

Adds `scripts/update-codex-skills.sh`, a small idempotent helper that copies the skill folders shipped in `skills/` (the 10 `nature-*` skills plus `_shared/`) into a Codex skills directory.

```sh
scripts/update-codex-skills.sh           # copy this checkout's skills into ~/.codex/skills/
PULL=1 scripts/update-codex-skills.sh    # git pull --ff-only first, then copy
CODEX_SKILLS_DIR=/path scripts/update-codex-skills.sh   # override destination
```

## Why

The README documents a Codex plugin-marketplace install, but some users install the skills by **manual copy** instead. For them, keeping the copy up to date is a fiddly multi-folder operation that's easy to get wrong (e.g. a naive `rsync --delete` on the whole `~/.codex/skills/` dir wipes unrelated skills). This script makes install/update a single safe command, and re-running it updates an existing install to the current checkout.

## Safety

- Syncs **only** the skill folders found in this repo, each in isolation. Unrelated skills already in the Codex skills dir (e.g. `pdf`, `playwright`) are left untouched.
- Default destination `$HOME/.codex/skills`, overridable via `CODEX_SKILLS_DIR`.
- Verified by syncing into a sandbox dir containing an unrelated skill folder: all 10 `nature-*` + `_shared` copied, the unrelated folder untouched.

Happy to add a short note under the Codex section of the README if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)