### PR TITLE
Add Claude Code install docs and OpenRouter schematic generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,25 @@
-<h1 align="center">Nature Skills</h1>
+<div align="center">
+  <h1>Nature Skills</h1>
+  <p><strong>面向全球 AI 学者的科研 Skill 库</strong></p>
+  <p>
+    文献检索 · 论文精读 · Nature 写作 · 审稿模拟 · 图表制作 · 引用审计 · 返修回复
+  </p>
+  <p>
+    <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-2ea44f"></a>
+    <a href="#安装"><img alt="Install" src="https://img.shields.io/badge/install-Codex-111827"></a>
+    <a href="#技能索引"><img alt="Skills" src="https://img.shields.io/badge/skills-16-0ea5e9"></a>
+    <a href="README_EN.md"><img alt="Language" src="https://img.shields.io/badge/language-中文%20%7C%20English-1f6feb"></a>
+  </p>
+  <p>
+    <a href="#安装"><strong>立即安装</strong></a>
+    · <a href="#技能索引">技能索引</a>
+    · <a href="#共享设计原则">设计原则</a>
+    · <a href="#新增技能">贡献方式</a>
+    · <a href="README_EN.md">English</a>
+  </p>
+</div>
 
-<p align="center">
-  面向全球 AI 学者的可复用科研技能库
-</p>
-
-<p align="center">
-  <a href="README_EN.md">English</a> · <strong>中文</strong>
-</p>
-
-<p align="center">
-  <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-2ea44f"></a>
-  <img alt="Language" src="https://img.shields.io/badge/language-中文%20%7C%20English-1f6feb">
-  <img alt="Skills" src="https://img.shields.io/badge/skills-16%20research%20skills-0ea5e9">
-  <img alt="Codex" src="https://img.shields.io/badge/Codex-ready-111827">
-</p>
-
-<p align="center">
-  <a href="#安装">立即安装</a> ·
-  <a href="#技能索引">技能索引</a> ·
-  <a href="#共享设计原则">设计原则</a> ·
-  <a href="#新增技能">贡献方式</a> ·
-  <a href="README_EN.md">English</a>
-</p>
+---
 
 * 大家好，我是 nature skills 的创立者袁一哲。感谢大家持续关注 `nature-skills`。我们在抖音更新了很多视频教程，大家可以根据名称检索查看，希望真心能够帮助到大家。
 * 如果你有任何需求，欢迎提交 issue；如果我们认为该需求有意义且可行，会尽量推进实现。我们也欢迎 PR，但请按照本文后面的贡献格式提交，方便更高效地审核与合并。

--- a/README.md
+++ b/README.md
@@ -1,6 +1,27 @@
-# nature-skills (面向全球AI学者收录SKILL)
+<h1 align="center">Nature Skills</h1>
 
-[English](README_EN.md) | 中文
+<p align="center">
+  面向全球 AI 学者的可复用科研技能库
+</p>
+
+<p align="center">
+  <a href="README_EN.md">English</a> · <strong>中文</strong>
+</p>
+
+<p align="center">
+  <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-2ea44f"></a>
+  <img alt="Language" src="https://img.shields.io/badge/language-中文%20%7C%20English-1f6feb">
+  <img alt="Skills" src="https://img.shields.io/badge/skills-16%20research%20skills-0ea5e9">
+  <img alt="Codex" src="https://img.shields.io/badge/Codex-ready-111827">
+</p>
+
+<p align="center">
+  <a href="#安装">立即安装</a> ·
+  <a href="#技能索引">技能索引</a> ·
+  <a href="#共享设计原则">设计原则</a> ·
+  <a href="#新增技能">贡献方式</a> ·
+  <a href="README_EN.md">English</a>
+</p>
 
 * 大家好，我是 nature skills 的创立者袁一哲。感谢大家持续关注 `nature-skills`。我们在抖音更新了很多视频教程，大家可以根据名称检索查看，希望真心能够帮助到大家。
 * 如果你有任何需求，欢迎提交 issue；如果我们认为该需求有意义且可行，会尽量推进实现。我们也欢迎 PR，但请按照本文后面的贡献格式提交，方便更高效地审核与合并。

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 <div align="center">
   <h1>Nature Skills</h1>
-  <p><strong>面向全球 AI 学者的科研 Skill 库</strong></p>
+  <p><strong>面向全球学者的科研 Skill 库</strong></p>
   <p>
     文献检索 · 论文精读 · Nature 写作 · 审稿模拟 · 图表制作 · 引用审计 · 返修回复
   </p>
   <p>
     <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-2ea44f"></a>
-    <a href="#安装"><img alt="Install" src="https://img.shields.io/badge/install-Codex-111827"></a>
+    <a href="#安装"><img alt="Install" src="https://img.shields.io/badge/install-Claude%20Code%20%7C%20Codex-111827"></a>
     <a href="#技能索引"><img alt="Skills" src="https://img.shields.io/badge/skills-16-0ea5e9"></a>
     <a href="README_EN.md"><img alt="Language" src="https://img.shields.io/badge/language-中文%20%7C%20English-1f6feb"></a>
   </p>
   <p>
-    <a href="#安装"><strong>立即安装</strong></a>
+    <a href="#安装">立即安装</a>
     · <a href="#技能索引">技能索引</a>
     · <a href="#共享设计原则">设计原则</a>
     · <a href="#新增技能">贡献方式</a>
@@ -64,6 +64,74 @@
 ## 安装
 
 `nature-skills` 是一组围绕 `SKILL.md` 组织的可复用技能包。`skills/` 下的每个顶层技能目录都是一个可安装单元，例如 `nature-*`；`skills/_shared/` 是共享内容目录，安装完整仓库时也需要保留。
