### PR TITLE
nature-writing: confirm intent before drafting (confirmation gate)

### DIFF
--- a/skills/nature-writing/references/chinese-author-workflow.md
+++ b/skills/nature-writing/references/chinese-author-workflow.md
@@ -1,33 +1,13 @@
 # Chinese Author Workflow
 
-Use this reference when the user's input is Chinese, mixed Chinese-English, or
-written as lab notes.
+Deep reference for Chinese, mixed Chinese-English, or lab-note input.
 
-## Translate intent, not syntax
-
-Chinese academic notes often place background, motivation, method and implication
-in one long sentence. Before drafting English, split the note into:
-
-- claim
-- evidence
-- condition
-- comparison
-- implication
-- limitation
-
-Then write English in the order required by the section, not in the order of the
-Chinese sentence.
-
-## Common repairs
-
-| Chinese-draft pattern | Repair |
-|---|---|
-| Broad importance before a clear object | Name the system or problem earlier |
-| Method list before research gap | Move the gap before the method |
-| `显著提高/明显改善` without baseline | Add the comparator or soften the verb |
-| `首次/创新性` without scope | Replace with a bounded novelty claim |
-| Mechanism inferred from correlation | Use `suggests`, `is consistent with`, or ask for mechanistic evidence |
-| Results mixed with implications | Put observation in Results and meaning in Discussion |
+This extends `static/fragments/language/zh-to-en.md`. That fragment already holds
+the base rule (**translate intent, not syntax** — split each note into claim /
+evidence / condition / comparison / implication / limitation, then reorder for
+the section) and the common-repair table. Do not repeat those here. Open this
+file only when the fragment is not enough: for the drafting sequence below and
+the edge-case repairs.
 
 ## Drafting from author notes
 
@@ -40,3 +20,16 @@ Use this sequence:
 
 Do not make the English sound like a literal translation. Make it sound like a
 Nature-style manuscript paragraph supported by the user's facts.
+
+## Edge-case repairs (beyond the fragment table)
+
+These patterns come from Chinese having no tense, no obligatory plural, and a
+topic-comment structure. They are the ones the base table does not cover.
+
+| Chinese-draft pattern | Repair |
+|---|---|
+| No tense marking | Choose tense explicitly: past for what was done/found, present for established facts and what the figure shows |
+| No obligatory plural | Decide singular vs plural per noun; do not leave bare count nouns (`sample` → `samples` / `each sample`) |
+| Stacked `的…的` nested modifiers | Break into a relative clause or a separate sentence; do not pile modifiers before the head noun |
+| Topic-comment opener (`关于X，…`) | Rewrite as subject-verb-object; make the topic the grammatical subject or drop it |
+| Every sentence opening with `本文 / 我们` | Vary openings; lead some sentences with the result or the object, not the agent |

--- a/skills/nature-writing/static/core/output-format.md
+++ b/skills/nature-writing/static/core/output-format.md
@@ -8,6 +8,7 @@ Default output:
 4. `Claim-evidence map:` — for major claims, in the form:
    `Claim: ... | Evidence: ... | Status: supported / needs evidence / inferred`
 5. `Why this structure:` — `2-4` short bullets on the structural choices made.
+6. `To redirect me:` — one line inviting targeted feedback, e.g. "Name the paragraph or claim that is off and I will revise only that, keeping the rest." This sets up the targeted revision loop (workflow step 9) instead of a full rewrite.
 
 For Chinese-author notes, provide polished English first, then brief Chinese notes explaining major structural choices.
 

--- a/skills/nature-writing/static/core/stance.md
+++ b/skills/nature-writing/static/core/stance.md
@@ -4,7 +4,7 @@
 
 - Do not invent results, mechanisms, references, methods, novelty, sample sizes, statistics, or limitations.
 - Write the argument before writing the sentences.
-- If essential evidence is missing, write a placeholder or ask for the missing input instead of filling the gap.
+- Prefer confirming over guessing. If essential input is missing or the framing is ambiguous, do not silently draft a full section on an assumed premise — confirm first (see Intake below) instead of filling the gap.
 
 ## Reader workflow
 
@@ -28,4 +28,4 @@ Identify before writing:
 - **target journal or word limit** if provided
 - **terminology**: on first contact with the material, extract the recurring methods, models, datasets, metrics, abbreviations, and notation into a Terminology Ledger and reuse the canonical forms across every section (see `../../../_shared/core/terminology-ledger.md`)
 
