### PR TITLE
docs: add nature-statistics manifest

### DIFF
--- a/skills/nature-statistics/README.md
+++ b/skills/nature-statistics/README.md
@@ -52,7 +52,9 @@
 ```text
 nature-statistics/
 ├── README.md
+├── README_EN.md
 ├── SKILL.md
+├── manifest.yaml
 └── references/
     ├── source-basis.md
     ├── statistical-reporting.md

--- a/skills/nature-statistics/README_EN.md
+++ b/skills/nature-statistics/README_EN.md
@@ -54,6 +54,15 @@ Use nature-statistics to answer this reviewer comment about unclear statistical 
 For drafting-only requests, the skill can return a shorter `Draft Statistical
 analysis` plus `Reporting notes`.
 
+## Manifest / On-Demand References
+
+`manifest.yaml` keeps the core statistics workflow lightweight:
+
+- `source-basis.md` and `statistical-reporting.md` are always loaded.
+- `common-failure-modes.md`, `figure-statistics.md`, and
+  `reviewer-checklist.md` are loaded only when nested data, figure legends,
+  reviewer response, or final audit QA requires them.
+
 ## Dependencies / API Keys / Local Environment
 
 No external API key is required by default. Statistical software names, package

--- a/skills/nature-statistics/manifest.yaml
+++ b/skills/nature-statistics/manifest.yaml
@@ -1,0 +1,25 @@
+name: nature-statistics
+version: 1.0.0
+description: >
+  Declarative manifest for the statistics-reporting workflow. SKILL.md uses
+  this to keep the always-needed reporting rules small while loading specialized
+  statistical risk checklists only when the manuscript section, figure legend,
+  or reviewer comment requires them.
+
+# Design note: nature-statistics is a conservative reporting/audit skill. The
+# default path always needs source hierarchy and minimum reporting requirements,
+# but heavier risk catalogs should stay on demand so a simple Statistical
+# analysis rewrite does not load every checklist.
+
+always_load:
+  - references/source-basis.md
+  - references/statistical-reporting.md
+
+references:
+  on_demand:
+    - condition: nested data, pseudoreplication, repeated measures, many comparisons, correlations, regressions, outliers, small samples, or overstrong p-value language
+      path: references/common-failure-modes.md
+    - condition: checking figure legends, panel-level n, error bars, stars, box/violin plots, source-data notes, or statistical annotations
+      path: references/figure-statistics.md
+    - condition: final audit QA, severity labeling, reviewer-risk summary, or response-to-reviewer drafting
+      path: references/reviewer-checklist.md


### PR DESCRIPTION
## Summary
- add a `manifest.yaml` for `nature-statistics` so routers/agents can load the core statistical-reporting rules first and defer heavier checklists until needed
- document the manifest in both Chinese and English detail pages
- validate that all manifest paths resolve to existing reference files

## Why
`nature-statistics` already has a clear split between always-needed reporting rules and specialized references (`common-failure-modes`, `figure-statistics`, `reviewer-checklist`). The manifest makes that split machine-readable and consistent with other skills that support static/dynamic loading.

## Test / validation
- Parsed `skills/nature-statistics/manifest.yaml` with Python/YAML
- Checked every `always_load` and `references.on_demand[].path` entry exists under `skills/nature-statistics/`