+
+### Claude Code 安装方式
+
+Claude Code 不能直接使用 `scripts/update-codex-skills.sh`，因为这个脚本只负责同步到 Codex 的 `~/.codex/skills/`。用于 Claude Code 时，推荐保留一个稳定的本地 clone，再用 subagent 或 slash command 指向真实的 `skills/*/SKILL.md`。这样不会破坏技能目录结构，也能继续读取 `references/`、`static/`、`manifest.yaml`、脚本、资产和 `skills/_shared/`。
+
+如果还没有安装 Claude Code：
+
+```bash
+npm install -g @anthropic-ai/claude-code
+claude
+```
+
+先把仓库 clone 到一个稳定路径：
+
+```bash
+mkdir -p ~/ai-skills
+cd ~/ai-skills
+git clone https://github.com/Yuan1z0825/nature-skills.git
+```
+
+推荐方式：为常用技能创建 Claude Code subagent wrapper。以 `nature-reader` 为例：
+
+```bash
+mkdir -p ~/.claude/agents
+cat > ~/.claude/agents/nature-reader.md <<'EOF'
+---
+name: nature-reader
+description: Use for Chinese-English paper reading, figure-aware translation, and source-grounded paper notes.
+---
+
+When invoked, first read `~/ai-skills/nature-skills/skills/nature-reader/SKILL.md` and follow it as the governing workflow.
+Read supporting files from `~/ai-skills/nature-skills/skills/nature-reader/` and `~/ai-skills/nature-skills/skills/_shared/` only when needed.
+Do not replace this skill with a generic paper-reading response.
+EOF
+```
+
+然后开启新的 Claude Code 会话，直接请求使用这个 subagent：
+
+```text
+Use the nature-reader subagent to turn this paper into a Chinese-English Markdown reader.
+```
+
+如果你更喜欢 slash command，也可以创建命令 wrapper：
+
+```bash
+mkdir -p ~/.claude/commands
+cat > ~/.claude/commands/nature-reader.md <<'EOF'
+Read `~/ai-skills/nature-skills/skills/nature-reader/SKILL.md` first and follow it strictly.
+Read directly needed supporting files from `~/ai-skills/nature-skills/skills/nature-reader/` and `~/ai-skills/nature-skills/skills/_shared/`.
+
+$ARGUMENTS
+EOF
+```
+
+在 Claude Code 中使用：
+
+```text
+/nature-reader 把这篇论文做成中英文对照的完整 Markdown reader。
+```
+
+安装其他技能时，把示例中的 `nature-reader` 换成对应目录名即可，例如 `nature-polishing`、`nature-writing`、`nature-reviewer`、`nature-response` 或 `nature-figure`。后续更新只需要：
+
+```bash
+cd ~/ai-skills/nature-skills
+git pull
+```
+
+只要 wrapper 仍然指向这个稳定 clone 路径，就不需要重复复制技能文件。
 
 ### Codex 推荐安装方式
 
@@ -118,21 +186,6 @@ https://github.com/Yuan1z0825/nature-skills.git
 
 关键规则：保留完整目录结构。请复制或引用整个技能文件夹，而不是只复制 `SKILL.md`，因为许多技能依赖 `references/`、`static/`、`manifest.yaml`、脚本、资产或共享文件。
 
-### 手动安装
-
-不推荐手动复制；如果你确实不想运行脚本，请复制 `skills/` 下所有顶层目录，而不是只复制 `nature-*`：
-
-```bash
-git clone https://github.com/Yuan1z0825/nature-skills.git
-cd nature-skills
-mkdir -p ~/.codex/skills
-for d in skills/*/; do
-  name="${d%/}"
-  name="${name##*/}"
-  rsync -a --delete "$d" "$HOME/.codex/skills/$name/"
-done
-```
-
 安装脚本不会自动安装 Python 依赖。需要使用相关脚本或 MCP 服务时，再按需安装：
 
 ```bash
@@ -172,11 +225,11 @@ skills/
     └── references/...
 ```
 
-### 非 Codex 场景
+### 其他 agent 场景
 
-用于 Claude Code 或其他 agent 时，建议保留一个稳定的仓库 clone，再创建轻量 subagent、slash command 或 custom prompt wrapper，指向真实的 `skills/*/SKILL.md`，并保留 `skills/_shared/`。
+用于其他 agent 时，建议保留一个稳定的仓库 clone，再创建轻量 subagent、slash command 或 custom prompt wrapper，指向真实的 `skills/*/SKILL.md`，并保留 `skills/_shared/`。
 
-手动或非 Codex 使用时：
+手动或其他 agent 使用时：
 
 1. 将完整技能目录复制到你的 prompt library 或项目中。
 2. 保留 `SKILL.md`、`manifest.yaml`、`static/`、`references/`、脚本、资产和需要的 `skills/_shared/` 文件。
@@ -192,7 +245,7 @@ skills/
 
 | 技能 | 状态 | 用途 | 触发词 |
 |-------|--------|---------|-----------------|
-| [`nature-figure`](skills/nature-figure/README.md) | Stable | 面向 Nature / 高影响力期刊的 Python 或 R 投稿级科研图工作流，内置 figures4papers demo | “Nature figure”, “投稿级图片”, “publication plot”, “scientific figure”, “figures4papers” |
+| [`nature-figure`](skills/nature-figure/README.md) | Stable | 面向 Nature / 高影响力期刊的 Python 或 R 投稿级科研图工作流，内置 figures4papers demo，并支持通过 OpenRouter GPT Image 2 生成论文示意图草稿 | “Nature figure”, “投稿级图片”, “publication plot”, “scientific figure”, “figures4papers”, “论文示意图”, “GPT Image 2” |
 | [`nature-polishing`](skills/nature-polishing/README.md) | Stable | 将学术文本润色、重构或翻译为 Nature 风格英文 | “Nature style”, “润色”, “academic writing”, “论文英文” |
 | [`nature-writing`](skills/nature-writing/README.md) | Draft | 起草 Nature 风格手稿章节，并重建论文论证 | “Nature writing”, “写摘要”, “写引言”, “manuscript draft”, “论文写作” |
 | [`nature-reviewer`](skills/nature-reviewer/README.md) | Draft | 从审稿人视角模拟 Nature 风格评审，输出三份 reviewer reports 和综合意见 | “Nature reviewer”, “预投稿评审”, “reviewer report”, “审稿人视角评估” |

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,27 +1,25 @@
-<h1 align="center">Nature Skills</h1>
+<div align="center">
+  <h1>Nature Skills</h1>
+  <p><strong>Reusable research skills for AI scholars worldwide</strong></p>
+  <p>
+    Literature Search · Paper Reading · Nature Writing · Reviewer Simulation · Figures · Citation Audit · Revision Response
+  </p>
+  <p>
+    <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-2ea44f"></a>
+    <a href="#installation"><img alt="Install" src="https://img.shields.io/badge/install-Codex-111827"></a>
+    <a href="#skill-index"><img alt="Skills" src="https://img.shields.io/badge/skills-16-0ea5e9"></a>
+    <a href="README.md"><img alt="Language" src="https://img.shields.io/badge/language-English%20%7C%20中文-1f6feb"></a>
+  </p>
+  <p>
+    <a href="#installation"><strong>Install</strong></a>
+    · <a href="#skill-index">Skill Index</a>
+    · <a href="#shared-design-principles">Design Principles</a>
+    · <a href="#adding-a-skill">Contributing</a>
+    · <a href="README.md">中文</a>
+  </p>
+</div>
 
-<p align="center">
-  Reusable Codex skills for AI scholars worldwide
-</p>
-
-<p align="center">
-  <strong>English</strong> · <a href="README.md">中文</a>
-</p>
-
-<p align="center">
-  <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-2ea44f"></a>
-  <img alt="Language" src="https://img.shields.io/badge/language-English%20%7C%20中文-1f6feb">
-  <img alt="Skills" src="https://img.shields.io/badge/skills-16%20research%20skills-0ea5e9">
-  <img alt="Codex" src="https://img.shields.io/badge/Codex-ready-111827">
-</p>
-
-<p align="center">
-  <a href="#installation">Install</a> ·
-  <a href="#skill-index">Skill Index</a> ·
-  <a href="#shared-design-principles">Design Principles</a> ·
-  <a href="#adding-a-skill">Contributing</a> ·
-  <a href="README.md">中文</a>
-</p>
+---
 
 - Hello everyone, I am Yizhe Yuan, the founder of `nature-skills`. Thank you for
   following this project. We have published many video tutorials on Douyin; you

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,6 +1,27 @@
-# nature-skills (Collecting SKILLs for AI Scholars Worldwide)
+<h1 align="center">Nature Skills</h1>
 
