### PR TITLE
fix: parse numeric and boolean values in fallback YAML parser

### DIFF
--- a/skills/nature-downloader/src/schools_loader.py
+++ b/skills/nature-downloader/src/schools_loader.py
@@ -24,6 +24,18 @@ def _parse_scalar(value: str) -> Any:
         if not inner:
             return []
         return [part.strip().strip('"') for part in inner.split(",")]
+    # Convert numeric and boolean strings so the fallback parser
+    # matches what PyYAML would produce
+    for cast in (int, float):
+        try:
+            return cast(value)
+        except (ValueError, TypeError):
+            pass
+    low = value.lower()
+    if low in ("true", "yes", "on"):
+        return True
+    if low in ("false", "no", "off"):
+        return False
     return value
 
 


### PR DESCRIPTION
The `_parse_scalar` function in the fallback YAML parser (used when PyYAML is not installed) returned all values as strings. Numbers like `8080` and booleans like `true` stayed as strings instead of being converted to their proper types.

Fix: add type conversion for int, float, and boolean values before the final string return.