### PR TITLE
Fix NameError (all_errors/all_references) breaking nature_citation final export

### DIFF
--- a/plugins/nature-skills/skills/nature-citation/scripts/nature_citation.py
+++ b/plugins/nature-skills/skills/nature-citation/scripts/nature_citation.py
@@ -1973,8 +1973,8 @@ def main(argv: list[str]) -> int:
     segments, skipped_segments = limit_segments(segments, args.max_segments or 0)
     mapping, references, errors = process_segment_batches(segments, args, outdir, output_path)
     doi_candidates, doi_errors = fetch_doi_candidates(dois, args)
-    all_errors.extend(doi_errors)
-    references = dedupe([*all_references, *doi_candidates])[: args.max_candidates]
+    errors.extend(doi_errors)
+    references = dedupe([*references, *doi_candidates])[: args.max_candidates]
 
     # 最终导出
     if args.format == "enw":

--- a/skills/nature-citation/scripts/nature_citation.py
+++ b/skills/nature-citation/scripts/nature_citation.py
@@ -1973,8 +1973,8 @@ def main(argv: list[str]) -> int:
     segments, skipped_segments = limit_segments(segments, args.max_segments or 0)
     mapping, references, errors = process_segment_batches(segments, args, outdir, output_path)
     doi_candidates, doi_errors = fetch_doi_candidates(dois, args)
-    all_errors.extend(doi_errors)
-    references = dedupe([*all_references, *doi_candidates])[: args.max_candidates]
+    errors.extend(doi_errors)
+    references = dedupe([*references, *doi_candidates])[: args.max_candidates]
 
     # 最终导出
     if args.format == "enw":


### PR DESCRIPTION
## What

Fixes the `NameError` reported in #62 that breaks the final export of `nature-citation`.

In `main()`, the tail of the pipeline referenced two names that are never defined anywhere in the file — `all_errors` and `all_references` (leftovers from a rename). Because the statement runs unconditionally (independent of `--doi`), every run crashed with `NameError` **after** the per-batch checkpoint was written but **before** the final export, so the script only ever left a `*.partial.enw` and exited non-zero.

`process_segment_batches()` actually returns `references` and `errors`, so the fix is to use those names:

```python
errors.extend(doi_errors)
references = dedupe([*references, *doi_candidates])[: args.max_candidates]
```

Applied to both copies:
- `skills/nature-citation/scripts/nature_citation.py`
- `plugins/nature-skills/skills/nature-citation/scripts/nature_citation.py` (mirror)

## Verification

```bash
python3 scripts/nature_citation.py \
  --claim "Cathodic protection mitigates external corrosion of buried steel pipelines" \
  --doi "10.1007/978-3-319-49409-8_35" \
  --scope cns --output-file out.enw --mailto you@example.com
# -> Reference output: out.enw ; Unique references exported: 1 ; exit 0
# Deep CORAL correctly fetched from the DOI
```

Both files also pass `python3 -m py_compile`.

Credit to @devin-ai-integration for the precise report and verified fix in #62.

Closes #62