-English | [中文](README.md)
+<p align="center">
+  Reusable Codex skills for AI scholars worldwide
+</p>
+
+<p align="center">
+  <strong>English</strong> · <a href="README.md">中文</a>
+</p>
+
+<p align="center">
+  <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-2ea44f"></a>
+  <img alt="Language" src="https://img.shields.io/badge/language-English%20%7C%20中文-1f6feb">
+  <img alt="Skills" src="https://img.shields.io/badge/skills-16%20research%20skills-0ea5e9">
+  <img alt="Codex" src="https://img.shields.io/badge/Codex-ready-111827">
+</p>
+
+<p align="center">
+  <a href="#installation">Install</a> ·
+  <a href="#skill-index">Skill Index</a> ·
+  <a href="#shared-design-principles">Design Principles</a> ·
+  <a href="#adding-a-skill">Contributing</a> ·
+  <a href="README.md">中文</a>
+</p>
 
 - Hello everyone, I am Yizhe Yuan, the founder of `nature-skills`. Thank you for
   following this project. We have published many video tutorials on Douyin; you

--- a/README_EN.md
+++ b/README_EN.md
@@ -6,12 +6,12 @@
   </p>
   <p>
     <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-2ea44f"></a>
-    <a href="#installation"><img alt="Install" src="https://img.shields.io/badge/install-Codex-111827"></a>
+    <a href="#installation"><img alt="Install" src="https://img.shields.io/badge/install-Claude%20Code%20%7C%20Codex-111827"></a>
     <a href="#skill-index"><img alt="Skills" src="https://img.shields.io/badge/skills-16-0ea5e9"></a>
     <a href="README.md"><img alt="Language" src="https://img.shields.io/badge/language-English%20%7C%20中文-1f6feb"></a>
   </p>
   <p>
-    <a href="#installation"><strong>Install</strong></a>
+    <a href="#installation">Install</a>
     · <a href="#skill-index">Skill Index</a>
     · <a href="#shared-design-principles">Design Principles</a>
     · <a href="#adding-a-skill">Contributing</a>
@@ -98,6 +98,83 @@
 such as `nature-*`; `skills/_shared/` contains shared content and should also be
 kept when installing the complete repository.
 
+### Claude Code Installation
+
+Claude Code cannot use `scripts/update-codex-skills.sh` directly because that
+script only syncs skills into Codex's `~/.codex/skills/`. For Claude Code, keep a
+stable local clone and create a subagent or slash command wrapper that points to
+the real `skills/*/SKILL.md`. This preserves the skill directory structure and
+lets the workflow keep using `references/`, `static/`, `manifest.yaml`, scripts,
+assets, and `skills/_shared/`.
+
+If Claude Code is not installed yet:
+
+```bash
+npm install -g @anthropic-ai/claude-code
+claude
+```
+
+Clone the repository to a stable path:
+
+```bash
+mkdir -p ~/ai-skills
+cd ~/ai-skills
+git clone https://github.com/Yuan1z0825/nature-skills.git
+```
+
+Recommended method: create a Claude Code subagent wrapper for the skills you use
+often. Example for `nature-reader`:
+
+```bash
+mkdir -p ~/.claude/agents
+cat > ~/.claude/agents/nature-reader.md <<'EOF'
+---
+name: nature-reader
+description: Use for Chinese-English paper reading, figure-aware translation, and source-grounded paper notes.
+---
+
+When invoked, first read `~/ai-skills/nature-skills/skills/nature-reader/SKILL.md` and follow it as the governing workflow.
+Read supporting files from `~/ai-skills/nature-skills/skills/nature-reader/` and `~/ai-skills/nature-skills/skills/_shared/` only when needed.
+Do not replace this skill with a generic paper-reading response.
+EOF
+```
+
+Then start a new Claude Code session and ask for the subagent explicitly:
+
+```text
+Use the nature-reader subagent to turn this paper into a Chinese-English Markdown reader.
+```
+
+If you prefer a slash command, create a command wrapper instead:
+
+```bash
+mkdir -p ~/.claude/commands
+cat > ~/.claude/commands/nature-reader.md <<'EOF'
+Read `~/ai-skills/nature-skills/skills/nature-reader/SKILL.md` first and follow it strictly.
+Read directly needed supporting files from `~/ai-skills/nature-skills/skills/nature-reader/` and `~/ai-skills/nature-skills/skills/_shared/`.
+
+$ARGUMENTS
+EOF
+```
+
+Use it inside Claude Code:
+
+```text
+/nature-reader Turn this paper into a full Chinese-English side-by-side Markdown reader.
+```
+
+To install other skills, replace `nature-reader` with the target directory name,
+such as `nature-polishing`, `nature-writing`, `nature-reviewer`,
+`nature-response`, or `nature-figure`. To update later:
+
+```bash
+cd ~/ai-skills/nature-skills
+git pull
+```
+
+As long as the wrapper still points to this stable clone path, no repeated file
+copy is needed.
+
 ### Recommended Codex Installation
 
 Use the repository script to install or update Codex skills. It syncs every
@@ -156,22 +233,6 @@ If the skill needs shared files, install skills/_shared as well.
 Key rule: keep the full directory structure. Many skills depend on
 `references/`, `static/`, `manifest.yaml`, scripts, assets, or shared files.
 
-### Manual Installation
-
-Manual copy is not recommended. If you do not want to run the script, copy every
-top-level directory under `skills/`:
-
-```bash
-git clone https://github.com/Yuan1z0825/nature-skills.git
-cd nature-skills
-mkdir -p ~/.codex/skills
-for d in skills/*/; do
-  name="${d%/}"
-  name="${name##*/}"
-  rsync -a --delete "$d" "$HOME/.codex/skills/$name/"
-done
-```
-
 The installer does not install Python dependencies automatically. Install them
 only when you need the corresponding scripts or MCP services:
 
