### PR TITLE
feat: add Claude Code plugin commands for all 10 nature skills

### DIFF
--- a/plugins/nature-skills/commands/nature-academic-search.md
+++ b/plugins/nature-skills/commands/nature-academic-search.md
@@ -1,0 +1,5 @@
+---
+description: >-
+---
+
+Read the skill definition file at `/Users/mira/.claude/plugins/marketplaces/Yuan1z0825-nature-skills/plugins/nature-skills/skills/nature-academic-search/SKILL.md` and follow all instructions in it exactly. All relative file paths mentioned in that file resolve relative to `/Users/mira/.claude/plugins/marketplaces/Yuan1z0825-nature-skills/plugins/nature-skills/skills/nature-academic-search/`.

--- a/plugins/nature-skills/commands/nature-citation.md
+++ b/plugins/nature-skills/commands/nature-citation.md
@@ -1,0 +1,5 @@
+---
+description: >-
+---
+
+Read the skill definition file at `/Users/mira/.claude/plugins/marketplaces/Yuan1z0825-nature-skills/plugins/nature-skills/skills/nature-citation/SKILL.md` and follow all instructions in it exactly. All relative file paths mentioned in that file resolve relative to `/Users/mira/.claude/plugins/marketplaces/Yuan1z0825-nature-skills/plugins/nature-skills/skills/nature-citation/`.

--- a/plugins/nature-skills/commands/nature-data.md
+++ b/plugins/nature-skills/commands/nature-data.md
@@ -1,0 +1,5 @@
+---
+description: >-
+---
+
+Read the skill definition file at `/Users/mira/.claude/plugins/marketplaces/Yuan1z0825-nature-skills/plugins/nature-skills/skills/nature-data/SKILL.md` and follow all instructions in it exactly. All relative file paths mentioned in that file resolve relative to `/Users/mira/.claude/plugins/marketplaces/Yuan1z0825-nature-skills/plugins/nature-skills/skills/nature-data/`.

--- a/plugins/nature-skills/commands/nature-figure.md
+++ b/plugins/nature-skills/commands/nature-figure.md
@@ -1,0 +1,5 @@
+---
+description: >-
+---
+
+Read the skill definition file at `/Users/mira/.claude/plugins/marketplaces/Yuan1z0825-nature-skills/plugins/nature-skills/skills/nature-figure/SKILL.md` and follow all instructions in it exactly. All relative file paths mentioned in that file resolve relative to `/Users/mira/.claude/plugins/marketplaces/Yuan1z0825-nature-skills/plugins/nature-skills/skills/nature-figure/`.

--- a/plugins/nature-skills/commands/nature-paper2ppt.md
+++ b/plugins/nature-skills/commands/nature-paper2ppt.md
@@ -1,0 +1,5 @@
+---
+description: Build a complete but efficient Nature-style Chinese PPTX presentation from a scientific paper, preprint, PDF, article text, abstract, figure legends, or reading notes. Use this skill whenever the user asks to make slides/PPT/PPTX for journal club, group meeting, paper sharing, thesis seminar, lab meeting, department report, or academic presentation from a research paper, not only medical papers. It identifies the paper type and argument, selects only the figures needed for the story, writes Chinese slide content and speaker notes, creates the actual .pptx deck, and runs an explicit self-review/corrective revision loop focused on figure quality, text overflow prevention, and non-template visual design before delivery.
+---
+
+Read the skill definition file at `/Users/mira/.claude/plugins/marketplaces/Yuan1z0825-nature-skills/plugins/nature-skills/skills/nature-paper2ppt/SKILL.md` and follow all instructions in it exactly. All relative file paths mentioned in that file resolve relative to `/Users/mira/.claude/plugins/marketplaces/Yuan1z0825-nature-skills/plugins/nature-skills/skills/nature-paper2ppt/`.

--- a/plugins/nature-skills/commands/nature-polishing.md
+++ b/plugins/nature-skills/commands/nature-polishing.md
@@ -1,0 +1,5 @@
+---
+description: Polish, restructure, or translate academic prose into Nature-leaning English using writing-strategy principles, curated Nature/Nature Communications article patterns, and phrase-level support from Academic Phrasebank. Use whenever the user asks to polish a manuscript paragraph, abstract, introduction, results, discussion, conclusion, title, methods section, or Chinese academic draft for publication-quality English. Also covers LaTeX layout/typesetting (排版) fixes — loose or sparse pages, stranded section headings, figures that don't fill the page or split across pages, "Float too large", multi-panel figure arrangement, and Supplementary Information that looks empty — via references/latex-layout.md.
+---
+
+Read the skill definition file at `/Users/mira/.claude/plugins/marketplaces/Yuan1z0825-nature-skills/plugins/nature-skills/skills/nature-polishing/SKILL.md` and follow all instructions in it exactly. All relative file paths mentioned in that file resolve relative to `/Users/mira/.claude/plugins/marketplaces/Yuan1z0825-nature-skills/plugins/nature-skills/skills/nature-polishing/`.