-If any of `core claim`, `evidence`, or `boundary` is absent, expose the gap before drafting. You may still produce a scaffold with explicit placeholders.
+If any of `core claim`, `evidence`, or `boundary` is absent, or the framing is ambiguous, run the **confirmation gate** in `workflow.md` (step 3b) before drafting the full section: echo back your one-sentence argument and key assumptions, ask at most 2–3 targeted questions, and wait for the user. A wrong assumed premise surfaced only in the final notes wastes the entire draft. If the user prefers to proceed without answering, you may still produce a scaffold with explicit placeholders.

--- a/skills/nature-writing/static/core/workflow.md
+++ b/skills/nature-writing/static/core/workflow.md
@@ -1,6 +1,6 @@
 # Writing workflow
 
-Run these steps for any drafting or restructuring task. Steps 1-3 are planning, step 3b is an alignment gate, 4-6 are drafting, 7-8 are checking.
+Run these steps for any drafting or restructuring task. Steps 1-3 are planning, step 3b is an alignment gate, 4-6 are drafting, 7-8 are checking, step 9 is the revision loop.
 
 ## 1. Build a one-sentence argument
 
@@ -28,7 +28,9 @@ Drafting a full section on a wrong assumed premise wastes the whole draft and is
 
 - **One-sentence argument** (from step 1) — the single most important thing to get right. Echo it back in plain language.
 - **Plan**: detected paper type, section(s), journal / word limit, and the paragraph map from step 3 as a short bullet list.
-- **Key assumptions**: anything you inferred rather than were told — especially what the core contribution is, who the audience is, and which result to lead with. Mark each clearly as an assumption.
+- **Key terminology**: the canonical forms locked in the Terminology Ledger (step 1b) for the main methods, models, datasets, and metrics. Surface them here so the user can fix a wrong canonical term before it propagates through every section.
+- **Primary reader**: who the draft is optimized for, and which of the five reader questions it leads with (relevance / novelty / trust / reuse / meaning — see `../../../_shared/core/reader-workflow.md`). Getting the lead question wrong is a common silent cause of "this is not what I meant".
+- **Key assumptions**: anything else you inferred rather than were told — especially what the core contribution is and which result to lead with. Mark each clearly as an assumption.
 - **At most 2–3 targeted questions**, only on genuinely ambiguous, high-leverage points (how to frame the core contribution, target audience / journal, which result leads). Do not ask about things the user already made clear, and do not pad the list to reach three.
 
 Then wait for the user to confirm or correct before drafting the full section.
@@ -61,3 +63,13 @@ For full reverse-outlining, open `references/paragraph-flow.md`.
 ## 8. Return prose plus notes
 
 Output the draft together with explicit notes on assumptions, missing inputs, and where evidence is needed. See `output-format.md`.
+
+## 9. Revise by targeted edit, not full rewrite
+
+When the user reacts to a draft, "this is not what I meant" is usually local — a wrong claim, a mis-framed paragraph, the wrong result leading. Do not silently re-draft the whole section: a full rewrite breaks the paragraphs that were already right and forces the user to re-check everything.
+
+- Change **only** the paragraphs or claims the user flagged; keep the rest verbatim.
+- If a requested fix genuinely forces a structural change (reordering sections, moving a claim across paragraphs), say so and confirm the new structure before applying it, rather than restructuring silently.
+- Keep the Terminology Ledger (step 1b) stable across revisions unless the user changes a term; never let a revision reintroduce a variant of a locked term.
+- After revising, re-run only the checks relevant to what changed (steps 5-7), not the whole workflow.
+- If the user's redirection reveals the original premise was wrong, return to the confirmation gate (step 3b) instead of patching prose on a broken premise.

--- a/skills/nature-writing/static/core/workflow.md
+++ b/skills/nature-writing/static/core/workflow.md
@@ -35,10 +35,11 @@ Drafting a full section on a wrong assumed premise wastes the whole draft and is
 
 Then wait for the user to confirm or correct before drafting the full section.
 
-Two shortcuts:
+Shortcuts:
 
 - **Skip the gate** when the core claim, evidence, and boundary are all clearly given and there is no real ambiguity in framing. In that case just state the one-sentence argument in a single line (per the router) and proceed.