@@ -214,13 +275,13 @@ skills/
     └── references/...
 ```
 
-### Non-Codex Scenarios
+### Other Agent Scenarios
 
-For Claude Code or other agents, keep a stable repository clone and create a
-lightweight subagent, slash command, or custom prompt wrapper that points to the
-real `skills/*/SKILL.md` files. Preserve `skills/_shared/`.
+For other agents, keep a stable repository clone and create a lightweight
+subagent, slash command, or custom prompt wrapper that points to the real
+`skills/*/SKILL.md` files. Preserve `skills/_shared/`.
 
-For manual or non-Codex use:
+For manual or other-agent use:
 
 1. Copy complete skill directories into your prompt library or project.
 2. Preserve `SKILL.md`, `manifest.yaml`, `static/`, `references/`, scripts,
@@ -239,7 +300,7 @@ The current `skills/` directory contains the following triggerable skills.
 
 | Skill | Status | Purpose | Example Triggers |
 |---|---|---|---|
-| [`nature-figure`](skills/nature-figure/README.md) | Stable | Submission-grade Python or R scientific figure workflow for Nature / high-impact journals, with a figures4papers-style demo | "Nature figure", "submission-grade figure", "publication plot", "scientific figure", "figures4papers" |
+| [`nature-figure`](skills/nature-figure/README.md) | Stable | Submission-grade Python or R scientific figure workflow for Nature / high-impact journals, with a figures4papers-style demo and OpenRouter GPT Image 2 schematic-draft generation | "Nature figure", "submission-grade figure", "publication plot", "scientific figure", "figures4papers", "paper schematic", "GPT Image 2" |
 | [`nature-polishing`](skills/nature-polishing/README.md) | Stable | Polish, restructure, or translate academic prose into Nature-style English | "Nature style", "polishing", "academic writing", "English manuscript" |
 | [`nature-writing`](skills/nature-writing/README.md) | Draft | Draft Nature-style manuscript sections and rebuild a paper argument | "Nature writing", "write an abstract", "write introduction", "manuscript draft", "paper writing" |
 | [`nature-reviewer`](skills/nature-reviewer/README.md) | Draft | Simulate Nature-style reviewer assessment from the reviewer perspective, returning three reviewer reports and a synthesis | "Nature reviewer", "pre-submission review", "reviewer report", "reviewer-perspective assessment" |

--- a/skills/nature-figure/README.md
+++ b/skills/nature-figure/README.md
@@ -1,12 +1,30 @@
 # `nature-figure` 技能
 
-`nature-figure` 用于生成可投稿级科研图，面向 Nature 级期刊和高影响力学术场景，同时支持 Python 与 R 两条绘图路径。
+`nature-figure` 用于生成可投稿级科研图，面向 Nature 级期刊和高影响力学术场景，同时支持 Python 与 R 两条绘图路径。若用户明确需要 AI 生成论文示意图、机制图或 graphical abstract，也支持通过 OpenRouter Images API 调用 `openai/gpt-image-2` 生成概念示意图草稿。
 
-该技能从“图件契约”开始，而不是直接套模板。开始绘图前，必须明确核心结论、证据层级、图件原型、后端选择、期刊与导出约束、统计说明和 source-data 可追溯性。只有在科学逻辑明确后，才使用绘图模板。
+该技能从“图件契约”开始，而不是直接套模板。开始绘图前，必须明确核心结论、证据层级、图件原型、后端选择、期刊与导出约束、统计说明和 source-data 可追溯性。第一次使用绘图路径时，用户选择 Python 或 R 后会写入默认偏好；后续默认沿用该后端，除非用户明确切换。只有在科学逻辑明确后，才使用绘图模板。
 
 Python 路径主要使用 `matplotlib`、`seaborn`、`subplot_mosaic` 和 `statsmodels`，适合精细低层布局控制。R 路径使用 `ggplot2`、`patchwork`、`ComplexHeatmap`、`ggrepel`、`svglite`、`cairo_pdf` 和 `ragg`。如果使用私有模板集合，不得在面向用户的输出中暴露私有路径、文件名或来源信息。
 
 该技能参考了 [figures4papers](https://github.com/ChenLiu-1996/figures4papers) 中来自 *Nature Machine Intelligence* 和顶级机器学习/生物信息学论文的生产脚本。原始 demo 脚本和预览图也打包在 `assets/figures4papers/` 中，供模式级改写使用。
+
+---
+
+## OpenRouter AI 示意图生成
+
+当用户明确要求“用 OpenRouter / GPT Image 2 生成论文示意图、机制示意图、graphical abstract”时，走独立 AI-schematic route，不需要先询问 Python 或 R。
+
+```bash
+export OPENROUTER_API_KEY="sk-or-..."
+python skills/nature-figure/scripts/generate_openrouter_schematic.py \
+  --title "Paper title" \
+  --abstract-file abstract.txt \
+  --panel-map "left: problem; center: proposed mechanism; right: validated outcome" \
+  --outdir outputs/schematic \
+  --basename graphical_abstract
+```
+
+这个功能生成的是概念视觉草稿，不应作为定量数据面板。正式投稿前，建议检查科学元素是否被幻觉扩写，并把关键文字、箭头和标注重画成可编辑矢量对象。
 
 ---
 
@@ -54,6 +72,9 @@ nature-figure/
 ├── SKILL.md                     # 短路由：后端 gate，加载 fragments
 ├── manifest.yaml                # always_load core + backend axis + 按需 references
 ├── README.md                    # 本文件
+├── scripts/
+│   ├── generate_openrouter_schematic.py
+│   └── nature_figure_backend.py
 ├── static/
 │   ├── core/                    # 始终加载
 │   │   ├── contract.md          # 图件契约、后端 gate、互斥规则、运行时缺失处理
@@ -75,6 +96,7 @@ nature-figure/
     ├── api.md                   # PALETTE 常量、helper 函数签名
     ├── design-theory.md         # 字体、色彩理论、布局、导出策略
     ├── common-patterns.md       # 可复用代码模式
+    ├── openrouter-image-generation.md
     ├── tutorials.md             # 端到端教程
     ├── chart-types.md           # radar、3D sphere、scatter、fill_between、log-scale
     └── demos.md                 # figures4papers demo map 与路由指南
@@ -84,7 +106,7 @@ nature-figure/
 
 ## 后端与图件契约规则
 
-除非用户已经指定后端，否则先询问用户选择 **Python 或 R**。如果用户需要推荐，参考 `references/backend-selection.md`。
+绘图任务优先使用用户已经指定的后端；如果没有指定，则读取 `scripts/nature_figure_backend.py` 保存的默认偏好。第一次使用且尚未保存偏好时，再询问用户选择 **Python 或 R**，并把答案保存为后续默认后端。如果用户需要推荐，参考 `references/backend-selection.md`。
 
 后端一旦选定，绘图、预览、导出和视觉 QA 都必须只使用该后端。如果所选运行时或包缺失，应停止并报告 blocker；不要用另一种语言临时替代。该规则双向适用：不能用 Python 替代 R，也不能用 R 替代 Python。
 

--- a/skills/nature-figure/SKILL.md
+++ b/skills/nature-figure/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nature-figure
 description: >-
-  Submission-grade Nature/high-impact journal figure workflow for Python or R. Use whenever the user asks to create, revise, audit, or polish manuscript figures, multi-panel scientific plots, figures4papers-style matplotlib plots, or journal-ready SVG/PDF/TIFF outputs, especially for Nature-family or other high-impact journals. Before plotting, define the figure's conclusion, evidence logic, export needs, and review risks. If the user has not chosen Python or R, ask "Python or R?" and stop. Use only the selected backend for figure generation, previewing, exporting, and QA. Supports matplotlib/seaborn and ggplot2/patchwork/ComplexHeatmap. Not for dashboards or Illustrator/Figma-first infographics. Also trigger on general academic-writing figure needs even without the word "Nature", such as making figures/plots for a paper, scientific/academic plotting, data visualization for a manuscript, and Chinese phrasings like 论文配图、学术写作配图、科研绘图、科研作图、画图、作图、出图、论文图表、可视化.
+  Submission-grade Nature/high-impact journal figure workflow for Python or R, plus optional OpenRouter GPT Image 2 manuscript schematic generation when the user explicitly asks for AI-generated graphical abstracts, concept schematics, mechanism diagrams, or paper schematic illustrations. Use whenever the user asks to create, revise, audit, or polish manuscript figures, multi-panel scientific plots, figures4papers-style matplotlib plots, journal-ready SVG/PDF/TIFF outputs, or OpenRouter/API-generated schematic drafts, especially for Nature-family or other high-impact journals. Before plotting or image generation, define the figure's conclusion, evidence logic, export needs, and review risks. For plotting tasks, honor an explicit Python/R choice, otherwise reuse the saved nature-figure backend preference; if no preference exists, ask once whether the user prefers Python or R and save that answer for future calls. For explicit OpenRouter/GPT Image 2 schematic generation, do not ask Python or R; use the AI-schematic route. Supports matplotlib/seaborn, ggplot2/patchwork/ComplexHeatmap, and OpenRouter Images API drafts. Not for dashboards or Illustrator/Figma-first infographics. Also trigger on general academic-writing figure needs even without the word "Nature", such as making figures/plots for a paper, scientific/academic plotting, data visualization for a manuscript, AI-generated paper schematics, and Chinese phrasings like 论文配图、学术写作配图、科研绘图、科研作图、画图、作图、出图、论文图表、可视化、论文示意图、机制示意图、图形摘要.
 version: 2.0.0
 author: Community contribution, refactored into static/dynamic layers
 ---
@@ -17,7 +17,20 @@ Do not try to apply the figure logic from memory or from this router. Always loa
 
 ## Routing protocol
 
-Follow these five steps every time the skill is invoked.
+Follow these steps every time the skill is invoked.
+
+### 0. Check for the OpenRouter AI-schematic route
+
+If the user explicitly asks to generate a manuscript schematic, graphical abstract, mechanism diagram, concept illustration, or paper schematic with OpenRouter, GPT Image 2, an image-generation API, or similar wording, do **not** ask "Python or R?". This is a non-plotting AI-schematic route.
+
+For this route:
+
+1. Read [manifest.yaml](manifest.yaml) and the `always_load` files.
+2. Read [references/openrouter-image-generation.md](references/openrouter-image-generation.md).
+3. Use [scripts/generate_openrouter_schematic.py](scripts/generate_openrouter_schematic.py) when the user wants a real API call or a reproducible payload.
+4. Treat output as a draft schematic / graphical abstract, not as a quantitative data panel. Do not invent experimental values, author logos, institutional marks, or unsupported mechanisms.
+
+Only continue to the Python/R backend gate for plotting, charting, data visualization, or manuscript figure assembly tasks that are not explicit OpenRouter AI image-generation requests.
 
 ### 1. Load the manifest and the core layer
 
@@ -27,12 +40,17 @@ Also read every file listed under `always_load` (`static/core/contract.md` and `
 
 ### 2. Resolve the backend — a blocking gate
 