--- a/plugins/nature-skills/commands/nature-reader.md
+++ b/plugins/nature-skills/commands/nature-reader.md
@@ -1,0 +1,5 @@
+---
+description: Build full-paper Chinese-English side-by-side, figure/table-aware, source-grounded Markdown readers for journal or conference papers from PDF, DOI, arXiv, publisher HTML, or pasted text. Use whenever the user asks to translate or read a paper, make 中英文对照/原文对照/全文翻译解读, extract figures or tables into the right positions, preserve figure/table placement near relevant prose, or keep exact source anchors for every block. This skill must not degrade into a summary-only output unless the user explicitly asks for a summary.
+---
+
+Read the skill definition file at `/Users/mira/.claude/plugins/marketplaces/Yuan1z0825-nature-skills/plugins/nature-skills/skills/nature-reader/SKILL.md` and follow all instructions in it exactly. All relative file paths mentioned in that file resolve relative to `/Users/mira/.claude/plugins/marketplaces/Yuan1z0825-nature-skills/plugins/nature-skills/skills/nature-reader/`.

--- a/plugins/nature-skills/commands/nature-response.md
+++ b/plugins/nature-skills/commands/nature-response.md
@@ -1,0 +1,5 @@
+---
+description: >-
+---
+
+Read the skill definition file at `/Users/mira/.claude/plugins/marketplaces/Yuan1z0825-nature-skills/plugins/nature-skills/skills/nature-response/SKILL.md` and follow all instructions in it exactly. All relative file paths mentioned in that file resolve relative to `/Users/mira/.claude/plugins/marketplaces/Yuan1z0825-nature-skills/plugins/nature-skills/skills/nature-response/`.

--- a/plugins/nature-skills/commands/nature-reviewer.md
+++ b/plugins/nature-skills/commands/nature-reviewer.md
@@ -1,0 +1,5 @@
+---
+description: >-
+---
+
+Read the skill definition file at `/Users/mira/.claude/plugins/marketplaces/Yuan1z0825-nature-skills/plugins/nature-skills/skills/nature-reviewer/SKILL.md` and follow all instructions in it exactly. All relative file paths mentioned in that file resolve relative to `/Users/mira/.claude/plugins/marketplaces/Yuan1z0825-nature-skills/plugins/nature-skills/skills/nature-reviewer/`.

--- a/plugins/nature-skills/commands/nature-writing.md
+++ b/plugins/nature-skills/commands/nature-writing.md
@@ -1,0 +1,5 @@
+---
+description: Draft, restructure, or plan Nature-style manuscript sections from author-provided claims, results, figures, notes, or Chinese drafts. Use when the user wants to write or rebuild an abstract, introduction, related-work, method, experiments, discussion, conclusion, title, or full manuscript argument rather than only polish finished prose.
+---
+
+Read the skill definition file at `/Users/mira/.claude/plugins/marketplaces/Yuan1z0825-nature-skills/plugins/nature-skills/skills/nature-writing/SKILL.md` and follow all instructions in it exactly. All relative file paths mentioned in that file resolve relative to `/Users/mira/.claude/plugins/marketplaces/Yuan1z0825-nature-skills/plugins/nature-skills/skills/nature-writing/`.


### PR DESCRIPTION
## What changed

Adds a `commands/` directory under `plugins/nature-skills/` with one `.md` command file per skill:

- `nature-polishing.md`
- `nature-writing.md`
- `nature-figure.md`
- `nature-reviewer.md`
- `nature-citation.md`
- `nature-data.md`
- `nature-reader.md`
- `nature-response.md`
- `nature-paper2ppt.md`
- `nature-academic-search.md`

## Why

Claude Code discovers slash commands from `.md` files in a plugin's `commands/` directory. Without this directory, installing the plugin via `claude plugin install` does not expose any `/nature-*` slash commands.

Each command file carries the full skill `description` in its frontmatter (used by Claude Code's auto-trigger logic) and its body instructs Claude to load and follow the actual `SKILL.md` from the skill's own subdirectory — so all relative references to `manifest.yaml`, `static/`, and `references/` assets continue to work.

## How to test

1. `claude plugin marketplace add Yuan1z0825/nature-skills`
2. `claude plugin install nature-skills@nature-skills`
3. Type `/nature-polishing` in a new Claude Code session — the command should appear in autocomplete and execute correctly.