-- **Style, not substance**: if the user says the voice or style "is not mine", do not keep guessing — ask for one short sample of their own writing to match.
+- **Depth dial**: for a full section or a major rewrite, offer to deliver the outline first (the paragraph map from step 3) and expand to full prose only after the user approves it. Reacting to an outline is far cheaper than reacting to full prose. Skip this for short or single-paragraph requests.
+- **Style, not substance**: if the user says the voice or style "is not mine", do not keep guessing — ask for one short sample of their own writing, then calibrate to it. From the sample, match: typical sentence length and rhythm, hedging level (`demonstrate` vs `may` / `could`), preferred connectives and transitions, person (first-person `we` vs passive), and terminology / abbreviation choices. Match the voice, not the content — never reuse the sample's claims or facts.
 
 ## 4. Draft from evidence outward
 

--- a/skills/nature-writing/static/core/workflow.md
+++ b/skills/nature-writing/static/core/workflow.md
@@ -1,6 +1,6 @@
 # Writing workflow
 
-Run these eight steps for any drafting or restructuring task. Steps 1-3 are planning, 4-6 are drafting, 7-8 are checking.
+Run these steps for any drafting or restructuring task. Steps 1-3 are planning, step 3b is an alignment gate, 4-6 are drafting, 7-8 are checking.
 
 ## 1. Build a one-sentence argument
 
@@ -21,6 +21,22 @@ Pick the section structure from the relevant `section/*.md` fragment and, if nee
 Each paragraph must do exactly one job from: context, gap, approach, result, comparison, mechanism, implication, limitation.
 
 If a paragraph carries two jobs, split it before drafting.
+
+## 3b. Confirmation gate — align before drafting
+
+Drafting a full section on a wrong assumed premise wastes the whole draft and is the main reason output "does not match what I meant". Before writing full prose, show the user a short alignment block and **stop for confirmation**:
+
+- **One-sentence argument** (from step 1) — the single most important thing to get right. Echo it back in plain language.
+- **Plan**: detected paper type, section(s), journal / word limit, and the paragraph map from step 3 as a short bullet list.
+- **Key assumptions**: anything you inferred rather than were told — especially what the core contribution is, who the audience is, and which result to lead with. Mark each clearly as an assumption.
+- **At most 2–3 targeted questions**, only on genuinely ambiguous, high-leverage points (how to frame the core contribution, target audience / journal, which result leads). Do not ask about things the user already made clear, and do not pad the list to reach three.
+
+Then wait for the user to confirm or correct before drafting the full section.
+
+Two shortcuts:
+
+- **Skip the gate** when the core claim, evidence, and boundary are all clearly given and there is no real ambiguity in framing. In that case just state the one-sentence argument in a single line (per the router) and proceed.
+- **Style, not substance**: if the user says the voice or style "is not mine", do not keep guessing — ask for one short sample of their own writing to match.
 
 ## 4. Draft from evidence outward
 


### PR DESCRIPTION
## Problem

A recurring complaint with `nature-writing` is that the draft "does not match what I meant". The root cause is the current default flow: given thin or ambiguous input, the skill **drafts a full section on an assumed premise** and only surfaces that assumption in the final notes — after the whole draft is written. If the assumed core claim / framing / emphasis is wrong, the entire draft is wasted, and the user has to articulate intent against a long piece of prose they didn't want.

## Change

Flip the default from *draft-then-list-gaps* to *confirm-then-draft*, with guards against over-asking. Touches only two core fragments:

- **`workflow.md`** — new **step 3b "Confirmation gate"**, sitting between planning (1–3) and drafting (4–6). Before writing full prose, the skill shows a short alignment block and stops:
  - the one-sentence argument (echoed in plain language),
  - the plan (paper type, section(s), journal/word limit, paragraph map),
  - key assumptions, each marked as an assumption,
  - **at most 2–3 targeted questions**, only on genuinely ambiguous, high-leverage points (how to frame the contribution, audience/journal, which result leads).
  
  Two shortcuts keep it from being annoying: **skip the gate** when core claim/evidence/boundary are all clear and unambiguous; and when the complaint is **voice/style** rather than substance, ask for a short writing sample to match instead of guessing.

- **`stance.md`** — the intake section now routes a missing core claim / evidence / boundary, or ambiguous framing, through the gate instead of silently scaffolding with placeholders. The placeholder-scaffold path remains available if the user prefers to proceed without answering.

## Why this is low-risk

- No behavior change for well-specified requests (the skip shortcut handles them).
- Confined to the writing skill's `static/core/` fragments; no manifest, router, or schema changes.
- Reacting to a concrete strawman (one-sentence argument + plan) is far cheaper for authors than answering abstract intent questions, and catches premise errors before the expensive drafting step.

Xinrui Ma