### PR TITLE
Use commit based plugin versions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "nature-skills",
-  "version": "cd0d68915b89",
+  "version": "176b5540ed3f",
   "description": "Academic workflow bundles for scientific writing, figures, citations, paper reading, literature search, response letters, presentations, and Chinese invention patent drafting",
   "owner": {
     "name": "Yuan1z0825"
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "nature-skills",
-      "version": "cd0d68915b89",
+      "version": "176b5540ed3f",
       "source": "./",
       "description": "A growing collection of Claude-compatible academic workflow bundles, including figures, manuscript writing and polishing, reviewer assessment, citation retrieval, data availability, paper reading, literature search, response letters, paper-to-presentation workflows, and evidence-grounded Chinese invention patent drafting.",
       "author": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "nature-skills",
-  "version": "1.0.0",
+  "version": "cd0d68915b89",
   "description": "Academic workflow bundles for scientific writing, figures, citations, paper reading, literature search, response letters, presentations, and Chinese invention patent drafting",
   "owner": {
     "name": "Yuan1z0825"
@@ -8,13 +8,21 @@
   "plugins": [
     {
       "name": "nature-skills",
-      "version": "1.0.0",
+      "version": "cd0d68915b89",
       "source": "./",
       "description": "A growing collection of Claude-compatible academic workflow bundles, including figures, manuscript writing and polishing, reviewer assessment, citation retrieval, data availability, paper reading, literature search, response letters, paper-to-presentation workflows, and evidence-grounded Chinese invention patent drafting.",
       "author": {
         "name": "Yuan1z0825"
       },
-      "keywords": ["nature", "academic", "science", "figure", "writing", "citation", "publication"],
+      "keywords": [
+        "nature",
+        "academic",
+        "science",
+        "figure",
+        "writing",
+        "citation",
+        "publication"
+      ],
       "category": "academic"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nature-skills",
   "description": "A growing collection of Claude-compatible academic workflow bundles. Covers scientific figures, manuscript writing and polishing, reviewer assessment, citation retrieval, data availability, paper reading, literature search, response letters, paper-to-PPTX conversion, and evidence-grounded Chinese invention patent drafting. Rules are organized as reusable skill folders with explicit workflows and quality checks.",
-  "version": "cd0d68915b89",
+  "version": "176b5540ed3f",
   "author": {
     "name": "Yuan1z0825",
     "email": ""

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nature-skills",
   "description": "A growing collection of Claude-compatible academic workflow bundles. Covers scientific figures, manuscript writing and polishing, reviewer assessment, citation retrieval, data availability, paper reading, literature search, response letters, paper-to-PPTX conversion, and evidence-grounded Chinese invention patent drafting. Rules are organized as reusable skill folders with explicit workflows and quality checks.",
-  "version": "1.0.0",
+  "version": "cd0d68915b89",
   "author": {
     "name": "Yuan1z0825",
     "email": ""
@@ -9,5 +9,13 @@
   "license": "MIT",
   "homepage": "https://github.com/Yuan1z0825/nature-skills",
   "repository": "https://github.com/Yuan1z0825/nature-skills",
-  "keywords": ["nature", "academic", "science", "figure", "writing", "citation", "publication"]
+  "keywords": [
+    "nature",
+    "academic",
+    "science",
+    "figure",
+    "writing",
+    "citation",
+    "publication"
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -184,7 +184,8 @@ refresh those fields from the current Git commit:
 For an exact release pointer, first commit the skill changes, then run the
 script and commit the manifest refresh. A commit cannot contain its own final
 hash, so the manifest refresh commit normally records the content commit that it
-packages.
+packages. After that second commit, verify with
+`~/miniconda3/python.exe scripts/sync_plugin_version.py --check --ref HEAD~1`.
 
 **Alternative: wrapper/subagent installation**
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ complete bundle, together with the shared support directory used by the newer
 router-style skills. If the skills do not appear immediately, refresh the plugin
 page or start a new Codex session.
 
+To receive later marketplace updates:
+
+```bash
+codex plugin marketplace upgrade
+codex plugin add nature-skills@nature-skills
+```
+
 **Manual local-skill installation**
 
 Codex can also use these folders directly as local skills.
@@ -155,6 +162,29 @@ claude plugin install nature-skills@nature-skills
 
 If the plugin does not appear immediately, refresh the plugin page or start a
 new Claude Code session.
+
+To receive later marketplace updates:
+
+```bash
+claude plugin marketplace update nature-skills
+claude plugin update nature-skills@nature-skills
+```
+
+**Marketplace version refresh for maintainers**
+
+Marketplace installs use the version stored in `.claude-plugin/plugin.json`,
+`.claude-plugin/marketplace.json`, and
+`plugins/nature-skills/.codex-plugin/plugin.json`. Before publishing an update,
+refresh those fields from the current Git commit:
+
+```bash
+~/miniconda3/python.exe scripts/sync_plugin_version.py
+```
+
+For an exact release pointer, first commit the skill changes, then run the
+script and commit the manifest refresh. A commit cannot contain its own final
+hash, so the manifest refresh commit normally records the content commit that it
+packages.
 
 **Alternative: wrapper/subagent installation**
 

--- a/install.md
+++ b/install.md
@@ -391,7 +391,12 @@ git push
 
 The second commit records the short hash of the content commit that it packages.
 This avoids relying on a manually maintained version number while still giving
-the plugin managers a changed version key.
+the plugin managers a changed version key. After the second commit, verify that
+relationship with:
+
+```bash
+~/miniconda3/python.exe scripts/sync_plugin_version.py --check --ref HEAD~1
+```
 
 ---
 

--- a/install.md
+++ b/install.md
@@ -85,6 +85,13 @@ After installation, start a new Codex session if the new skills do not appear
 immediately. The plugin package contains all `nature-*` skills and the shared
 support files they reference.
 
+To update a Codex marketplace installation later:
+
+```bash
+codex plugin marketplace upgrade
+codex plugin add nature-skills@nature-skills
+```
+
 ### 3.2 Manual local-skill installation
 
 Clone the repository:
@@ -147,6 +154,9 @@ cp -R skills/nature-polishing ~/.codex/skills/
 If you installed all skills, re-copy `skills/_shared` and all `skills/nature-*`
 folders after pulling.
 
+For Codex marketplace installs, use the marketplace update commands from
+section 3.1 rather than copying local skill folders.
+
 ### 3.7 Common Codex mistake
 
 Do **not** do this:
@@ -196,6 +206,13 @@ After installation:
 - restart Claude Code or open a fresh session if the plugin does not appear
 - the complete `nature-skills` bundle should be available without manually
   creating wrappers
+
+To update a Claude Code plugin installation later:
+
+```bash
+claude plugin marketplace update nature-skills
+claude plugin update nature-skills@nature-skills
+```
 
 ### 4.2 Wrapper / subagent installation
 
@@ -339,6 +356,43 @@ git pull
 
 If your wrapper points to this stable clone path, no further reinstall step is needed.
 
+For Claude Code marketplace installs, use the marketplace update commands from
+section 4.1.
+
+---
+
+## 4.8 Maintainer release versioning
+
+Plugin managers cache installed bundles by version. If the repository changes
+but the plugin version remains unchanged, Codex or Claude Code may keep using an
+older cached bundle.
+
+Before publishing a marketplace update, refresh all plugin manifest versions
+from the current Git commit:
+
+```bash
+~/miniconda3/python.exe scripts/sync_plugin_version.py
+```
+
+The script updates `.claude-plugin/plugin.json`,
+`.claude-plugin/marketplace.json`, and
+`plugins/nature-skills/.codex-plugin/plugin.json`.
+
+A practical release sequence is:
+
+```bash
+git add skills README.md install.md plugins .claude-plugin scripts
+git commit -m "Update nature skills"
+~/miniconda3/python.exe scripts/sync_plugin_version.py
+git add .claude-plugin plugins/nature-skills/.codex-plugin
+git commit -m "Refresh plugin version"
+git push
+```
+
+The second commit records the short hash of the content commit that it packages.
+This avoids relying on a manually maintained version number while still giving
+the plugin managers a changed version key.
+
 ---
 
 ## 5. Install for other agents
@@ -417,6 +471,9 @@ Then:
 - for Codex local skills, copy `skills/_shared` and the updated folder(s) again
 - for Codex plugin installation, run `codex plugin marketplace upgrade` and reinstall or refresh the plugin as needed
 - for Claude Code wrappers, no reinstall is needed if the wrapper still points to the same clone path
+
+For Claude Code plugin installation, run `claude plugin marketplace update
+nature-skills` and `claude plugin update nature-skills@nature-skills`.
 
 ---
 

--- a/plugins/nature-skills/.codex-plugin/plugin.json
+++ b/plugins/nature-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nature-skills",
-  "version": "1.0.0",
+  "version": "cd0d68915b89",
   "description": "Academic writing, figures, citations, paper reading, literature search, response, presentation, and Chinese invention patent drafting skills.",
   "author": {
     "name": "Yuan1z0825",

--- a/plugins/nature-skills/.codex-plugin/plugin.json
+++ b/plugins/nature-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nature-skills",
-  "version": "cd0d68915b89",
+  "version": "176b5540ed3f",
   "description": "Academic writing, figures, citations, paper reading, literature search, response, presentation, and Chinese invention patent drafting skills.",
   "author": {
     "name": "Yuan1z0825",

--- a/scripts/sync_plugin_version.py
+++ b/scripts/sync_plugin_version.py
@@ -36,8 +36,8 @@ def git_output(*args: str) -> str:
     return result.stdout.strip()
 
 
-def current_commit_version() -> str:
-    return git_output("rev-parse", "--short=12", "HEAD")
+def commit_version(ref: str) -> str:
+    return git_output("rev-parse", "--short=12", ref)
 
 
 def read_json(path: Path) -> OrderedDict[str, Any]:
@@ -74,13 +74,18 @@ def main() -> int:
         help="Use an explicit version instead of the current short Git commit.",
     )
     parser.add_argument(
+        "--ref",
+        default="HEAD",
+        help="Use the short Git commit for this ref when --version is not set.",
+    )
+    parser.add_argument(
         "--check",
         action="store_true",
         help="Only verify that all plugin manifest versions already match.",
     )
     args = parser.parse_args()
 
-    version = (args.version or current_commit_version()).strip()
+    version = (args.version or commit_version(args.ref)).strip()
     if not version:
         print("error: version cannot be empty", file=sys.stderr)
         return 2

--- a/scripts/sync_plugin_version.py
+++ b/scripts/sync_plugin_version.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections import OrderedDict
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TARGETS = (
+    (ROOT / ".claude-plugin" / "plugin.json", (("version",),)),
+    (
+        ROOT / ".claude-plugin" / "marketplace.json",
+        (("version",), ("plugins", 0, "version")),
+    ),
+    (
+        ROOT / "plugins" / "nature-skills" / ".codex-plugin" / "plugin.json",
+        (("version",),),
+    ),
+)
+
+
+def git_output(*args: str) -> str:
+    result = subprocess.run(
+        ("git", *args),
+        cwd=ROOT,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def current_commit_version() -> str:
+    return git_output("rev-parse", "--short=12", "HEAD")
+
+
+def read_json(path: Path) -> OrderedDict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"), object_pairs_hook=OrderedDict)
+
+
+def value_at(data: Any, path: tuple[str | int, ...]) -> Any:
+    node = data
+    for part in path:
+        node = node[part]
+    return node
+
+
+def set_value(data: Any, path: tuple[str | int, ...], value: str) -> None:
+    node = data
+    for part in path[:-1]:
+        node = node[part]
+    node[path[-1]] = value
+
+
+def write_json(path: Path, data: OrderedDict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(data, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Synchronize plugin manifest versions with the repository commit.",
+    )
+    parser.add_argument(
+        "--version",
+        help="Use an explicit version instead of the current short Git commit.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Only verify that all plugin manifest versions already match.",
+    )
+    args = parser.parse_args()
+
+    version = (args.version or current_commit_version()).strip()
+    if not version:
+        print("error: version cannot be empty", file=sys.stderr)
+        return 2
+
+    mismatches: list[str] = []
+    changed: list[Path] = []
+
+    for path, fields in TARGETS:
+        data = read_json(path)
+        local_changed = False
+        for field in fields:
+            old_value = value_at(data, field)
+            if old_value != version:
+                if args.check:
+                    field_name = ".".join(str(part) for part in field)
+                    mismatches.append(f"{path.relative_to(ROOT)}:{field_name}={old_value}")
+                else:
+                    set_value(data, field, version)
+                    local_changed = True
+        if local_changed:
+            write_json(path, data)
+            changed.append(path.relative_to(ROOT))
+
+    if args.check:
+        if mismatches:
+            print(f"expected version: {version}")
+            print("mismatched fields:")
+            for mismatch in mismatches:
+                print(f"  {mismatch}")
+            return 1
+        print(f"all plugin manifest versions match {version}")
+        return 0
+
+    if changed:
+        print(f"plugin manifest version set to {version}")
+        for path in changed:
+            print(f"  updated {path}")
+    else:
+        print(f"plugin manifest version already set to {version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 中文说明

### 原有问题

当前插件清单里的版本号长期固定为 `1.0.0`。当 `skills/` 或插件内容更新后，Codex 和 Claude Code 的插件管理器仍可能根据相同版本号复用旧缓存，导致仓库已经更新但本地插件无法正常更新。

### 本次修复

1. 新增 `scripts/sync_plugin_version.py`，用于把插件清单版本同步为指定 Git ref 的短提交号。
2. 同步更新以下版本字段：`.claude-plugin/plugin.json`、`.claude-plugin/marketplace.json`、`plugins/nature-skills/.codex-plugin/plugin.json`。
3. 在 `README.md` 和 `install.md` 中补充 Codex 与 Claude Code 的插件更新命令，并记录维护者发布时的版本刷新流程。
4. 最终插件清单版本记录为 `176b5540ed3f`，对应本分支中实际引入版本同步逻辑的内容提交。

### 验证

已运行：

```bash
~/miniconda3/python.exe scripts/sync_plugin_version.py --check --ref HEAD~1
claude plugin validate .
```

两个检查均通过。

## English Summary

### Original issue

The plugin manifests kept a fixed `1.0.0` version. After repository updates, Codex and Claude Code could continue reusing an older cached plugin bundle because the visible plugin version did not change.

### What changed

1. Added `scripts/sync_plugin_version.py` to synchronize plugin manifest versions from a Git ref short commit hash.
2. Updated the version fields in `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and `plugins/nature-skills/.codex-plugin/plugin.json`.
3. Documented marketplace update commands for Codex and Claude Code, plus the maintainer release flow.
4. The manifest version is now `176b5540ed3f`, pointing to the content commit that introduced the version synchronization support.

### Validation

Ran:

```bash
~/miniconda3/python.exe scripts/sync_plugin_version.py --check --ref HEAD~1
claude plugin validate .
```

Both checks passed.