-Backend selection blocks everything else. Decide the `backend` value only from an explicit user choice or a clearly language-specific input file/workflow:
+Backend selection blocks plotting tasks, but it should not annoy the same user forever. Decide the `backend` value in this order:
+
+1. If the current request explicitly chooses Python or R, use that backend and save it with `scripts/nature_figure_backend.py set python` or `scripts/nature_figure_backend.py set r`.
+2. If the request provides a clearly language-specific input file/workflow, use that backend and save it.
+3. Otherwise run `scripts/nature_figure_backend.py get`. If it returns `python` or `r`, use the saved preference.
+4. If no saved preference exists, ask exactly one concise question — **Python or R? I will remember this as your default.** — and stop. After the user answers, save the answer before proceeding.
 
 - `python` — matplotlib / seaborn.
 - `r` — ggplot2 / patchwork / ComplexHeatmap.
 
-If the user has **not** explicitly chosen, ask exactly one concise question — **Python or R?** — and stop. Do not default, guess, generate mock data, or write scripts before the answer. Only recommend a backend when the user explicitly asks you to choose; then use `references/backend-selection.md`, state the reason, and proceed. Once selected, the backend is **exclusive** for all drawing, previewing, exporting, and visual QA (see `core/contract.md`).
+Do not guess or choose a backend by aesthetics alone. Only recommend a backend when the user explicitly asks you to choose; then use `references/backend-selection.md`, state the reason, save the selected backend, and proceed. Once selected, the backend is **exclusive** for all drawing, previewing, exporting, and visual QA (see `core/contract.md`). This gate does not apply to the explicit OpenRouter AI-schematic route above.
 
 ### 3. Load the matching backend fragment
 

--- a/skills/nature-figure/manifest.yaml
+++ b/skills/nature-figure/manifest.yaml
@@ -3,27 +3,49 @@ version: 2.0.0
 description: >
   Declarative manifest for the static/dynamic split. SKILL.md uses this to
   decide which fragments to load for a given figure request. The main axis is
-  the plotting backend (Python or R), which is a blocking gate: it must be
-  chosen explicitly before any figure is drawn. The large body of design,
-  API, pattern, and QA material stays in on-demand references.
+  the plotting backend (Python or R). The first plotting use should establish
+  a saved user preference; later tasks reuse that preference unless the user
+  explicitly changes it. The large body of design, API, pattern, and QA
+  material stays in on-demand references.
 
 always_load:
   # Skill-local core (figure does not use the prose-oriented _shared layer)
   - static/core/contract.md
   - static/core/stance.md
 
+routes:
+  openrouter_image_generation:
+    detect: |
+      Use this route only when the user explicitly asks for OpenRouter, GPT
+      Image 2, image-generation API output, AI-generated paper schematics,
+      graphical abstracts, concept illustrations, or mechanism diagrams. This
+      route skips the Python/R backend gate because it generates a raster/vector
+      image draft through an external image API rather than plotting data.
+    reference: references/openrouter-image-generation.md
+    script: scripts/generate_openrouter_schematic.py
+
+preference:
+  backend_script: scripts/nature_figure_backend.py
+  config_env: NATURE_FIGURE_CONFIG
+  default_config: ~/.config/nature-skills/nature-figure.json
+  behavior: |
+    For plotting tasks, first honor an explicit Python/R choice, then a clearly
+    language-specific input workflow, then the saved preference returned by the
+    backend script. If none exists, ask the user once and save the answer.
+
 axes:
   backend:
     detect: |
