### PR TITLE
Add 2025 Nature Communications empirical reference layer to four skills

### DIFF
--- a/skills/nature-figure/manifest.yaml
+++ b/skills/nature-figure/manifest.yaml
@@ -49,6 +49,8 @@ references:
       path: references/common-patterns.md
     - condition: "real Nature page archetypes: schematic-led composites, dark image plates, clinical triptychs, asymmetric hero layouts"
       path: references/nature-2026-observations.md
+    - condition: writing or auditing figure/table legend text — Fig. N | title, panel style, stats in legend, Source Data boilerplate, attribution
+      path: references/figure-legend-conventions.md
     - condition: "end-to-end walkthroughs: bars, trends, heatmaps"
       path: references/tutorials.md
     - condition: "radar, 3D sphere, fill_between, scatter patterns"

--- a/skills/nature-figure/references/figure-legend-conventions.md
+++ b/skills/nature-figure/references/figure-legend-conventions.md
@@ -1,0 +1,71 @@
+# Figure & Table Legend Conventions (Nat Commun 2025 CS/AI corpus)
+
+Use this file when **writing or auditing the legend text** of a figure or table.
+It complements `nature-2026-observations.md`, which covers visual/layout
+archetypes; this file covers the *words* of the caption. Distilled from a 2025
+set of 20 open-access *Nature Communications* computer-science / AI papers
+(legend conventions were consistent across all research articles). **Do not copy
+source wording.**
+
+## Legend structure — the fixed skeleton
+
+1. **`Fig. N | ` + a bold noun-phrase overall title** that names the whole
+   figure. Common openers: *Overview of …*, *Comparison of …*, *Performance of
+   …*, or a finding phrase. No terminal full stop required on the title.
+2. **`a / b / c …` panels, each described in present tense, telegraphic style**,
+   often subject-less: *"a Comparison of the four EMS paradigms. b Distributions
+   of WSIs and patches in the pre-training dataset."*
+3. **Statistics written into the legend**: sample size `n=`, error type, and
+   test — *"mean ± 95% CI (n = 1373) … one-way ANOVA with Tukey correction."*
+4. **Data-availability boilerplate** at the end: *"Source data are provided as a
+   Source Data file."*
+
+## Tense
+
+- Visual facts in **present** tense — *"are shown as cyan sticks"*, *"depicts"*.
+- Methods/how-it-was-made in **past** tense — *"was performed"*, *"was adopted
+  from"*.
+
+## Self-containment rule
+
+A legend must be readable away from the body text. Put colour/shape mappings,
+sample size, and key numeric anchors (PDB id, RMSD, units) into the legend
+itself — *"tRNA-Glu of E. coli (PDB: 2DER chain C). 76 nt, RMSD: 2.88 Å."*;
+*"Grey boxes designate what is defined by the benchmark, and orange boxes
+indicate what is unique to each solution."*
+
+## Advanced: the claim-closing sentence
+
+A legend's final sentence may advance an argument rather than only describe —
+*"…indicating that these co-folding models are not predicting poses based on
+physics but rather learning patterns in global structures."* Use sparingly, and
+only when the panel actually supports the inference.
+
+## Review/Perspective legends
+
+When a figure aggregates others' published systems, each sub-panel gets a
+one-line characterisation (often past tense, describing prior work) and the
+legend carries an attribution line — *"adapted with permission from refs. 16,17
+… by Springer Nature."* Include the permission/attribution string for any
+adapted panel.
+
+## Table captions
+
+Same shape: **`Table N | ` + noun phrase**, with detailed specs pointed to
+Methods — *"Table 1 | … Detailed specifications are provided in the Methods
+section."* Benchmark/framework papers lean on tables (multi-metric results) more
+than figures.
+
+## Length & title limits (consistency with style-guardrails)
+
+- Keep a Nature-style legend `<= 300` words.
+- Keep the `Fig. N |` title short and nominal; no numbers/results in the figure
+  *title* line (numbers live in the panels and stats).
+
+## 中文图注要点
+
+- 结构铁律:`图 N | 加粗名词短语总题` → `a/b/c` 现在时电报式分面 → 统计(n、误差、检验)写进图注 → "Source data are provided as a Source Data file." 套语。
+- 时态:视觉事实用现在时,制作方法用过去时。
+- 自足:颜色/形状映射、样本量、关键数值(PDB/RMSD/单位)都写进图注,使其脱离正文可读。
+- 进阶:图注末句可给一句推断结论,但须确有面板支撑。
+- 综述图注:聚合他人系统时逐子图一句话定性,并标注"adapted with permission from refs… by Springer Nature"授权。

