### PR TITLE
feat: add nature-statistics skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <p>
     <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-2ea44f"></a>
     <a href="#安装"><img alt="Install" src="https://img.shields.io/badge/install-Claude%20Code%20%7C%20Codex%20%7C%20OpenClaw%20%7C%20OpenCode%20%7C%20Hermes-111827"></a>
-    <a href="#技能索引"><img alt="Skills" src="https://img.shields.io/badge/skills-16-0ea5e9"></a>
+    <a href="#技能索引"><img alt="Skills" src="https://img.shields.io/badge/skills-17-0ea5e9"></a>
     <a href="README_EN.md"><img alt="Language" src="https://img.shields.io/badge/language-中文%20%7C%20English-1f6feb"></a>
   </p>
   <p>
@@ -256,6 +256,7 @@ OpenClaw、OpenCode、Hermes 的具体接入方式见 [OpenClaw / OpenCode / Her
 | [`nature-reviewer`](skills/nature-reviewer/README.md) | Draft | 从审稿人视角模拟 Nature 风格评审，输出三份 reviewer reports 和综合意见 | “Nature reviewer”, “预投稿评审”, “reviewer report”, “审稿人视角评估” |
 | [`nature-citation`](skills/nature-citation/README.md) | Beta | 检索严格限定在 Nature / CNS 系列的支撑文献，并导出 ENW、RIS 或 Zotero RDF | “Nature citation”, “CNS citation”, “分段引用”, “支撑文献”, “Zotero RDF” |
 | [`nature-data`](skills/nature-data/README.md) | Draft | 准备 Data Availability statement、数据仓储方案和 FAIR 检查 | “Data Availability”, “数据可用性”, “repository”, “FAIR metadata” |
+| [`nature-statistics`](skills/nature-statistics/README.md) | Draft | 审查、改写或起草 Nature / 高影响力期刊投稿中的统计报告，覆盖样本量、独立分析单位、重复数、p 值、多重比较、效应量、置信区间、图注统计和审稿人统计意见 | “Nature statistics”, “统计审查”, “statistical analysis”, “p value”, “sample size”, “replicates”, “multiple comparisons”, “图注统计”, “统计分析小节” |
 | [`nature-reader`](skills/nature-reader/README.md) | Beta | 生成带来源锚点、图文对应和中英文对照的全文 Markdown reader | “nature reader”, “全文 Markdown”, “原文对照”, “图文对应”, “全文翻译” |
 | [`nature-response`](skills/nature-response/README.md) | Beta | 解析返修邮件，起草、审查和修改返修 cover letter、逐点回复审稿人的 response letter、标红修改稿，并提供 LaTeX 模板 | “response to reviewers”, “rebuttal letter”, “cover letter”, “major revision”, “返修邮件”, “审稿意见回复”, “修回信”, “LaTeX 模板” |
 | [`nature-paper2ppt`](skills/nature-paper2ppt/README.md) | Beta | 从科研论文生成中文 PPTX 文献汇报 deck | “paper PPT”, “journal club”, “paper to slides”, “论文汇报” |

--- a/README_EN.md
+++ b/README_EN.md
@@ -7,7 +7,7 @@
   <p>
     <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-2ea44f"></a>
     <a href="#installation"><img alt="Install" src="https://img.shields.io/badge/install-Claude%20Code%20%7C%20Codex%20%7C%20OpenClaw%20%7C%20OpenCode%20%7C%20Hermes-111827"></a>
-    <a href="#skill-index"><img alt="Skills" src="https://img.shields.io/badge/skills-16-0ea5e9"></a>
+    <a href="#skill-index"><img alt="Skills" src="https://img.shields.io/badge/skills-17-0ea5e9"></a>
     <a href="README.md"><img alt="Language" src="https://img.shields.io/badge/language-English%20%7C%20中文-1f6feb"></a>
   </p>
   <p>
@@ -311,6 +311,7 @@ The current `skills/` directory contains the following triggerable skills.
 | [`nature-reviewer`](skills/nature-reviewer/README.md) | Draft | Simulate Nature-style reviewer assessment from the reviewer perspective, returning three reviewer reports and a synthesis | "Nature reviewer", "pre-submission review", "reviewer report", "reviewer-perspective assessment" |
 | [`nature-citation`](skills/nature-citation/README.md) | Beta | Search support literature strictly within Nature / CNS families and export ENW, RIS, or Zotero RDF | "Nature citation", "CNS citation", "segmented citation", "supporting references", "Zotero RDF" |
 | [`nature-data`](skills/nature-data/README.md) | Draft | Prepare Data Availability statements, data repository plans, and FAIR checks | "Data Availability", "data availability", "repository", "FAIR metadata" |
+| [`nature-statistics`](skills/nature-statistics/README.md) | Draft | Audit, revise, or draft statistical reporting for Nature / high-impact journal manuscripts, covering sample size, independent units, replicates, p values, multiple comparisons, effect sizes, confidence intervals, figure statistics, and reviewer comments | "Nature statistics", "statistical analysis", "p value", "sample size", "replicates", "multiple comparisons", "figure statistics", "statistics review" |
 | [`nature-reader`](skills/nature-reader/README.md) | Beta | Generate full-paper Markdown readers with source anchors, figure-text alignment, and Chinese-English side-by-side translation | "nature reader", "full Markdown", "source-aligned text", "figure-text alignment", "full translation" |
 | [`nature-response`](skills/nature-response/README.md) | Beta | Parse revision emails; draft, audit, and revise revision cover letters, point-by-point response letters, red-marked manuscripts, and LaTeX templates | "response to reviewers", "rebuttal letter", "cover letter", "major revision", "revision email", "reviewer-comment response", "LaTeX template" |
 | [`nature-paper2ppt`](skills/nature-paper2ppt/README.md) | Beta | Generate Chinese PPTX journal-club or paper-presentation decks from research papers | "paper PPT", "journal club", "paper to slides", "paper presentation" |

--- a/skills/nature-statistics/README.md
+++ b/skills/nature-statistics/README.md
@@ -1,0 +1,66 @@
+﻿# `nature-statistics` 技能
+
+`nature-statistics` 用于审查、改写或起草 Nature / 高影响力期刊投稿中的统计报告文本。它关注的是论文中统计信息是否足够透明、可复核、与实验设计一致，而不是把所有统计问题简化成“p 值是否显著”。
+
+该技能适合处理中文作者常见的投稿场景：作者可以用中文描述样本量、重复数、统计检验、图注或审稿意见；技能会把这些信息整理成保守的英文 Statistical analysis、Results 统计表述或图注统计说明，并标记仍需作者确认的事实。
+
+## 功能
+
+- 审查 Statistical analysis / Methods 中的统计报告是否完整。
+- 检查 Results 里 p 值、置信区间、效应量、样本量和检验名称是否表述清楚。
+- 区分 biological replicates、technical replicates、重复测量、细胞/视野/子样本和独立实验单位。
+- 识别伪重复、嵌套数据、未校正多重比较、错误的交互解释、过度依赖显著性、相关性过度解释等常见问题。
+- 改写图注中的统计说明，包括 error bars、box plots、violin plots、stars、exact p values、source data 和 n 定义。
+- 根据审稿人统计意见，生成逐点修改建议或可粘贴的保守回应文本。
+- 在信息缺失时输出 `AUTHOR_INPUT_NEEDED`，不替作者编造统计细节。
+
+## 适用场景
+
+- 投稿前检查 Statistical analysis 小节。
+- 审稿人指出 “statistical analysis is unclear / insufficient”。
+- 图中星号、误差线、n 数和检验方法需要统一说明。
+- 需要把中文统计描述改成英文稿件可用文本。
+- 需要判断某个结果是否存在伪重复、多重比较或模型假设问题。
+- 需要让 Results 中的统计语言更克制，避免把显著性写成机制或因果。
+
+## 默认返回内容
+
+常规审查会返回：
+
+1. `Statistics review scope`
+2. `Major statistical issues`
+3. `Ready-to-paste revision`
+4. `AUTHOR_INPUT_NEEDED`
+5. `Reviewer-risk note`
+
+如果用户只是要求起草统计方法，技能会返回更短的：
+
+1. `Draft Statistical analysis`
+2. `Reporting notes`
+
+## 核心规则
+
+- 先确认实验设计和独立分析单位，再讨论统计检验。
+- 不把细胞、图像、技术重复、重复读数或模拟次数默认当作独立样本。
+- 优先报告效应量、置信区间、样本量、检验方法和校正策略，而不是只报告星号。
+- 不编造 p 值、自由度、样本量、软件版本、排除标准、随机化、盲法或 power analysis。
+- 当材料不足时，给出保守文本和短问题清单，而不是替作者补事实。
+- 统计结果不能自动证明机制、因果或生物学重要性。
+
+## 文件结构
+
+```text
+nature-statistics/
+├── README.md
+├── SKILL.md
+└── references/
+    ├── source-basis.md
+    ├── statistical-reporting.md
+    ├── common-failure-modes.md
+    ├── figure-statistics.md
+    └── reviewer-checklist.md
+```
+
+## 状态
+
+Draft。第一版聚焦统计报告与审稿风险检查，尚未用真实匿名稿件库做系统回归测试。

--- a/skills/nature-statistics/SKILL.md
+++ b/skills/nature-statistics/SKILL.md
@@ -1,0 +1,116 @@
+﻿---
+name: nature-statistics
+description: >-
+  Audit, revise, or draft manuscript statistical reporting for Nature / high-impact journal submissions. Use when the user asks to check statistical analysis sections, p values, confidence intervals, sample size, biological versus technical replicates, randomization, blinding, multiple-comparison correction, model assumptions, figure legends, Results statistics wording, reviewer comments about statistics, or Chinese academic drafts needing publication-ready Statistical analysis text. Also trigger on general paper-statistics requests such as 统计审查、统计分析小节、统计方法、p值、样本量、重复数、多重比较、置信区间、效应量、图注统计、审稿人统计意见.
+---
+
+# Nature Statistics Reporting Skill
+
+Use this skill to make manuscript statistics transparent, reproducible, and appropriately bounded. It is a reporting and review skill, not a substitute for a statistician reanalysing raw data unless the user supplies the data and explicitly asks for computation.
+
+## Default stance
+
+- Prioritize design transparency over decorative statistical language.
+- Separate three questions: what was measured, what unit was analysed, and what inference was claimed.
+- Treat the independent experimental unit as the default `n`; do not silently treat cells, fields of view, repeated readings, spectra, model runs, or technical replicates as independent biological or experimental samples.
+- Prefer effect sizes, uncertainty intervals, sample sizes, and exact test definitions over significance-only phrasing.
+- State missing information as `AUTHOR_INPUT_NEEDED` instead of inventing sample sizes, tests, software, corrections, exclusion rules, randomization, or blinding.
+- If a journal-specific instruction, study-type guideline, or field standard conflicts with this skill, follow the more specific source and mark the source used.
+
+## Accepted inputs
+
+The skill may receive:
+
+- a Statistical analysis / Methods subsection
+- Results paragraphs containing test statistics or p values
+- figure panels, legends, captions, or source-data notes
+- reviewer comments about statistics
+- author notes in Chinese or English
+- tables of reported comparisons
+- raw or summary data, only when the user wants a concrete reanalysis or figure-statistics check
+
+If the input is partial, run a bounded audit and state which parts cannot be assessed.
+
+## Workflow
+
+1. **Classify the task.** Decide whether the user wants audit, rewrite, draft, reviewer-response support, figure-statistics alignment, or data-backed reanalysis.
+2. **Extract the design.** Identify groups, treatments, time points, endpoints, blocking factors, repeated measures, randomization, blinding, exclusions, and missing-data handling.
+3. **Define `n` and replication.** Separate independent experimental units, biological replicates, technical replicates, repeated measures, cells/fields/subsamples, simulations, and pooled observations.
+4. **Map claims to analyses.** For each result claim, record the comparison/model, test family, assumptions, correction strategy, effect estimate, uncertainty, and exact p-value policy.
+5. **Check common failure modes.** Use `references/common-failure-modes.md` when the text involves nested data, many comparisons, cell-level measurements, interaction claims, correlations, regression, outliers, small samples, or significance-only reasoning.
+6. **Check reporting completeness.** Use `references/statistical-reporting.md` to verify that Methods and Results give enough information for readers and reviewers to understand the analysis.
+7. **Align figure statistics.** Use `references/figure-statistics.md` when figure legends, panel labels, stars, error bars, box plots, violin plots, source data, or supplementary figure notes are involved.
+8. **Draft or revise.** Produce conservative, ready-to-paste text. Keep claims within the supplied design and evidence. Do not upgrade statistical association into mechanism or causality.
+9. **Run final QA.** Use `references/reviewer-checklist.md` before final delivery for severity labels, unresolved author questions, and reviewer-facing risk.
+
+## Output format
+
+Unless the user asks for another format, return:
+
+```text
+Statistics review scope
+- Input reviewed:
+- Boundary / missing materials:
+- Study design readout:
+- Independent unit and replication readout:
+
+Major statistical issues
+- [P0/P1/P2] Issue:
+  Evidence from supplied text:
+  Why it matters:
+  Fix:
+
+Ready-to-paste revision
+[Rewritten Statistical analysis / Results / figure legend text]
+
+AUTHOR_INPUT_NEEDED
+- [short factual questions only]
+
+Reviewer-risk note
+- What a statistical reviewer may still challenge:
+```
+
+For a clean drafting request with enough information, skip the long issue list and return:
+
+```text
+Draft Statistical analysis
+[ready-to-paste text]
+
+Reporting notes
+- n definition:
+- tests/models:
+- multiple comparisons:
+- software/version:
+- unresolved fields:
+```
+
+## Red lines
+
+- Do not invent p values, sample sizes, degrees of freedom, confidence intervals, software versions, correction methods, preregistration, exclusion rules, or power calculations.
+- Do not recommend a statistical test as final when the unit of analysis or design is unclear.
+- Do not accept `n = number of cells/images/measurements` as independent replication without checking the experimental hierarchy.
+- Do not use “significant” as a synonym for important, large, causal, or biologically meaningful.
+- Do not hide non-significant or weak results by rewriting them into stronger claims.
+- Do not give medical, regulatory, or clinical-trial statistical advice beyond reporting checks unless the user provides the relevant protocol and asks for bounded manuscript wording.
+
+## Related files
+
+| File | Open when |
+|---|---|
+| [references/source-basis.md](references/source-basis.md) | You need the source hierarchy or want to justify why the skill emphasizes transparency, reproducibility, and design reporting |
+| [references/statistical-reporting.md](references/statistical-reporting.md) | You are drafting or auditing Statistical analysis, Methods, Results, or Supplementary Methods text |
+| [references/common-failure-modes.md](references/common-failure-modes.md) | You see nested measurements, many comparisons, interaction claims, correlation/regression, outliers, tiny samples, or overstrong p-value language |
+| [references/figure-statistics.md](references/figure-statistics.md) | You are checking figure legends, panel statistics, error bars, stars, box/violin plots, source-data notes, or graphical reporting |
+| [references/reviewer-checklist.md](references/reviewer-checklist.md) | You are finalizing an audit or preparing a reviewer-facing risk summary |
+
+## Source hierarchy
+
+Use sources in this order:
+
+1. User-supplied manuscript, data, protocol, statistical analysis plan, reviewer comments, and journal instructions.
+2. Nature Portfolio reporting standards and reporting-summary requirements.
+3. Nature Methods / Nature Portfolio statistics guidance summarized in `references/source-basis.md`.
+4. Study-type reporting guidelines where relevant, for example CONSORT, STROBE, PRISMA, ARRIVE, or field-specific community standards.
+5. Conservative statistical reporting practice.
+
+If the supplied material is insufficient for a defensible statistical recommendation, ask for the missing design facts or provide a bounded wording option rather than guessing.

--- a/skills/nature-statistics/references/common-failure-modes.md
+++ b/skills/nature-statistics/references/common-failure-modes.md
@@ -1,0 +1,136 @@
+﻿# Common statistical failure modes
+
+Use this file to identify reviewer-risk patterns. Do not accuse the authors; state the risk and the fix.
+
+## P0: likely to undermine the result
+
+### Pseudoreplication
+
+Signal:
+- `n` is reported as cells, images, fields, spectra, droplets, reads, technical wells, or repeated readings.
+- The independent experimental unit is likely animal, patient, culture, donor, batch, plot, device, or experiment.
+
+Risk:
+- The test may overstate precision and produce artificially small p values.
+
+Fix:
+- Analyse independent units, aggregate technical subsamples, or use a hierarchical / mixed-effects model when justified.
+- Show subsample-level spread visually without treating every subsample as independent.
+
+### Uncorrected multiple comparisons
+
+Signal:
+- Many genes, proteins, time points, panels, groups, pairwise contrasts, or exploratory endpoints are tested.
+- The manuscript reports selected significant comparisons only.
+
+Risk:
+- False-positive rate is inflated or the comparison family is unclear.
+
+Fix:
+- Define the family of tests and use an appropriate correction or distinguish prespecified primary comparisons from exploratory analyses.
+
+### Wrong interaction inference
+
+Signal:
+- Authors say two effects differ because one comparison is significant and the other is not.
+
+Risk:
+- Difference in significance is not evidence of a significant difference between effects.
+
+Fix:
+- Test the interaction or directly compare effect sizes.
+
+### Analysis unit mismatch
+
+Signal:
+- Design is paired, matched, blocked, longitudinal, nested, or repeated-measures, but analysis uses independent tests.
+
+Risk:
+- Dependence structure is ignored.
+
+Fix:
+- Use paired tests, repeated-measures analysis, mixed-effects models, blocking, or cluster-robust methods as appropriate.
+
+## P1: important reporting or interpretation risk
+
+### Significance-only conclusion
+
+Signal:
+- Result is described mainly by stars or p thresholds.
+
+Risk:
+- Readers cannot judge magnitude, uncertainty, or practical importance.
+
+Fix:
+- Add effect estimates, confidence/credible intervals, raw distributions, and exact p values where possible.
+
+### Small-sample overclaim
+
+Signal:
+- Very small `n`, unstable estimates, or no uncertainty interval, but strong language.
+
+Risk:
+- Effect size and direction may be imprecise.
+
+Fix:
+- Use cautious wording and report the limitation directly.
+
+### Normality or equal-variance assumption not supportable
+
+Signal:
+- Parametric tests are used on small or skewed samples with no rationale.
+
+Risk:
+- Assumptions may be unverifiable or violated.
+
+Fix:
+- Add assumption checks, use robust/nonparametric alternatives, or describe the limitation.
+
+### Outlier handling is unclear
+
+Signal:
+- Points disappear, exclusions are mentioned vaguely, or outlier tests are named without prespecified rules.
+
+Risk:
+- Post-hoc exclusion may bias results.
+
+Fix:
+- State exclusion criteria, timing, number removed, and whether conclusions are robust to inclusion.
+
+### Correlation or regression overclaim
+
+Signal:
+- Association is written as mechanism, prediction, or causality without design support.
+
+Risk:
+- Confounding, non-independence, and model extrapolation may be ignored.
+
+Fix:
+- Reword as association unless experimental or causal identification supports stronger claims.
+
+## P2: clarity and presentation risk
+
+### Error bars are undefined
+
+Fix:
+- State s.d., s.e.m., confidence interval, interquartile range, or other convention.
+
+### `n` varies across panels but is not panel-specific
+
+Fix:
+- Give panel-specific `n` and define what `n` represents.
+
+### Star notation is not defined
+
+Fix:
+- Define thresholds, correction status, and exact p values if available.
+
+### Software is missing
+
+Fix:
+- Add software/package and version if supplied by the user.
+
+### `ns` hides the result
+
+Fix:
+- Provide exact p value or state the reporting threshold and avoid interpreting lack of significance as proof of no effect.

--- a/skills/nature-statistics/references/figure-statistics.md
+++ b/skills/nature-statistics/references/figure-statistics.md
@@ -1,0 +1,92 @@
+﻿# Figure statistics and legend alignment
+
+Use this file when checking figure panels, legends, star labels, error bars, source data, or statistical annotations.
+
+## Legend information each quantitative panel should provide
+
+For each panel or panel group, check whether the legend states:
+
+- what points, bars, boxes, lines, or shaded regions represent
+- the exact definition of `n`
+- whether `n` is independent samples, animals, donors, patients, cultures, experiments, simulations, fields, cells, or technical replicates
+- summary convention: mean ± s.d., mean ± s.e.m., median with IQR, min-max, confidence interval, or model estimate
+- test/model used
+- paired/unpaired or repeated-measures status if relevant
+- multiple-comparison correction if multiple contrasts are displayed
+- exact p values or star thresholds
+- whether source data include raw independent values or only summary values
+
+## Plot-type checks
+
+### Bar plots
+
+Risk:
+- Bars can hide sample size and distribution.
+
+Fix:
+- Prefer showing individual independent data points when feasible.
+- If bars remain, require error-bar definition and panel-specific `n`.
+
+### Box plots
+
+Require:
+- median line, box bounds, whisker rule, outlier display rule, and `n`.
+
+### Violin plots
+
+Require:
+- what points represent, kernel/density caveat if relevant, and independent-unit definition.
+- Avoid making dense cell-level violins look like many independent experiments.
+
+### Time courses
+
+Require:
+- whether the same units are followed over time.
+- Use repeated-measures or mixed models when inference uses all time points from the same unit.
+
+### Heat maps / omics panels
+
+Require:
+- normalization, scaling, clustering distance/linkage if used, multiple-testing or FDR treatment for highlighted features, and whether rows/columns are selected post hoc.
+
+### Regression / correlation panels
+
+Require:
+- correlation coefficient or model coefficient, uncertainty if available, sample size, independence of points, and whether the fit is descriptive or inferential.
+
+## Star notation
+
+Avoid legends that only say:
+
+```text
+*P < 0.05, **P < 0.01, ***P < 0.001
+```
+
+Prefer:
+
+```text
+Symbols indicate adjusted p values from AUTHOR_INPUT_NEEDED test with AUTHOR_INPUT_NEEDED correction for the comparisons shown: *p < 0.05, **p < 0.01, ***p < 0.001. Exact p values and sample sizes are provided in Source Data. n denotes independent AUTHOR_INPUT_NEEDED.
+```
+
+Only use this after the relevant facts are supplied.
+
+## Source-data notes
+
+Ask whether source data should include:
+
+- raw independent-unit values behind summary panels
+- exact p values and test statistics
+- sample-size table per panel
+- excluded-data notes if any
+- code or script used to produce the panel, where central to the claims
+
+## Figure audit output mini-format
+
+```text
+Figure statistics audit
+- Panel:
+- Current legend problem:
+- Risk:
+- Required fix:
+- Suggested legend text:
+```

--- a/skills/nature-statistics/references/reviewer-checklist.md
+++ b/skills/nature-statistics/references/reviewer-checklist.md
@@ -1,0 +1,95 @@
+﻿# Reviewer checklist for statistical reporting
+
+Use this file before final delivery. It converts the audit into reviewer-facing risk and concrete author actions.
+
+## Severity labels
+
+### P0 — must fix before submission or resubmission
+
+Use P0 when the current statistical reporting or analysis logic could invalidate a central claim.
+
+Examples:
+- independent unit is wrong or undefined for a central claim
+- paired/repeated/nested structure is ignored
+- many comparisons are made without any correction or family definition
+- interaction is inferred incorrectly
+- exclusion/missing-data handling could change the result but is not disclosed
+- analysis cannot be understood from Methods and legends
+
+### P1 — important revision strongly recommended
+
+Use P1 when the claim may be defensible but reporting is too weak for review.
+
+Examples:
+- exact sample sizes are missing
+- error bars or box-plot conventions are undefined
+- effect sizes or uncertainty are absent for key results
+- software/package/version is missing
+- p-value thresholds are used without exact values or clear correction status
+- small-sample limitation is not acknowledged
+
+### P2 — clarity or polish improvement
+
+Use P2 when the issue is unlikely to change the conclusion but could frustrate reviewers.
+
+Examples:
+- inconsistent terminology for replicates
+- figure legends repeat methods but omit panel-specific `n`
+- `ns` labels are unclear
+- statistical text is scattered between Methods, legends and supplementary notes
+
+## Final QA questions
+
+Before sending the answer, check:
+
+1. Did we define the independent unit?
+2. Did we distinguish biological and technical replicates?
+3. Did we avoid inventing p values, tests, software, sample size, randomization, or blinding?
+4. Did every central result claim map to a test/model or to a clear descriptive statement?
+5. Did we identify whether multiple-comparison correction is needed or missing?
+6. Did we state which issues are not assessable from the supplied material?
+7. Did the proposed wording avoid causal or mechanistic overclaiming?
+8. Did we include short `AUTHOR_INPUT_NEEDED` questions rather than broad requests?
+
+## Reviewer-risk phrasing
+
+Use neutral phrasing:
+
+- `A reviewer may challenge whether the analysis treats the correct independent unit as n.`
+- `The current legend does not make clear whether the plotted points are biological replicates or technical subsamples.`
+- `The claim is stronger than the statistical evidence currently reported.`
+- `The comparison family is not defined, so the correction status is unclear.`
+
+Avoid accusatory phrasing:
+
+- `This is fake significance.`
+- `The authors manipulated p values.`
+- `The analysis is wrong.`
+
+Unless raw data and full design are supplied, prefer:
+
+- `not assessable from the supplied material`
+- `potential risk`
+- `requires author confirmation`
+- `should be clarified before submission`
+
+## Response to reviewer support
+
+When helping draft a response to statistical reviewer comments, use this structure:
+
+```text
+Reviewer concern
+- [quote or short paraphrase]
+
+Author-side action needed
+- [analysis/text/figure/source data change]
+
+Draft response
+- We thank the reviewer for raising this point. We have revised the Statistical analysis section to define AUTHOR_INPUT_NEEDED and have updated Fig. AUTHOR_INPUT_NEEDED legend to report AUTHOR_INPUT_NEEDED. The revised text now states: "AUTHOR_INPUT_NEEDED".
+
+Manuscript change
+- Section / figure:
+- Replacement text:
+```
+
+Do not claim that a new analysis was performed unless the user supplies the result or asks you to run it on data.

--- a/skills/nature-statistics/references/source-basis.md
+++ b/skills/nature-statistics/references/source-basis.md
@@ -1,0 +1,47 @@
+﻿# Source basis for `nature-statistics`
+
+This file keeps the skill conservative. It is a local summary of sources the agent should use to justify reporting checks; it is not a replacement for the target journal's current author instructions.
+
+## Primary source hierarchy
+
+1. **Target journal instructions and user-supplied protocol**
+   - Use these first when the user provides them.
+   - If a reviewer comment or statistical analysis plan gives a stricter requirement, follow that local constraint.
+
+2. **Nature Portfolio reporting standards**
+   - Nature Portfolio frames reporting transparency around the ability of readers to replicate and build on published claims.
+   - Where relevant, manuscripts sent for review may require completed reporting summary documents.
+   - For life sciences, behavioural and social sciences, ecology, evolution and environmental sciences, the reporting summary asks authors to provide details of experimental and analytical design that are often poorly reported.
+   - Source: https://www.nature.com/nature-portfolio/editorial-policies/reporting-standards
+
+3. **Nature / Nature Methods statistics guidance**
+   - The Nature collection `Statistics for Biologists` groups practical guidance on statistical design, P values, power, sample size, error bars, multiple comparisons, nonparametric tests, experimental design, replication, nested designs, regression, outliers, and correlation versus causation.
+   - Treat this collection as practical guidance for common failure modes, not as a single mandatory checklist for every field.
+   - Source: https://www.nature.com/collections/qghhqm
+
+4. **Study-type reporting guidelines**
+   - Use these only when the study type clearly applies or the user requests them.
+   - Examples: CONSORT for randomized trials, STROBE for observational studies, PRISMA for systematic reviews, ARRIVE for animal research, and field-specific community standards.
+
+5. **Conservative statistical reporting practice**
+   - If no field-specific rule is available, require enough information for a reader to identify the design, analysis unit, test/model, assumptions, correction strategy, sample size, uncertainty, and software.
+
+## Implementation boundaries
+
+The skill should not pretend that Nature has one universal statistical recipe. It should instead enforce transparent reporting and identify risks that reviewers commonly challenge.
+
+Use careful language:
+
+- Prefer: `The manuscript should define the independent experimental unit.`
+- Avoid: `Nature requires this exact test.` unless the journal instruction actually says so.
+
+When the user supplies a target journal or reporting summary, ask for or use that document before relying on generic guidance.
+
+## Key reporting principles used by this skill
+
+- Replication depends on the independent experimental unit, not merely the number of measurements.
+- Statistical tests are interpretable only relative to the design, assumptions, and data structure.
+- P values should not carry the full evidential burden; effect estimates, uncertainty, design quality, and reproducibility matter.
+- Multiple testing changes interpretation and usually needs a declared correction or a clearly justified family of planned comparisons.
+- Figures should expose the data structure: `n`, error-bar meaning, test/model, correction, and whether points represent independent units or subsamples.
+- Missing statistical details should be surfaced as author questions, not silently repaired.

--- a/skills/nature-statistics/references/statistical-reporting.md
+++ b/skills/nature-statistics/references/statistical-reporting.md
@@ -1,0 +1,85 @@
+﻿# Statistical reporting checklist
+
+Use this file when drafting or auditing a Statistical analysis, Methods, Results, or Supplementary Methods section.
+
+## Minimum information to extract
+
+For each major analysis, identify:
+
+- endpoint or response variable
+- experimental groups / conditions
+- independent experimental unit
+- biological replicates and technical replicates
+- repeated measures, paired observations, blocks, batches, sites, donors, animals, patients, plots, or model runs
+- inclusion / exclusion criteria
+- missing-data handling
+- randomization and blinding, if applicable
+- transformation or normalization
+- test or model name
+- assumptions checked or rationale for robust / nonparametric approach
+- multiple-comparison correction or planned-comparison rationale
+- reported estimate, uncertainty interval, p value, and sample size
+- software, package, and version when available
+
+## Statistical analysis paragraph structure
+
+A clean manuscript paragraph usually follows this order:
+
+1. **Software and environment**
+   - Name software and packages when supplied.
+   - Do not invent versions.
+
+2. **Data summary convention**
+   - State whether values are mean ± s.d., mean ± s.e.m., median with interquartile range, box-plot convention, or another summary.
+
+3. **Sample-size and replication definition**
+   - Define `n` for each experiment class.
+   - Distinguish independent samples from technical readings or submeasurements.
+
+4. **Test/model choice**
+   - State which comparisons used which tests or models.
+   - Explain paired vs unpaired, parametric vs nonparametric, repeated-measures or mixed-effects models where relevant.
+
+5. **Multiplicity strategy**
+   - State the family of comparisons and correction method, or explain that tests were prespecified and limited.
+
+6. **Thresholds and exact reporting**
+   - Use exact p values where possible.
+   - If thresholds are used, define them and avoid star-only reporting.
+
+7. **Exclusions and robustness**
+   - State pre-established exclusion rules or mark them as missing.
+   - Do not add post-hoc exclusions unless the user supplied them.
+
+## Results wording rules
+
+Prefer:
+
+- `Treatment A was associated with a higher response than control (mean difference ..., 95% CI ..., p = ...).`
+- `The analysis used animals as the independent unit; cell-level measurements are shown to display within-animal variability.`
+- `The evidence is consistent with an increase, although the small sample size limits precision.`
+
+Avoid:
+
+- `proved`, `demonstrated conclusively`, `confirmed the mechanism`, based only on a p value.
+- `highly significant` without effect size or uncertainty.
+- `n = 300 cells` when the experiment actually has three animals or three independent cultures.
+- `ns` as the only result.
+- `data were normally distributed` without a clear basis, especially for very small samples.
+
+## Missing-information labels
+
+Use short factual labels:
+
+- `AUTHOR_INPUT_NEEDED: define independent unit for Fig. 2c.`
+- `AUTHOR_INPUT_NEEDED: state whether comparisons were corrected for multiple testing.`
+- `AUTHOR_INPUT_NEEDED: provide exact p values or the thresholding rule used by the journal.`
+- `AUTHOR_INPUT_NEEDED: state software/package and version.`
+
+## Ready-to-paste skeleton
+
+```text
+Statistical analyses were performed using AUTHOR_INPUT_NEEDED. Data are presented as AUTHOR_INPUT_NEEDED unless otherwise stated. The independent experimental unit was AUTHOR_INPUT_NEEDED; technical replicates were averaged before inferential analysis where applicable. Comparisons between two groups were analysed using AUTHOR_INPUT_NEEDED. Comparisons among more than two groups were analysed using AUTHOR_INPUT_NEEDED, followed by AUTHOR_INPUT_NEEDED correction for multiple comparisons. Exact p values, test statistics and sample sizes are reported in the figure legends or Source Data where available. No data were excluded unless specified in the relevant Methods section.
+```
+
+Use the skeleton only after filling supplied facts. Keep placeholders if facts are missing.


### PR DESCRIPTION
﻿## Summary

Add `nature-statistics`, a Draft skill for manuscript statistical reporting and reviewer-risk checks.

The skill focuses on:

- Statistical analysis / Methods reporting completeness
- independent unit and replication definitions
- p values, effect sizes, uncertainty and multiple-comparison reporting
- figure legend statistics, error bars, star annotations and source-data notes
- conservative responses to reviewer comments about statistics

## Files added

```text
skills/nature-statistics/
├── README.md
├── SKILL.md
└── references/
    ├── source-basis.md
    ├── statistical-reporting.md
    ├── common-failure-modes.md
    ├── figure-statistics.md
    └── reviewer-checklist.md
```

## Notes

This is marked as `Draft` because it defines the workflow and source basis, but has not yet been validated against a larger set of real anonymized manuscripts.