-      BLOCKING GATE. Determine the plotting backend from an explicit user
-      choice or a clearly language-specific input file/workflow. If the user
-      has NOT explicitly chosen Python or R, ask exactly one concise question —
-      "Python or R?" — and stop. Do not default, do not guess, do not generate
-      mock data or scripts before the answer. Only recommend a backend when the
-      user explicitly asks you to choose; in that case use
-      references/backend-selection.md, state the reason, then proceed.
-      Once selected, the backend is exclusive for all drawing, previewing,
-      exporting, and visual QA.
+      BLOCKING GATE WITH PERSISTED PREFERENCE. Determine the plotting backend
+      from an explicit user choice, a clearly language-specific input
+      file/workflow, or the saved preference returned by
+      scripts/nature_figure_backend.py get. If no saved preference exists, ask
+      exactly one concise question — "Python or R? I will remember this as your
+      default." — and stop. Save the answer with the backend preference script
+      before proceeding. Only recommend a backend when the user explicitly asks
+      you to choose; in that case use references/backend-selection.md, state the
+      reason, save the selected backend, then proceed. Once selected, the
+      backend is exclusive for all drawing, previewing, exporting, and visual QA.
     values:
       python:  static/fragments/backend/python.md
       r:       static/fragments/backend/r.md
@@ -49,6 +71,8 @@ references:
       path: references/common-patterns.md
     - condition: "real Nature page archetypes: schematic-led composites, dark image plates, clinical triptychs, asymmetric hero layouts"
       path: references/nature-2026-observations.md
+    - condition: "OpenRouter/GPT Image 2 route: AI-generated graphical abstracts, mechanism diagrams, paper schematics, or concept illustrations"
+      path: references/openrouter-image-generation.md
     - condition: writing or auditing figure/table legend text — Fig. N | title, panel style, stats in legend, Source Data boilerplate, attribution
       path: references/figure-legend-conventions.md
     - condition: "end-to-end walkthroughs: bars, trends, heatmaps"

--- a/skills/nature-figure/references/backend-selection.md
+++ b/skills/nature-figure/references/backend-selection.md
@@ -1,10 +1,16 @@
 # Backend Selection
 
-At the start of a figure task, ask the user to choose **Python or R** if they have
-not already specified a backend. This is a blocking gate: stop after asking and wait
-for the user's answer. Do not infer Python just because the task involves simulation,
-NumPy-like data, or custom layout, and do not infer R just because the task is biological
-or omics-adjacent.
+At the start of a plotting task, resolve the user's preferred backend in this order:
+
+1. explicit Python/R choice in the current request;
+2. clearly language-specific input file or workflow;
+3. saved preference from `scripts/nature_figure_backend.py get`;
+4. if no preference exists, ask **Python or R? I will remember this as your default.**
+
+Stop after asking and wait for the user's answer. After the answer, save it with
+`scripts/nature_figure_backend.py set python` or `scripts/nature_figure_backend.py set r`.
+Do not infer Python just because the task involves simulation, NumPy-like data, or
+custom layout, and do not infer R just because the task is biological or omics-adjacent.
 
 Use the decision table only in either of these cases:
 
@@ -21,8 +27,9 @@ Use the decision table only in either of these cases:
 | The user provides an R template collection or an existing R plotting workflow | The user wants a self-contained script with matplotlib/seaborn/statsmodels and no R dependency |
 | Heatmap annotations are biologically rich and multi-layered | Image panels and quantitative panels need tight pixel/axis control |
 
-If either backend can do the job, honor the user's preference. Do not switch
-backends for aesthetics alone.
+If either backend can do the job, honor the user's saved preference. Do not switch
+backends for aesthetics alone. If the user explicitly switches backend, save the new
+preference.
 
 ## Backend exclusivity rule
 

--- a/skills/nature-figure/references/openrouter-image-generation.md
+++ b/skills/nature-figure/references/openrouter-image-generation.md
@@ -1,0 +1,109 @@
+# OpenRouter Image Generation for Manuscript Schematics
+
+Use this reference only when the user explicitly asks to generate a paper schematic, graphical abstract, mechanism diagram, or concept illustration through OpenRouter / GPT Image 2 / an image-generation API.
+
+Do not use this route for quantitative plots, data panels, heatmaps, microscopy plates, blots, or figure assembly unless the user explicitly wants an AI-generated draft illustration. Keep data-driven figures in the Python or R route.
+
+## Source
+
+OpenRouter's dedicated Images API uses:
+
+- model discovery: `GET https://openrouter.ai/api/v1/images/models`
+- generation: `POST https://openrouter.ai/api/v1/images`
+- default model for this skill: `openai/gpt-image-2`
+
+Authentication uses `OPENROUTER_API_KEY` as a bearer token.
+
+## Safety and scientific integrity
+
+- Treat generated images as draft visual concepts, not evidence.
+- Do not invent quantitative values, p-values, spectra, microscopy findings, institution logos, author photos, journal marks, or unsupported mechanisms.
+- Prefer short labels and simple shapes. AI image models can misspell text; final publication labels should usually be redrawn in Illustrator, Inkscape, PowerPoint, or a Python/R vector workflow.
+- If the schematic could be interpreted as a data panel, explicitly mark it as conceptual.
+- Do not send confidential manuscript content to OpenRouter without user permission.
+
+## Prompt contract
+
+Before calling the API, collect or infer:
+
+1. article title or central claim
+2. key biological/material/computational entities
+3. cause-effect mechanism or workflow stages
+4. desired layout, such as left-to-right pipeline, circular mechanism, split before/after, or graphical abstract
+5. target aspect ratio and output format
+6. any labels that must appear, keeping them short
+7. things that must be excluded
+
+Write a compact prompt with:
+
+- visual role: "Nature-style graphical abstract" or "clean scientific mechanism schematic"
+- composition: panel flow, hierarchy, and focal element
+- style: flat vector-like, restrained palette, high contrast, white or transparent background
+- scientific constraints: no fabricated numbers, no extra organs/cells/materials, no logos
+- output constraints: minimal text, editable downstream, journal-safe
+
+## Script usage
+
+Use the bundled script for reproducible calls:
+
+```bash
+export OPENROUTER_API_KEY="sk-or-..."
+python skills/nature-figure/scripts/generate_openrouter_schematic.py \
+  --title "Paper title" \
+  --abstract-file abstract.txt \
+  --panel-map "left: problem; center: proposed mechanism; right: validated outcome" \
+  --outdir outputs/schematic \
+  --basename graphical_abstract \
+  --aspect-ratio 16:9 \
+  --resolution 2K \
+  --quality high
+```
+
+Dry-run without network or API key:
+
+```bash
+python skills/nature-figure/scripts/generate_openrouter_schematic.py \
+  --title "Self-healing cementitious sensor" \
+  --abstract "A composite sensor couples chloride ingress with recoverable piezoresistive response." \
+  --panel-map "left: marine exposure; center: ion transport and microcrack healing; right: signal recovery curve" \
+  --dry-run
+```
+
+Use a fully custom prompt:
+
+```bash
+python skills/nature-figure/scripts/generate_openrouter_schematic.py \
+  --prompt-file schematic_prompt.md \
+  --raw \
+  --outdir outputs/schematic
+```
+
+Use one or more reference images:
+
+```bash
+python skills/nature-figure/scripts/generate_openrouter_schematic.py \
+  --prompt-file schematic_prompt.md \
+  --reference-image draft_layout.png \
+  --reference-image https://example.com/style-reference.png
+```
+
+The script saves generated files plus `request_metadata.json` in the output directory.
+
+## Recommended defaults
+
+- `model`: `openai/gpt-image-2`
+- `aspect_ratio`: `16:9` for graphical abstracts, `4:3` for mechanism figures, `1:1` for cover-like concepts
+- `resolution`: `2K` for review drafts; use higher only when needed
+- `quality`: `high`
+- `output_format`: `png`
+- `background`: `opaque` unless the user asks for transparent
+
+## Follow-up QA
+
+After generation:
+
+1. inspect the image visually
+2. check whether labels are legible and spelled correctly
+3. list any scientific hallucinations or unsupported visual claims
+4. recommend which labels or arrows should be redrawn as vector objects
+5. keep the generated image and metadata together for provenance