--- a/skills/nature-polishing/manifest.yaml
+++ b/skills/nature-polishing/manifest.yaml
@@ -71,6 +71,8 @@ references:
   on_demand:
     - condition: needs Nature/Nature Communications article-level patterns for abstracts, intros, Results openings, Discussion, conclusions, titles
       path: references/published-article-patterns.md
+    - condition: empirical 2025 Nat Commun diction calibration — connector frequencies, the significantly red line, hedge/booster/tense word choices
+      path: references/nat-comms-2025-diction.md
     - condition: needs section-specific move orders or phrase patterns
       path: references/section-moves.md
     - condition: needs hedging, transition, evidence, limitation, future-work phrases

--- a/skills/nature-polishing/references/nat-comms-2025-diction.md
+++ b/skills/nature-polishing/references/nat-comms-2025-diction.md
@@ -1,0 +1,73 @@
+# Nature Communications 2025 — Diction & Connector Calibration
+
+Use this file during the sentence-level polish pass when you want **empirical,
+quantified word-choice calibration** to back up `style-guardrails.md` and
+`published-article-patterns.md`. The preferences below are measured from a 2025
+reading set of 20 open-access *Nature Communications* computer-science / AI
+articles. They are calibration data, not rules to apply blindly — a discipline
+or a specific journal house style overrides them. **Do not copy source wording.**
+
+## 1. Connectors — observed preference order
+
+句首大写连接词词频(5 篇子集合计):
+`However` **51** ≫ `Furthermore` 22 · `Therefore` 19 · `Overall`/`Notably` 16 · `In addition` 13 · `In contrast` 6 · `Moreover` 4 · `Importantly` 2.
+
+- **However** carries turns, gap-opening, and surprises — do not scatter weaker
+  alternatives where `However` is idiomatic.
+- For addition, prefer **Furthermore** over **Moreover** (22 vs 4 here).
+- Cause/close with **Therefore**; summarise a block with **Overall / In summary / In conclusion**.
+- Reserve **Notably / Importantly / Interestingly / Surprisingly** for the
+  paragraph's key finding, not as routine sentence openers.
+
+## 2. Boosters — the `significantly` red line
+
+- **`significantly` appears 0 times in the corpus.** When a draft leans on
+  "significantly (better/higher/improved)", first check it is a *statistical*
+  claim with a test behind it; otherwise replace with **notably /
+  substantially / considerably / markedly**.
+- This extends the `style-guardrails.md` overclaim list: treat blanket
+  intensifiers as a smell, and attach every booster to a number or a test.
+
+## 3. Hedges — concentrated, not sprinkled
+
+- Primary hedges are **may** and **potential**; `might / could / likely` are
+  secondary. They cluster in meaning/Discussion sentences, not in Results
+  reporting. Pattern marker: *"Encoding these mechanisms **may** help further
+  improve the performance."*
+- Keep Results sentences assertive + numeric; move the hedge to the
+  interpretation sentence.
+
+## 4. Achievement verbs — the house vocabulary
+
+Frequent, defensible when backed by data: **achieve · demonstrate · outperform
+· superior · robust · generalizable · comparable**. When the result is *weaker*
+than a baseline, state it honestly and reframe with **comparable** +
+concession: *"**Despite the smaller scale** of our pre-training data …, the
+**comparable** performance highlights the effectiveness."* Do not upgrade
+`comparable` to `superior`.
+
+## 5. Tense & voice (polish-pass checks)
+
+- Background / property = present; specific operation = past; figure
+  description = present. Flag accidental past-tense for a standing property
+  (*"CataPro demonstrates…"* not *"demonstrated"* when stating a capability).
+- Active **we** for narrative and claims; passive for apparatus/method only.
+  Flag passive over-use that hides the agent in claim sentences.
+
+## 6. Sentence-skeleton phrases (calibrated to 2025 corpus)
+
+- Abstract hinge: `Here we show/present X (FULL NAME, abbr.), a … that …`
+- Gap: `However, … remains a challenge` / `the scarcity of … hinders …` /
+  `Without X, Y cannot be quantified`.
+- Result close: `These findings collectively affirm/confirm that …`
+- Significance (soft promise, not a guarantee): `promises to / offers
+  potential / paves the way`.
+- Title: no number, no result — keep digits for the abstract.
+
+## 7. 中文润色要点
+
+- 连接词:转折/制造空白优先"然而";递进偏"此外/进一步"(对应 Furthermore);
+  因果用"因此";收束用"总体而言/综上"。
+- 慎用"显著"——英文 `significantly` 在本语料 0 次。无统计检验支撑时改"明显/大幅/相当/尤为"。
+- 对冲(可能/提示/有望)集中在意义句,结果句保持带数字的肯定陈述。
+- 战绩措辞(实现/证明/优于/稳健/可泛化/相当)需有数据支撑;弱于对手时用"相当"+"尽管规模更小"客观化,不拔高为"优于"。

--- a/skills/nature-reader/manifest.yaml
+++ b/skills/nature-reader/manifest.yaml
@@ -41,3 +41,5 @@ references:
       path: references/output-spec.md
     - condition: answering follow-up questions with source-grounded citations
       path: references/grounding-rules.md
+    - condition: labelling the argumentative function of each section (gap/contribution/result/limits) and genre tells as a reading aid
+      path: references/article-anatomy.md

--- a/skills/nature-reader/references/article-anatomy.md
+++ b/skills/nature-reader/references/article-anatomy.md
@@ -1,0 +1,57 @@
+# Article Anatomy — a reading aid (Nat Commun 2025 CS/AI corpus)
+
+Use this file as a **reading aid** while building the bilingual reader, to label
+the *argumentative function* of each block so the reader can locate the gap, the
+contribution, the decisive result, and the self-contained figure legends. It is
+distilled from a 2025 set of 20 open-access *Nature Communications* computer
+science / AI papers across genres.
+
+> This is an aid for **locating structure**, not a license to summarise. The
+> `core/principles.md` contract still holds: translate every block for meaning,
+> keep the bilingual side-by-side, and never degrade to a summary-only output.
+> Use the function labels to help a reader navigate, e.g. in a short orientation
+> note, not to replace the full translation.
+
+## Where each function lives
+
+- **Abstract = a funnel.** Read it as five moves: field value → gap (almost
+  always after **However**) → hinge `Here we show/present X` → one quantified
+  result → significance. The hinge sentence is the fastest way to state what the
+  paper actually contributes.
+- **Introduction = hook → gap → contribution.** Gap signal words to spot:
+  **However / remains / Unfortunately / underexplored / the scarcity of … /
+  Without X, Y cannot be …**. The contribution is the explicit `Here we… / In
+  this work, we…` sentence, often with a `(Fig. 1)` pointer.
+- **Results = conclusion-first.** Each paragraph opens with the judgement; the
+  figure call (`Fig. Xa`, or `Figure X shows…`) and the numbers follow.
+  Subheadings are often conclusions or method names, so the subheading list
+  alone sketches the evidence ladder.
+- **Figure/Table legends are self-contained.** `Fig. N | bold noun title`, then
+  `a/b/c` panels, with `n=`, error type, and test written in. A legend's last
+  sentence sometimes advances a claim (*"…indicating that the models are not
+  predicting poses based on physics…"*) — flag it; it is interpretation, not
+  description.
+- **Discussion = restate contribution → why credible → wider meaning → limits
+  (`Another limitation…` / `remains to be tested`) → future work.** The limits
+  sentence is where the paper bounds its own claim.
+
+## Genre tells (so the reader frames the paper correctly)
+
+- **Research article**: own data, IMRaD, `we` + passive.
+- **Review**: chapters by topic/modality synthesising others' citations, little
+  own data, closes with `Conclusions and outlook`.
+- **Perspective**: history/era hook, numbered argument, normative `X should…`,
+  roadmap close.
+- **Comment**: first-person `I`, rhetorical-question opening, analogy/history,
+  no IMRaD, no figures.
+- **Benchmark/framework**: the gap is "the field lacks an agreed standard";
+  tables dominate; stresses community / reproducibility / versioning.
+
+## 中文阅读提示
+
+- 给读者的导航可标注每段功能(背景/空白/贡献/结果/局限),帮助快速抓论证骨架;
+  但**不得**因此省略逐段对照翻译或退化为摘要。
+- "然而 / 仍是挑战 / 鲜有研究 / 缺乏 / 没有 X 就无法 Y"是空白信号词;`Here we / 本文`
+  之后是作者自述贡献。
+- 图注通常自足(含 n、误差、检验);若图注末句给出推断结论,标注为"解读"而非"描述"。
+- 先判定体裁(研究论文/综述/观点/评论/基准),再据此理解其组织方式与语气。

--- a/skills/nature-writing/manifest.yaml
+++ b/skills/nature-writing/manifest.yaml
@@ -75,6 +75,8 @@ references:
   on_demand:
     - condition: needs section-level structure, argument order, or published-article patterns
       path: references/article-architecture.md
+    - condition: genre-aware 2025 Nat Commun empirical structure, quantified connector/diction preferences, or research/review/perspective/comment/benchmark differences
+      path: references/nat-comms-2025-corpus.md
     - condition: drafting/revising abstract; especially challenge-contribution forms
       path: references/abstract.md
     - condition: drafting/revising a Nature-family broad-audience summary paragraph or introduction opening

--- a/skills/nature-writing/references/nat-comms-2025-corpus.md
+++ b/skills/nature-writing/references/nat-comms-2025-corpus.md
@@ -1,0 +1,95 @@
+# Nature Communications 2025 — Empirical Drafting Patterns (CS/AI corpus)
+
+Use this file when drafting or restructuring a manuscript and you want
+**genre-aware, evidence-backed structure calibration** beyond the generic
+section fragments. The patterns below are distilled from a 2025 reading set of
+20 open-access *Nature Communications* articles in computer science / AI
+(research articles plus Perspective, Comment, Review, and benchmark/framework
+papers). **Do not copy their wording.** Use the patterns to decide structure,
+move order, and signal words; the short quoted fragments are pattern markers,
+not text to reuse.
+
+> Companion of `references/article-architecture.md` (generic move orders) and
+> `nature-polishing/references/published-article-patterns.md`. This file adds
+> the 2025 CS/AI evidence layer, quantified word preferences, and genre splits.
+
+## 0. Decide the genre first — it picks the skeleton
+
+| Genre | Skeleton |
+|---|---|
+| Research article | Abstract funnel → Intro (hook→gap→`Here we`) → Results (conclusion-first) → Discussion → Methods |
+| Benchmark / framework | Same, but the *gap is "the field has no agreed standard"*; tables dominate; stress community / reproducibility / versioning |
+| Review | Trend declaration → `This Perspective/Review explores…` → topic/modality chapters synthesising others' work → `Conclusions and outlook` |
+| Perspective | History/era hook → numbered argument points → normative `X should…` advice → roadmap close |
+| Comment | First-person singular, rhetorical question opening, analogy/history, no IMRaD, no abstract/figures |
+
+State the detected genre before drafting; the rest of this file assumes a
+research article unless noted.
+
+## 1. Title
+
+- Four recurring shapes, chosen by intent:
+  - Noun phrase, method-led (most common): *AlphaFold prediction of structural ensembles of disordered proteins*
+  - Declarative claim (the selling point is a finding): *Dendrites endow artificial neural networks with accurate, robust and parameter-efficient learning*
+  - `System name: function` colon form (brands a tool/model): *CodonTransformer: a multispecies codon optimizer…*
+  - Gerund/question for benchmark or Perspective: *Benchmarking large language models for…*; *Does provable absence of barren plateaus imply classical simulability?*
+- An evaluative adjective often pre-loads the claim: *robust*, *generalizable*, *data-driven*.
+- Almost never contains a number or a result; keep digits for the abstract.
+- Prepositional chain carries "what + how + where": *…discovery and engineering **with** deep learning **using** CataPro*.
+
+## 2. Abstract — the funnel
+
+Five moves, one paragraph, 4–11 sentences (research longer, benchmark/active-learning tighter):
+
+1. Field value / why-it-matters (present tense, often subject-less assertion)
+2. Gap, almost always opened by **However** + a nominalised pain point
+3. Hinge sentence: `Here we show/present/introduce X (FULL NAME, abbr.), a … that …`
+4. One hard quantified result (a factor, %, or accuracy), past tense
+5. Significance + optional resource link (GitHub)
+
+Pattern markers: gap *"However, DE can be inefficient when mutations exhibit … epistatic behavior."*; hinge *"Here, we show that traditional fine-tuning outperforms zero- or few-shot LLMs in most tasks."*; close *"Our findings suggest…"* / *"These results indicate…"*.
+
+## 3. Introduction
+
+- **Hook**, three forms: importance declaration (*"The biological brain is remarkable in its ability to…"*); definition framing (*"Protein engineering is an optimization problem, where…"*); domain-then-obstacle (benchmark default: broad use → *"Despite its promises, progress … is impeded due to the absence of … benchmarks."*).
+- **Gap** signal words cluster tightly: **However / remains / Unfortunately / underexplored / the scarcity of … hinder / Without X, Y cannot be …**. High-end move: quantify the scarcity — *"merely 124 (3.0%) have … structures in the PDB."*
+- **Contribution**: `Here we…` / `In this work, we…`, usually with a `(Fig. 1)` pointer; multiple contributions as `First… Second… Finally…`.
+- Make the **choice of system/problem explicit** — *"We chose this model system because…"* — this satisfies the "科学问题要科学" expectation: the question must be motivated, not assumed.
+
+## 4. Results narrative
+
+- **Subheadings** are either a conclusion sentence or a noun/gerund phrase naming the method — *"CodonTransformer generates DNA sequences with natural-like distributions"*, *"Exploring the biocatalytic synthesis landscape of McbA"*. Avoid neutral *Experiment 1 / Dataset* labels.
+- **Conclusion-first**: the paragraph opens with the judgement, evidence and figure call follow — *"Interestingly, wt-McbA displayed a tolerance to multiple 'unprotected' functional groups…"*
+- **Figure callouts**, two shapes: figure-led (*"Figure 3 (a) depicts the action distributions…"*) and trailing parenthetical (*"…synthesize 11 pharmaceutical compounds (Fig. 2C)"*).
+- **Numbers** come as absolute + relative + direction — *"from 323.4 to 297.3 … representing an improvement of 8.8%"*; closing roll-up *"These findings collectively affirm that…"*.
+- Paragraph-advance engine: `With [previous result], we next …` / `To <goal>, we <did> (Fig. X).`
+
+## 5. Transitions (observed frequencies, 5-article subset)
+
+`However` 51 ≫ `Furthermore` 22 · `Therefore` 19 · `Overall`/`Notably` 16 · `In addition` 13 · `In contrast` 6 · `Moreover` 4.
+- **However** is the workhorse for turning, gap-opening, and surprise.
+- Prefer **Furthermore** over **Moreover** for addition (22 vs 4).
+- `Notably / Importantly / Interestingly / Surprisingly` flag the key finding; `Overall / In summary` close a block.
+
+## 6. Syntax & register
+
+- Tense: background/properties = present; what-we-did = past; current meaning/figure description = present.
+- Voice: active **we** for narrative and claims; passive for apparatus/method (*"The optical convolutional layer is implemented by integrating…"*).
+- Hedge (`may / suggest / likely / potential`) only in meaning sentences; boosters are rationed to the key finding.
+
+## 7. Genre-difference cheatsheet
+
+| Axis | Research | Review | Perspective | Comment |
+|---|---|---|---|---|
+| Data | own figures/numbers | synthesis of others' citations | argument, no experiments | none |
+| Person | `we` + passive | `we` + survey | `we/our` throughout | first-person `I` |
+| Stance | assert findings | weigh + outlook | argue + normative `should` | rhetorical, value-driven |
+| Close | Discussion + limits | `Conclusions and outlook` + governance call | roadmap / conditions | call to action |
+
+## 8. 中文迁移要点
+
+- 保留信息链:`现象（现在时）→ 然而/目前仍/尚不清楚 → 本文提出 X → 带一个硬核数字的结果 → 意义升华`。
+- 标题按体裁切模板:方法文用名词短语、卖点文用陈述句、工具用"系统名:功能"、论辩文可用疑问句;**标题不放数字与结论**。
+- gap 必带信号词(然而/不幸的是/仍是挑战/鲜有研究/缺乏);高级写法用数字量化稀缺。
+- 贡献句显式给出选题理由("之所以选该体系,是因为…"),呼应"科学问题要科学"。
+- 对冲词(可能/提示/很可能)只用于意义句;少用"显著"——对应英文 `significantly` 在本语料 0 次,改用"明显/大幅/相当"(notably/substantially/considerably)。


### PR DESCRIPTION
## What

Adds one on-demand `references/` file to each of four skills, distilling **writing and figure conventions** from a 2025 reading set of **20 open-access Nature Communications computer-science / AI articles** (research, Perspective, Review, Comment, and benchmark/framework genres). Each file is hooked into its skill's `manifest.yaml` `references.on_demand` table.

| Skill | New reference | Adds |
|---|---|---|
| nature-writing | `nat-comms-2025-corpus.md` | genre-first skeletons, title shapes, abstract funnel, gap signal words, conclusion-first Results, genre-difference cheatsheet |
| nature-polishing | `nat-comms-2025-diction.md` | quantified connector frequencies (However 51 ≫ Furthermore 22 > Moreover 4), the `significantly`=0 red line, hedge/booster/tense calibration |
| nature-reader | `article-anatomy.md` | per-section argumentative-function labels as a reading aid |
| nature-figure | `figure-legend-conventions.md` | legend *text* conventions, complementing the visual-only `nature-2026-observations.md` |

## Why

The existing pattern references (`published-article-patterns.md`, `nature-2026-observations.md`) are strong on structure and visual layout but predate a focused 2025 CS/AI corpus and carry no quantified diction data or figure-legend text rules. These files add that empirical layer.

## Notes / safety

- **Additive only**: no existing file changed except a single one-line manifest hook per skill (8 files, +304 lines, 0 deletions).
- Each reference states its corpus provenance, carries a **do-not-copy-wording** disclaimer, and ends with a Chinese-transfer section (consistent with the repo's bilingual references).
- `nature-reader`'s file is explicitly framed as a reading aid that **does not override** the skill's no-summary output contract.
- All four `manifest.yaml` files validated as parseable YAML after the hook.

Xinrui Ma