--- a/skills/nature-figure/scripts/generate_openrouter_schematic.py
+++ b/skills/nature-figure/scripts/generate_openrouter_schematic.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Generate manuscript schematic drafts with OpenRouter's Images API."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import mimetypes
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+API_URL = "https://openrouter.ai/api/v1/images"
+DEFAULT_MODEL = "openai/gpt-image-2"
+
+
+def read_optional_text(text: str | None, path: str | None) -> str:
+    parts: list[str] = []
+    if text:
+        parts.append(text.strip())
+    if path:
+        parts.append(Path(path).read_text(encoding="utf-8").strip())
+    return "\n\n".join(part for part in parts if part)
+
+
+def build_prompt(args: argparse.Namespace) -> str:
+    custom_prompt = read_optional_text(args.prompt, args.prompt_file)
+    if custom_prompt and args.raw:
+        return custom_prompt
+
+    title = args.title.strip() if args.title else ""
+    abstract = read_optional_text(args.abstract, args.abstract_file)
+    panel_map = args.panel_map.strip() if args.panel_map else ""
+
+    content_blocks = []
+    if title:
+        content_blocks.append(f"Title: {title}")
+    if abstract:
+        content_blocks.append(f"Article summary:\n{abstract}")
+    if panel_map:
+        content_blocks.append(f"Desired panel flow:\n{panel_map}")
+    if custom_prompt:
+        content_blocks.append(f"Additional instructions:\n{custom_prompt}")
+
+    if not content_blocks:
+        raise SystemExit(
+            "Provide --prompt/--prompt-file or at least one of --title, "
+            "--abstract/--abstract-file, or --panel-map."
+        )
+
+    style = args.style or (
+        "Create a clean Nature-style scientific graphical abstract / mechanism "
+        "schematic for a research paper. Use a flat vector-like visual language, "
+        "restrained journal palette, clear hierarchy, simple arrows, and minimal "
+        "short labels. Keep the background uncluttered."
+    )
+
+    constraints = (
+        "Scientific constraints: show only the mechanisms and entities described "
+        "below; do not invent quantitative values, p-values, microscopy results, "
+        "institutional logos, journal marks, or unsupported experimental claims. "
+        "Use conceptual visual elements rather than fake data panels. Text labels "
+        "must be short and easy to redraw later."
+    )
+
+    return "\n\n".join([style, constraints, *content_blocks])
+
+
+def reference_to_payload(value: str) -> dict[str, Any]:
+    if value.startswith(("http://", "https://", "data:")):
+        url = value
+    else:
+        path = Path(value)
+        if not path.exists():
+            raise SystemExit(f"Reference image not found: {value}")
+        media_type = mimetypes.guess_type(path.name)[0] or "image/png"
+        encoded = base64.b64encode(path.read_bytes()).decode("ascii")
+        url = f"data:{media_type};base64,{encoded}"
+    return {"type": "image_url", "image_url": {"url": url}}
+
+
+def build_payload(args: argparse.Namespace) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "model": args.model,
+        "prompt": build_prompt(args),
+    }
+
+    optional_fields = {
+        "aspect_ratio": args.aspect_ratio,
+        "resolution": args.resolution,
+        "quality": args.quality,
+        "output_format": args.output_format,
+        "background": args.background,
+        "size": args.size,
+        "n": args.n,
+    }
+    for key, value in optional_fields.items():
+        if value is not None:
+            payload[key] = value
+
+    if args.reference_image:
+        payload["input_references"] = [
+            reference_to_payload(value) for value in args.reference_image
+        ]
+
+    return payload
+
+
+def media_extension(media_type: str | None, output_format: str | None) -> str:
+    if media_type == "image/svg+xml":
+        return ".svg"
+    if media_type == "image/jpeg":
+        return ".jpg"
+    if media_type == "image/webp":
+        return ".webp"
+    if media_type == "image/png":
+        return ".png"
+    if output_format == "jpeg":
+        return ".jpg"
+    if output_format in {"png", "webp"}:
+        return f".{output_format}"
+    return ".png"
+
+
+def decode_b64_image(value: str) -> bytes:
+    if value.startswith("data:"):
+        value = value.split(",", 1)[1]
+    return base64.b64decode(value)
+
+
+def request_images(payload: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
+    api_key = os.environ.get(args.api_key_env)
+    if not api_key:
+        raise SystemExit(f"Missing API key: set {args.api_key_env}.")
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    site_url = args.site_url or os.environ.get("OPENROUTER_SITE_URL")
+    app_name = args.app_name or os.environ.get("OPENROUTER_APP_NAME")
+    if site_url:
+        headers["HTTP-Referer"] = site_url
+    if app_name:
+        headers["X-Title"] = app_name
+
+    request = urllib.request.Request(
+        API_URL,
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=args.timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise SystemExit(f"OpenRouter request failed ({exc.code}): {body}") from exc
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"OpenRouter request failed: {exc}") from exc
+
+
+def save_outputs(response: dict[str, Any], payload: dict[str, Any], args: argparse.Namespace) -> None:
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+    basename = args.basename or time.strftime("openrouter_schematic_%Y%m%d_%H%M%S")
+
+    saved: list[str] = []
+    for index, item in enumerate(response.get("data", []), start=1):
+        media_type = item.get("media_type")
+        ext = media_extension(media_type, args.output_format)
+        suffix = "" if len(response.get("data", [])) == 1 else f"_{index:02d}"
+        outpath = outdir / f"{basename}{suffix}{ext}"
+
+        if "b64_json" in item:
+            outpath.write_bytes(decode_b64_image(item["b64_json"]))
+            saved.append(str(outpath))
+        elif "url" in item:
+            with urllib.request.urlopen(item["url"], timeout=args.timeout) as image_response:
+                outpath.write_bytes(image_response.read())
+            saved.append(str(outpath))
+        else:
+            raise SystemExit(f"No image bytes or URL in response item {index}: {item}")
+
+    metadata = {
+        "api_url": API_URL,
+        "request": payload,
+        "response_usage": response.get("usage"),
+        "created": response.get("created"),
+        "saved_files": saved,
+    }
+    metadata_path = outdir / f"{basename}_request_metadata.json"
+    metadata_path.write_text(json.dumps(metadata, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    print("Saved:")
+    for path in saved:
+        print(f"  {path}")
+    print(f"  {metadata_path}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate manuscript schematic drafts with OpenRouter's Images API."
+    )
+    parser.add_argument("--model", default=os.environ.get("OPENROUTER_IMAGE_MODEL", DEFAULT_MODEL))
+    parser.add_argument("--title")
+    parser.add_argument("--abstract")
+    parser.add_argument("--abstract-file")
+    parser.add_argument("--panel-map")
+    parser.add_argument("--prompt")
+    parser.add_argument("--prompt-file")
+    parser.add_argument("--style")
+    parser.add_argument("--raw", action="store_true", help="Use prompt text without the schematic scaffold.")
+    parser.add_argument("--reference-image", action="append", help="Path, URL, or data URL for image-to-image guidance.")
+    parser.add_argument("--outdir", default="openrouter_schematic")
+    parser.add_argument("--basename")
+    parser.add_argument("--aspect-ratio", default="16:9")
+    parser.add_argument("--resolution", default="2K")
+    parser.add_argument("--size", help="Optional OpenRouter size shorthand, such as 2048x2048.")
+    parser.add_argument("--quality", default="high", choices=["auto", "low", "medium", "high"])
+    parser.add_argument("--output-format", default="png", choices=["png", "jpeg", "webp"])
+    parser.add_argument("--background", choices=["auto", "transparent", "opaque"])
+    parser.add_argument("--n", type=int, default=1)
+    parser.add_argument("--api-key-env", default="OPENROUTER_API_KEY")
+    parser.add_argument("--site-url")
+    parser.add_argument("--app-name")
+    parser.add_argument("--timeout", type=int, default=180)
+    parser.add_argument("--dry-run", action="store_true", help="Print request payload without calling OpenRouter.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    payload = build_payload(args)
+
+    if args.dry_run:
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+        return 0
+
+    response = request_images(payload, args)
+    save_outputs(response, payload, args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/nature-figure/scripts/nature_figure_backend.py
+++ b/skills/nature-figure/scripts/nature_figure_backend.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Read or write the user's default nature-figure plotting backend."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+
+VALID_BACKENDS = {"python", "r"}
+
+
+def config_path() -> Path:
+    override = os.environ.get("NATURE_FIGURE_CONFIG")
+    if override:
+        return Path(override).expanduser()
+    return Path("~/.config/nature-skills/nature-figure.json").expanduser()
+
+
+def read_config(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Invalid nature-figure config JSON at {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise SystemExit(f"Invalid nature-figure config at {path}: expected object")
+    return data
+
+
+def write_config(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def get_backend(path: Path) -> int:
+    backend = read_config(path).get("backend")
+    if backend in VALID_BACKENDS:
+        print(backend)
+        return 0
+    return 1
+
+
+def set_backend(path: Path, backend: str) -> int:
+    backend = backend.lower()
+    if backend not in VALID_BACKENDS:
+        raise SystemExit("backend must be one of: python, r")
+    data = read_config(path)
+    data["backend"] = backend
+    write_config(path, data)
+    print(backend)
+    return 0
+
+
+def clear_backend(path: Path) -> int:
+    data = read_config(path)
+    data.pop("backend", None)
+    write_config(path, data)
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("get", help="Print the saved backend; exit 1 if unset.")
+    set_parser = subparsers.add_parser("set", help="Save the default backend.")
+    set_parser.add_argument("backend", choices=sorted(VALID_BACKENDS))
+    subparsers.add_parser("clear", help="Remove the saved backend preference.")
+    subparsers.add_parser("path", help="Print the config path.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    path = config_path()
+    if args.command == "get":
+        return get_backend(path)
+    if args.command == "set":
+        return set_backend(path, args.backend)
+    if args.command == "clear":
+        return clear_backend(path)
+    if args.command == "path":
+        print(path)
+        return 0
+    raise AssertionError(args.command)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/nature-figure/static/core/contract.md
+++ b/skills/nature-figure/static/core/contract.md
@@ -2,11 +2,15 @@
 
 A publication-quality scientific figure is a visual argument, not an isolated pretty plot. Every figure starts from a claim, an evidence hierarchy, and a review-risk check before code or aesthetics. Before generating or editing code, establish the contract below.
 
-## Backend selection is a blocking gate
+## Backend selection uses a saved preference
 
-If the user has not explicitly chosen Python or R in the current request or provided a clearly language-specific input file/workflow, ask one concise question: **Python or R?** Then stop and wait for the user's answer. Do not generate mock data, write scripts, create figures, or choose Python/R by default. This overrides general autonomy/default-execution behavior for figure tasks.
+For plotting tasks, first honor an explicit Python/R choice in the current request or a clearly language-specific input file/workflow. Save that backend as the user's default with `scripts/nature_figure_backend.py set python` or `scripts/nature_figure_backend.py set r`.
 
-Only recommend a backend when the user explicitly asks you to choose or recommend one. In that case, use `references/backend-selection.md`, state the reason, and then proceed with the recommended backend.
+If the current request does not specify a backend, check the saved preference with `scripts/nature_figure_backend.py get`. If it returns `python` or `r`, use that backend without asking again.
+
+If no saved preference exists, ask one concise question: **Python or R? I will remember this as your default.** Then stop and wait for the user's answer. Do not generate mock data, write scripts, create figures, or choose Python/R by default before this first preference is established. After the user answers, save it and proceed.
+
+Only recommend a backend when the user explicitly asks you to choose or recommend one. In that case, use `references/backend-selection.md`, state the reason, save the selected backend, and then proceed with the recommended backend.
 
 ## The selected backend is exclusive
 
@@ -21,7 +25,7 @@ After the backend is selected, check the selected runtime early (`Rscript`/R for
 1. **Core conclusion**: write the one-sentence claim the figure must defend.
 2. **Evidence chain**: map each planned panel to the claim, and drop panels that do not carry a unique piece of evidence.
 3. **Archetype**: classify the figure as `quantitative grid`, `schematic-led composite`, `image plate + quant`, or `asymmetric mixed-modality figure`.
-4. **Backend**: use the selected Python or R track exclusively for all figure drawing, previewing, exporting, and visual QA. Do not cross-render with the other language.
+4. **Backend**: use the explicit or saved Python/R track exclusively for all figure drawing, previewing, exporting, and visual QA. Do not cross-render with the other language.
 5. **Journal/export contract**: set final dimensions, editable text, source data, statistics, image-integrity notes, and export formats before styling.
 
 The highest-priority rule is: **the chart serves the scientific logic**. Aesthetic polish, template matching, and complex layout are subordinate to making the core conclusion clear, defensible, and reviewable.


### PR DESCRIPTION
## Summary
- polish README installation entry and put Claude Code before Codex
- add OpenRouter GPT Image 2 schematic-draft route to nature-figure
- add scripts for OpenRouter image payload generation and persistent Python/R backend preference

## Validation
- python3 -m py_compile skills/nature-figure/scripts/nature_figure_backend.py skills/nature-figure/scripts/generate_openrouter_schematic.py
- OpenRouter schematic dry-run JSON validation
- Ruby YAML parse for nature-figure SKILL.md and manifest.yaml
- git diff --check
- GitHub Markdown API render for README.md and README_EN.md