### PR TITLE
docs: polish skill readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,26 +319,82 @@ skills/nature-<topic>/
 | `README_EN.md` | 必需 | 与中文详情页配套的英文说明文档 |
 | `references/*.md` | 复杂技能推荐 | 模块化规则文件，例如 API、设计理论、教程、图表类型等 |
 
-建议每个 `README.md` / `README_EN.md` 尽量使用统一的信息结构，方便用户点进详情页后快速判断能不能用：
+### 3. README 写作规则
+
+每个新增技能都必须同时提供 `README.md` 和 `README_EN.md`。README 是面向人的技能入口页，不是 `SKILL.md` 的重复版，也不是安装手册。它的目标是让用户在 30 秒内判断：这个 skill 能不能解决我的问题、我要给它什么、它会产出什么、边界在哪里。
+
+基本规则：
+
+- 中文 README 和英文 README 必须一一镜像：标题数量一致、顺序一致、信息点一致；英文页不要写成另一套独立模板。
+- 顶部固定为技能名、语言切换链接和一句定位说明。
+- 默认使用下面的基础结构；只有确实需要时才插入可选章节。
+- 不要在单个 skill README 中重复仓库安装教程、作者信息、变更日志、开发过程、完整文件树或大段内部实现细节。
+- 复杂规则、API 参数、长教程、脚本说明和模板索引应放进 `references/`、`static/`、`scripts/` 或 `SKILL.md`，README 只保留路标。
+- 如果技能有视觉资产，可以放一个小型预览表；不要把 README 变成大型图库或长篇技术手册。
+
+中文 README 基础结构：
 
 ```markdown
-# nature-<topic>
+# `nature-<topic>` 技能
 
-## 它能做什么
-## 适合什么时候用
-## 你可以直接这样问
-## 输入需要什么
-## 输出会是什么
-## 依赖 / API Key / 本地环境
-## 常见问题
+[English](README_EN.md)
+
+一句话说明这个技能的定位、主要任务和使用边界。
+
+## 适合用它做什么
+## 典型请求
+## 你需要提供
+## 产出
+## 边界
 ## 相关技能
 ```
 
-### 3. 录制使用教程
+英文 README 必须对应为：
+
+```markdown
+# `nature-<topic>` Skill
+
+[中文说明](README.md)
+
+One sentence describing the skill's role, main task, and usage boundary.
+
+## What To Use It For
+## Typical Requests
+## What You Need To Provide
+## Outputs
+## Boundaries
+## Related Skills
+```
+
+可选章节必须中英文同步插入，并保持相同顺序。常见可选章节包括：
+
+| 中文章节 | 英文章节 | 使用场景 |
+|----------|----------|----------|
+| `## 工作方式` | `## Workflow` | 需要解释核心流程或路由方式 |
+| `## 运行和依赖` | `## Runtime and Dependencies` | 有脚本、MCP、API key、本地配置或外部依赖 |
+| `## 示例预览` | `## Example Preview` | 有少量图件、截图或可视化资产值得展示 |
+| `## 内置参考` | `## Built-In References` | 需要指向 `references/`、`assets/` 或 demo |
+| `## 方法来源` | `## Method Sources` | 写作、审查或分析规则来自特定来源 |
+| `## 三种模式` | `## Three Modes` | 技能有清晰的 compose/revise/hybrid 等模式 |
+| `## 与 ... 的关系` | `## Relationship With ...` | 容易和另一个技能混淆，需要说明分工 |
+
+提交前至少做这些 README 检查：
+
+```bash
+git diff --check
+for d in skills/nature-*; do
+  [ -f "$d/README.md" ] && [ -f "$d/README_EN.md" ] || continue
+  rg -q '^\[English\]\(README_EN\.md\)$' "$d/README.md"
+  rg -q '^\[中文说明\]\(README\.md\)$' "$d/README_EN.md"
+  test "$(rg -c '^## ' "$d/README.md")" = "$(rg -c '^## ' "$d/README_EN.md")"
+done
+```
+
+### 4. 录制使用教程
 
 提交 PR 时，请同时录制一个简短的使用教程，说明这个 skill 解决什么问题、如何触发、需要什么输入，以及会产出什么结果。可以在 PR 描述中附上视频、录屏链接或可公开访问的教程地址。
 
-### 4. `SKILL.md` frontmatter 模板
+### 5. `SKILL.md` frontmatter 模板
 
 ```yaml
 ---
@@ -348,7 +404,7 @@ description: >-
 ---
 ```
 
-### 5. 更新技能索引
+### 6. 更新技能索引
 
 在上方 [技能索引](#技能索引) 表格中添加一行：
 
@@ -356,7 +412,7 @@ description: >-
 | [`nature-<topic>`](skills/nature-<topic>/README.md) | Draft / Stable | 一句话用途 | 触发词 | [详情](skills/nature-<topic>/README.md) |
 ```
 
-### 6. 状态标签
+### 7. 状态标签
 
 | 标签 | 含义 |
 |-------|------|

--- a/README_EN.md
+++ b/README_EN.md
@@ -382,29 +382,85 @@ skills/nature-<topic>/
 | `README_EN.md` | Yes | English documentation paired with the Chinese details page |
 | `references/*.md` | Recommended for complex skills | Modular rule files, API references, design theory, tutorials, chart types, and similar material |
 
-Each `README.md` / `README_EN.md` should use a consistent information structure so users can open a details page and quickly decide whether the skill fits:
+### 3. README Writing Rules
+
+Every new skill must include both `README.md` and `README_EN.md`. The README is a human-facing entry page, not a duplicate of `SKILL.md` and not an installation manual. Its job is to help users decide within 30 seconds whether the skill fits their task, what they need to provide, what it will output, and where its boundaries are.
+
+Basic rules:
+
+- The Chinese and English README files must be one-to-one mirrors: same heading count, same order, and same information points. Do not let the English page become a separate template.
+- Start with the skill name, language switch link, and one positioning sentence.
+- Use the base structure below by default; add optional sections only when they are genuinely needed.
+- Do not repeat repository installation instructions, author bios, changelogs, development history, full file trees, or long internal implementation details inside a single skill README.
+- Put complex rules, API parameters, long tutorials, script explanations, and template indexes in `references/`, `static/`, `scripts/`, or `SKILL.md`. Keep only navigational pointers in the README.
+- If the skill has visual assets, a small preview table is fine; do not turn the README into a large gallery or long technical manual.
+
+Chinese README base structure:
 
 ```markdown
-# nature-<topic>
+# `nature-<topic>` 技能
 
-## What It Does
-## When to Use It
-## Copy-Paste Prompts
-## Required Inputs
-## Expected Outputs
-## Dependencies / API Keys / Local Environment
-## FAQ
+[English](README_EN.md)
+
+一句话说明这个技能的定位、主要任务和使用边界。
+
+## 适合用它做什么
+## 典型请求
+## 你需要提供
+## 产出
+## 边界
+## 相关技能
+```
+
+The English README must mirror it as:
+
+```markdown
+# `nature-<topic>` Skill
+
+[中文说明](README.md)
+
+One sentence describing the skill's role, main task, and usage boundary.
+
+## What To Use It For
+## Typical Requests
+## What You Need To Provide
+## Outputs
+## Boundaries
 ## Related Skills
 ```
 
-### 3. Record a Usage Tutorial
+Optional sections must be inserted in both languages and in the same order. Common optional sections:
+
+| Chinese Section | English Section | Use Case |
+|---|---|---|
+| `## 工作方式` | `## Workflow` | Explain the core workflow or routing behavior |
+| `## 运行和依赖` | `## Runtime and Dependencies` | Scripts, MCP services, API keys, local config, or external dependencies |
+| `## 示例预览` | `## Example Preview` | A few figures, screenshots, or visual assets are worth showing |
+| `## 内置参考` | `## Built-In References` | Point to `references/`, `assets/`, or demos |
+| `## 方法来源` | `## Method Sources` | Writing, review, or analysis rules come from specific sources |
+| `## 三种模式` | `## Three Modes` | The skill has clear compose/revise/hybrid-style modes |
+| `## 与 ... 的关系` | `## Relationship With ...` | The skill is easy to confuse with another skill and needs a division-of-labor note |
+
+Before submitting, run at least these README checks:
+
+```bash
+git diff --check
+for d in skills/nature-*; do
+  [ -f "$d/README.md" ] && [ -f "$d/README_EN.md" ] || continue
+  rg -q '^\[English\]\(README_EN\.md\)$' "$d/README.md"
+  rg -q '^\[中文说明\]\(README\.md\)$' "$d/README_EN.md"
+  test "$(rg -c '^## ' "$d/README.md")" = "$(rg -c '^## ' "$d/README_EN.md")"
+done
+```
+
+### 4. Record a Usage Tutorial
 
 When submitting a PR, please also record a short usage tutorial explaining what
 problem the skill solves, how to trigger it, what inputs it needs, and what
 outputs it produces. Add the video, screencast link, or public tutorial URL to
 the PR description.
 
-### 4. `SKILL.md` Frontmatter Template
+### 5. `SKILL.md` Frontmatter Template
 
 ```yaml
 ---
@@ -415,7 +471,7 @@ description: >-
 ---
 ```
 
-### 5. Update Skill Index
+### 6. Update Skill Index
 
 After adding a skill, update the [Skill Index](#skill-index) table:
 
@@ -423,7 +479,7 @@ After adding a skill, update the [Skill Index](#skill-index) table:
 | [`nature-<topic>`](skills/nature-<topic>/README_EN.md) | Draft / Stable | One-sentence purpose | Trigger terms | [Details](skills/nature-<topic>/README_EN.md) |
 ```
 
-### 6. Status Labels
+### 7. Status Labels
 
 | Status | Meaning |
 |---|---|

--- a/skills/nature-academic-search/README.md
+++ b/skills/nature-academic-search/README.md
@@ -2,60 +2,51 @@
 
 [English](README_EN.md)
 
-`nature-academic-search` 是面向 Claude Code / Codex 工作流的学术检索技能包，集成 CrossRef、PubMed、arXiv、Scopus 和 ScienceDirect 文献数据源。
+`nature-academic-search` 用于多源学术检索、文献元数据核查、引用格式生成、严格他引审计和高影响力引用者分析。
 
-## 功能
+## 适合用它做什么
 
-- **多源并发搜索**：默认查询 CrossRef、PubMed、arXiv，并合并返回结果。
-- **按 ID 获取详情**：支持 DOI、PMID、arXiv ID 自动识别。
-- **格式化引用**：支持 APA、Nature、IEEE、Vancouver 等风格。
-- **MeSH 词表查询**：辅助构建精准 PubMed 检索式。
-- **文献管理脚本**：支持 `.nbib`、`.ris`、`.bib`、`.enw` 格式互转。
-- **Scopus / ScienceDirect**：支持论文、作者、机构、期刊、引用概览、PlumX 指标和 ScienceDirect 元数据检索。
-- **严格他引与高影响力引用者审计**：判断引用目标论文的文献是否属于严格他引，排除自引、团队引和明显合作网络引用；可把指定文章的文章名、发表时间、作者名、作者机构、引用数、严格他引数和 DOI 整理成表格；进一步识别院士、校长/院长、杰青/长江、Fellow、高被引学者等高影响力引用者，并提取他们在正文中如何引用目标论文。
+- 在 CrossRef、PubMed、arXiv、Scopus、ScienceDirect 等来源中检索论文。
+- 根据 DOI、PMID 或 arXiv ID 获取结构化文献信息。
+- 生成 Nature、APA、IEEE、Vancouver 等引用格式。
+- 构建 MeSH 检索式，辅助医学和生命科学主题检索。
+- 审计目标论文的严格他引，排除自引、团队引和明显合作网络引用。
+- 识别院士、Fellow、高被引学者、院校领导或领域专家如何引用目标论文。
 
-## MCP 运行
+## 典型请求
 
-插件默认通过 `uv` 启动隔离运行环境：
+- “帮我查这篇论文的严格他引，并列出高影响力引用者。”
+- “按这个主题找 20 篇近五年的 Nature/Science/Cell 相关论文。”
+- “把这些 DOI 转成 Nature 格式引用，并导出 RIS。”
+- “为 PubMed 检索式补 MeSH 词和同义词。”
 
-```bash
-uv run --no-project --directory <mcp-server> --with "mcp>=1.0.0,<2.0.0" --with "requests>=2.28.0,<3.0.0" --with "toml>=0.10.2,<2.0.0" --with "lxml>=4.9.0,<6.0.0" --with "pybliometrics>=4.4.1,<5.0.0" python academic_search_server.py
-```
+## 你需要提供
 
-PubMed 需要在环境变量 `PUBMED_EMAIL` 或 `mcp-server/config.toml` 中配置邮箱。Scopus / ScienceDirect 是可选 provider，复用本机 `pybliometrics` 配置，默认读取 `~/.config/pybliometrics.cfg`；不要把 Elsevier API key 写入插件文件。
+- 检索主题、关键词、时间范围、期刊范围或目标文献 DOI。
+- 是否允许使用 Scopus / ScienceDirect 等需要本机配置的来源。
+- 严格他引的排除口径，例如是否排除同机构、共同作者或课题组网络。
 
-`search_papers` 只有在 `sources` 显式包含 `scopus` / `sciencedirect` 时才会调用 Elsevier-backed provider，以避免无意消耗 Elsevier API 配额。
+## 产出
 
-## MCP 工具
+- 去重后的文献表，包含标题、作者、年份、期刊、DOI 和来源。
+- 引用格式文本或 `.ris`、`.bib`、`.nbib`、`.enw` 等文献管理文件。
+- 严格他引统计表和引用上下文摘要。
+- 查询策略、数据源说明和无法验证的条目列表。
 
-| 工具 | 说明 |
-|------|------|
-| `search_papers` | 默认三源并发搜索；可显式添加 Scopus / ScienceDirect |
-| `get_paper_by_id` | 按 DOI、PMID 或 arXiv ID 获取详情 |
-| `get_citation` | 生成格式化引用 |
-| `lookup_mesh` | 查询 MeSH 词表 |
-| `search_scopus` | Scopus 高级检索 |
-| `get_scopus_abstract` | Scopus 摘要与详情元数据 |
-| `get_scopus_citation_overview` | Scopus 引用概览 |
-| `search_scopus_authors` / `get_scopus_author` | 作者检索与详情 |
-| `search_scopus_affiliations` / `get_scopus_affiliation` | 机构检索与详情 |
-| `search_scopus_serial_titles` / `get_scopus_serial_title` | 期刊与连续出版物检索和详情 |
-| `get_scopus_plumx_metrics` | PlumX 指标 |
-| `search_sciencedirect` | ScienceDirect 检索 |
-| `get_sciencedirect_article_metadata` | ScienceDirect 文章元数据 |
+## 运行和依赖
 
-## 严格他引与引用者画像
+- PubMed 检索需要配置 `PUBMED_EMAIL` 或 `mcp-server/config.toml`。
+- Scopus / ScienceDirect 依赖本机 `pybliometrics` 配置，默认读取 `~/.config/pybliometrics.cfg`。
+- 不要把 Elsevier API key 写入仓库文件；只在本机安全配置中保存。
 
-当用户询问 `严格他引`、`他引判定`、`谁引用了我的文章`、`引用我的文章的人有没有大牛`、`文章引用表`、`指定文章引用数`、`严格他引数`、`整理成表格`、`院士引用`、`杰青引用`、`长江学者引用` 或 `Fellow citation` 时，本技能会加载
-`references/workflows/wf6-strict-other-citation-impact-audit.md`。
+## 边界
 
-该 workflow 的默认标准比普通“非自引”更严格：
+- 二级学术索引只能作为发现线索，关键字段应回到 DOI、PubMed、出版社页面或数据库记录核实。
+- 严格他引判断需要明确排除规则；没有作者/机构信息时会标注不确定。
+- 无权限数据库不会被绕过，只会报告缺失来源或需要用户登录。
 
-1. 先确认目标论文的 DOI、作者、机构和可用作者 ID。
-2. 汇总 Scopus、Web of Science、Semantic Scholar、OpenAlex、CrossRef 或出版商 cited-by 页面中的 citing papers，并说明覆盖范围。
-3. 排除直接自引、同团队/同课题组引用、明显合作网络引用和元数据不足的情况。
-4. 如果用户要表格，输出 `文章名 / 发表时间 / 作者名 / 作者机构 / 引用数 / 严格他引数 / DOI / 证据备注`。
-5. 对严格他引或可能外部引用者，核验是否存在院士、校长/院长、杰青/长江、Fellow、高被引学者等身份信号。
-6. 从可获取全文中抽取 citation context，判断对方是把目标论文作为背景、方法、对比、延伸、复现、批评还是综述性引用。
+## 相关技能
 
-所有身份标签都必须附带证据来源；无法确认同一人的情况只能标记为 `unverified`。
+- `nature-citation`：为手稿 claim 匹配 Nature/CNS/Cell 支撑文献。
+- `nature-literature-pipeline`：把一次性检索升级为持续文献监测。
+- `nature-ref-verifier`：逐条核查参考文献字段。

--- a/skills/nature-academic-search/README_EN.md
+++ b/skills/nature-academic-search/README_EN.md
@@ -2,54 +2,51 @@
 
 [中文说明](README.md)
 
-## What It Does
+`nature-academic-search` supports multi-source scholarly search, bibliographic metadata checks, citation formatting, strict external-citation audits, and influential-citer analysis.
 
-- Coordinates multi-source academic search, citation verification, strict external-citation audits, influential-citer profiling, and reference-management exports.
-- It is the right entry point when a task needs evidence from scholarly databases rather than a single ad hoc search.
+## What To Use It For
 
-## When to Use It
+- Search papers across CrossRef, PubMed, arXiv, Scopus, ScienceDirect, and related scholarly sources.
+- Retrieve structured paper details by DOI, PMID, or arXiv ID.
+- Generate Nature, APA, IEEE, Vancouver, and other citation styles.
+- Build MeSH-assisted PubMed search strategies for biomedical topics.
+- Audit strict external citations for a target paper while excluding self-citations, team citations, and obvious collaboration-network citations.
+- Identify how academy members, Fellows, highly cited scholars, institutional leaders, or field experts cited a target paper.
 
-- Search papers across multiple sources for a topic, DOI, author, or manuscript claim.
-- Verify bibliographic metadata or DOI accuracy.
-- Build a table of a paper's title, publication date, authors, affiliations, citation count, strict external-citation count, and DOI.
-- Check whether major scholars, academy members, presidents, deans, distinguished young scholars, Changjiang Scholars, or Fellows have cited a paper, and summarize how they cited it.
+## Typical Requests
 
-## Copy-Paste Prompts
+- "Check the strict external citations for this paper and list influential citers."
+- "Find 20 recent Nature/Science/Cell-related papers on this topic."
+- "Convert these DOIs into Nature-style references and export RIS."
+- "Add MeSH terms and synonyms to this PubMed query."
 
-- `Search recent high-impact papers about chloride-induced corrosion prediction and return a ranked table.`
-- `Verify this reference list and flag fabricated authors, wrong years, page mismatches, and DOI conflicts.`
-- `Create a table for this paper with title, publication date, authors, affiliations, citation count, strict external-citation count, and DOI.`
-- `Check whether influential scholars or Fellows cited this paper, and summarize the citing context.`
+## What You Need To Provide
 
-## Required Inputs
+- Search topic, keywords, time range, journal scope, or target DOI.
+- Whether Scopus / ScienceDirect or other locally configured sources may be used.
+- The exclusion rule for strict external citations, such as whether to exclude same-institution, coauthor, or lab-network citations.
 
-- Research topic, paper title, DOI, author name, reference list, or manuscript passage.
-- Optional source preferences such as PubMed, CrossRef, arXiv, Scopus, ScienceDirect, or publisher pages.
-- Optional definition of self-citation or strict external citation for the target field.
+## Outputs
 
-## Expected Outputs
+- Deduplicated paper table with title, authors, year, journal, DOI, and source.
+- Formatted citation text or `.ris`, `.bib`, `.nbib`, `.enw` reference-management files.
+- Strict external-citation table and citation-context summary.
+- Search strategy, source notes, and records that could not be verified.
 
-- Ranked search tables with source links and metadata.
-- Reference-verification reports and corrected citation candidates.
-- Strict external-citation audit tables.
-- Influential-citer profiles with cited-context summaries and uncertainty notes.
-- BibTeX, RIS, NBIB, or other reference-manager-ready exports when supported by the workflow.
+## Runtime and Dependencies
 
-## Dependencies / API Keys / Local Environment
+- PubMed search needs `PUBMED_EMAIL` or `mcp-server/config.toml`.
+- Scopus / ScienceDirect depend on local `pybliometrics` configuration, normally read from `~/.config/pybliometrics.cfg`.
+- Do not write Elsevier API keys into repository files; keep them in local secure configuration.
 
-- Some providers require local credentials or API access.
-- PubMed workflows require a configured `PUBMED_EMAIL`.
-- Scopus, ScienceDirect, and other optional providers require credentials configured outside the repository.
-- Never commit API keys or provider credentials to the repository.
+## Boundaries
 
-## FAQ
-
-- **Can it guarantee exact citation counts?** No. Citation counts differ by database and update time; the report should name the source and timestamp when counts matter.
-- **What is strict external citation?** It excludes citations by overlapping authors or institutions according to the task's stated rule, then reports the rule used.
-- **Can it identify influential citers automatically?** It can profile candidates from affiliation, title, honors, and public scholarly signals, but uncertain cases should be marked rather than overstated.
+- Secondary scholarly indexes are discovery aids; key fields should be verified through DOI records, PubMed, publisher pages, or authoritative databases.
+- Strict external-citation analysis needs a clear exclusion rule; missing author or affiliation metadata is marked as uncertain.
+- Restricted databases are not bypassed; the skill reports missing sources or asks for user login when needed.
 
 ## Related Skills
 
-- [`nature-citation`](../nature-citation/README_EN.md)
-- [`nature-ref-verifier`](../nature-ref-verifier/README_EN.md)
-- [`nature-reader`](../nature-reader/README_EN.md)
+- `nature-citation`: match Nature/CNS/Cell supporting citations for manuscript claims.
+- `nature-literature-pipeline`: turn one-off search into ongoing literature monitoring.
+- `nature-ref-verifier`: verify reference-list metadata field by field.

--- a/skills/nature-citation/README.md
+++ b/skills/nature-citation/README.md
@@ -2,95 +2,43 @@
 
 [English](README_EN.md)
 
-`nature-citation` 用于把论文段落、手稿片段或单条科研判断转化为可审查的 Nature / CNS 系列参考文献候选，并导出可被文献管理器直接导入的文件。
+`nature-citation` 用于把论文段落、手稿片段或单条科学判断拆成可引用的 claim，并为每个 claim 寻找 Nature Portfolio、Science family 和 Cell Press 范围内的支撑文献。
 
-这个技能支持中文输入。用户可以直接提出“分段引用”“Nature 系列引用”“CNS 及子刊”“补引用”“支撑文献”“导出 Zotero”等需求；技能会用英文科学概念检索文献，同时默认返回中文审查说明。
+## 适合用它做什么
 
-## 功能
+- 给 introduction、discussion 或 reviewer response 中的关键判断补引用。
+- 将长段落拆成稳定编号的 claim 单元，例如 `S001`、`S002`。
+- 限定只查 Nature、Science、Cell 及其子刊，或只保留旗舰刊。
+- 为每个候选文献说明支撑位置、证据强度和插入建议。
+- 导出 Zotero、EndNote 或其他文献管理器可用的文件。
 
-- 将手稿拆分为可引用的 claim 单元，并生成稳定编号，例如 `S001`、`S002`、`S003`。
-- 为每个片段生成面向 Crossref 等结构化元数据源的检索式。
-- 将结果限制在 Nature Portfolio、AAAS Science family、Cell Press，或只保留旗舰刊范围。
-- 为每个片段匹配候选文献，并给出建议的正文插入位置。
-- 导出一个 `ENW`、`RIS` 或 Zotero `RDF` 文献管理文件。
-- 可选生成 JSON、TSV、Markdown 和 HTML 审查材料，便于人工筛选。
-- 支持长文批处理、部分检查点、失败重试和局部段落运行。
-- 支持 DOI-only 导出，适合用户已经确认文献列表的场景。
+## 典型请求
 
-## 来源层级
+- “把这段 introduction 分段补 Nature 系列引用。”
+- “只用 CNS 及子刊，为这些 claim 找近五年的支撑文献。”
+- “我已经确认这些 DOI，帮我导出 Zotero 可导入文件。”
 
-- Crossref 结构化元数据与 DOI 记录。
-- 相关时使用 PubMed / NCBI E-utilities 做生物医学交叉核对。
-- Nature Portfolio、AAAS Science、Cell Press 的官方出版商页面。
-- 二级学术索引只作为发现线索，不能作为唯一支撑依据。
+## 你需要提供
 
-## 文件结构
+- 待引用的段落、claim 列表或 DOI 清单。
+- 期刊范围、时间范围、是否允许综述、是否只要旗舰刊。
+- 目标引用格式和导出格式，例如 `RIS`、`ENW` 或 Zotero `RDF`。
 
-该技能采用 router/static-dynamic 结构：`SKILL.md` 负责短路由，`manifest.yaml` 决定常驻内容和按需参考文件。`nature-citation` 是线性工作流，没有内容轴，因此主要由 core 常驻内容和按需 references 组成。
+## 产出
 
-```text
-nature-citation/
-├── SKILL.md                     # 短路由
-├── manifest.yaml                # always_load core + 按需 references
-├── README.md
-├── static/
-│   └── core/                    # 始终加载
-│       ├── principles.md        # 产物、期刊范围、来源层级、检索规则
-│       ├── chinese-mode.md      # 中文用户模式
-│       └── workflow.md          # 7 步工作流与报告格式
-├── references/                  # 按需打开
-│   ├── script-usage.md          # nature_citation.py 参数与长文批处理
-│   ├── journal-scope.md
-│   ├── ris-endnote.md
-│   └── search-strategy.md
-└── scripts/
-    └── nature_citation.py
-```
+- claim 分段表和候选文献表。
+- 每个 claim 的建议插入位置、候选 DOI、期刊、年份和支撑说明。
+- 可选的 JSON、TSV、Markdown、HTML 审查材料。
+- 可导入文献管理器的引用文件。
 
-## 适用场景
+## 边界
 
-- 给摘要、引言、结果、讨论或单段文字补充引用。
-- 将长文本拆成“片段-候选文献”对应表。
-- 限定只检索 `Nature系列`、`CNS`、`CNS及其子刊` 或 `只看正刊`。
-- 为 EndNote、Zotero 或其他文献管理器导出记录。
-- 判断一句话获得的是直接支撑、部分支撑，还是背景性支撑。
-- 生成 HTML 审查页，让用户按年份筛选、选择文献并下载所需记录。
+- 只把论文作为候选支撑，不会替作者保证其必然适合最终引用。
+- 不会使用博客、新闻稿或搜索摘要作为唯一依据。
+- 当文献只能支撑相邻但不完全相同的 claim 时，会明确标注证据偏差。
 
-## 长文本处理
+## 相关技能
 
-短输入会采用普通的一次性检索流程。较长输入可以分批处理，每批完成后写入部分导出检查点，避免后续批次失败导致前面进度丢失。Crossref 临时失败会自动重试。
-
-经验规则：
-
-- 1-10 个片段：普通运行。
-- 11-25 个片段：优先使用 batch mode。
-- 26 个以上片段：优先按小节分开运行。
-
-## 设计意图
-
-该技能优先追求可辩护性，而不是候选文献数量。它的目标是帮助用户发现范围内的潜在支撑文献，而不是把元数据当成证据本身。每条导出记录都应保留真实元数据，不补造字段，并明确提示仍需人工阅读全文或摘要来确认支撑强度。
-
-对长手稿而言，设计目标还包括运行稳定性：更小批次、更少中断、更清晰的检查点轨迹。
-
-## 参考文件
-
-- `search-strategy.md`：claim 拆解、支撑等级和常见检索失败模式。
-- `journal-scope.md`：Nature / Science / Cell 家族边界与旗舰刊解释。
-- `ris-endnote.md`：`ENW`、`RIS`、Zotero `RDF` 导出说明。
-- `scripts/nature_citation.py`：本地 CLI，用于分段、Crossref 检索、导出和 HTML 审查页生成。
-
-## 常用 CLI 参数
-
-- `--batch-size 2`：将长文本拆成更小批次处理。
-- `--max-segments 12`：限制一次运行处理的片段数。
-- `--max-retries 2`：重试临时 Crossref 失败。
-- `--sleep 0.3`：缩短请求间默认等待。
-- `--with-artifacts`：生成 HTML、TSV、JSON 和 Markdown 审查文件。
-
-## 注意事项
-
-- 默认产物是单个文献管理文件；其他审查材料需显式开启。
-- `metadata-only candidate` 表示仍需人工查看摘要或全文后才能引用。
-- HTML 审查页可将用户选中的记录导出为 `ENW`、`RIS` 或 Zotero `RDF`。
-- 长文本建议开启 `--with-artifacts`，因为 HTML 页面最方便人工筛选。
-- Batch mode 会在最终导出前持续写入 `.partial.enw`、`.partial.ris` 或 `.partial.rdf` 检查点。
+- `nature-academic-search`：更宽范围的文献搜索和引用指标审计。
+- `nature-ref-verifier`：校验已选参考文献的元数据。
+- `nature-writing`：把引用选择整合回手稿论证。

--- a/skills/nature-citation/README_EN.md
+++ b/skills/nature-citation/README_EN.md
@@ -2,46 +2,43 @@
 
 [中文说明](README.md)
 
-## What It Does
+`nature-citation` splits manuscript passages or scientific claims into citable units and finds supporting references from Nature Portfolio, the Science family, and Cell Press.
 
-- Adds strict Nature/CNS-style supporting citations to manuscript passages by splitting claims into citable segments and searching within curated high-impact source families.
+## What To Use It For
 
-## When to Use It
+- Add citations to key claims in an introduction, discussion, or reviewer response.
+- Split long passages into stable claim units such as `S001` and `S002`.
+- Restrict evidence to Nature, Science, Cell, and their subjournals, or keep only flagship journals.
+- Explain each candidate paper's support position, evidence strength, and insertion point.
+- Export selected references for Zotero, EndNote, or other reference managers.
 
-- You need supporting references for a manuscript paragraph, abstract, introduction, or discussion.
-- You want references constrained to Nature Portfolio, Science-family, or Cell Press sources.
-- You need citation exports such as ENW, RIS, or Zotero RDF.
+## Typical Requests
 
-## Copy-Paste Prompts
+- "Split this introduction paragraph and add Nature-series citations."
+- "Use only CNS and subjournal papers from the last five years to support these claims."
+- "I have confirmed these DOIs; export them in a Zotero-importable format."
 
-- `Add Nature/CNS-style supporting citations to this introduction paragraph.`
-- `Split this long claim into citable segments and find supporting high-impact references.`
-- `Export the selected references as RIS for Zotero.`
+## What You Need To Provide
 
-## Required Inputs
+- Passage to cite, claim list, or DOI list.
+- Journal scope, year range, whether reviews are allowed, and whether only flagship journals should be kept.
+- Target citation style and export format such as `RIS`, `ENW`, or Zotero `RDF`.
 
-- Manuscript passage or claim list.
-- Optional journal/source constraints and publication-year range.
-- Optional export format preference.
+## Outputs
 
-## Expected Outputs
+- Claim-segmentation table and candidate-reference table.
+- Suggested insertion position, DOI, journal, year, and support note for each claim.
+- Optional JSON, TSV, Markdown, or HTML review materials.
+- Reference-management export file.
 
-- Segmented claim-to-reference mapping.
-- Recommended citations with source rationale.
-- Reference-manager-ready export files when requested.
+## Boundaries
 
-## Dependencies / API Keys / Local Environment
-
-- Internet or literature-search access may be required for fresh verification.
-- Reference exports depend on the available local scripts and source metadata.
-
-## FAQ
-
-- **Does it cite any paper it finds?** No. It should follow the skill's strict source and relevance filters.
-- **Can I use it for non-Nature journals?** Yes, but the default source discipline is Nature/CNS-leaning support, so say when a broader scope is desired.
+- Candidate papers are support options, not a guarantee that the final citation is appropriate.
+- Blogs, press releases, and search snippets are not used as sole evidence.
+- When a paper supports a nearby but not identical claim, the evidence mismatch is stated explicitly.
 
 ## Related Skills
 
-- [`nature-academic-search`](../nature-academic-search/README_EN.md)
-- [`nature-ref-verifier`](../nature-ref-verifier/README_EN.md)
-- [`nature-writing`](../nature-writing/README_EN.md)
+- `nature-academic-search`: broader literature search and citation-metric audits.
+- `nature-ref-verifier`: verify selected reference metadata.
+- `nature-writing`: integrate citation choices back into manuscript argument.

--- a/skills/nature-data/README.md
+++ b/skills/nature-data/README.md
@@ -2,62 +2,43 @@
 
 [English](README_EN.md)
 
-`nature-data` 用于为 Nature / Springer Nature 风格投稿准备或审查 Data Availability statement、数据仓储方案、数据集引用和 FAIR 元数据检查。
+`nature-data` 用于准备、审查或修改 Nature / Springer Nature 风格的 Data Availability statement、数据仓储计划、数据集引用和 FAIR 元数据清单。
 
-该技能支持中文作者笔记。用户可以用中文描述“数据可向通讯作者索取”“原始数据”“受限数据”“公共数据库”等情况；技能会转化为可投稿的英文表述，并在需要时给出中文确认项。
+## 适合用它做什么
 
-## 功能
-
-- 起草可直接粘贴到稿件中的 Data Availability statement。
-- 在投稿前审查薄弱或不完整的数据可用性表述。
-- 将每个支撑结果的数据集映射到仓储、accession、DOI 或访问路径。
+- 起草可放入稿件的 Data Availability statement。
+- 审查“数据可向通讯作者索取”“原始数据见补充材料”等表述是否充分。
+- 为每个支撑论文结论的数据集匹配仓储、accession、DOI、许可证或访问条件。
 - 区分公开数据、受控访问数据、第三方数据、补充材料数据和不适用场景。
-- 准备 FAIR 元数据和 DataCite 风格的数据集引用检查。
-- 标记缺失的仓储记录、许可证、来源、embargo 细节和访问条件。
-- 将中文作者意图对齐为 Nature 风格英文数据可用性措辞。
+- 将中文作者笔记转成投稿可用英文，并列出需要作者确认的信息。
 
-## 来源层级
+## 典型请求
 
-- Nature Portfolio 与 Springer Nature 的研究数据政策。
-- Nature Portfolio 关于数据、代码、材料和实验方案可用性的报告标准。
-- Scientific Data 关于仓储、原始性、长期保存和数据引用的实践。
-- FAIR Guiding Principles 与 DataCite 元数据规范。
+- “帮我把这篇稿子的 Data Availability 写成 Nature 风格。”
+- “这些数据有一部分不能公开，帮我写受控访问说明。”
+- “检查我的数据声明是否缺 accession、仓储或许可证。”
 
-## 文件结构
+## 你需要提供
 
-该技能采用 router/static-dynamic 结构：`SKILL.md` 负责短路由，`manifest.yaml` 加载常驻 core 和按需 references。`nature-data` 是线性工作流，没有内容轴。
+- 支撑每个图表或结论的数据来源。
+- 数据是否已上传、仓储链接、accession、DOI、embargo 或访问限制。
+- 代码、材料、实验方案和第三方数据的可用性边界。
 
-```text
-nature-data/
-├── SKILL.md                     # 短路由
-├── manifest.yaml                # always_load core + 按需 references
-├── README.md
-├── agents/
-│   └── openai.yaml
-├── static/
-│   └── core/                    # 始终加载
-│       ├── stance.md            # 默认立场与来源层级
-│       ├── chinese-mode.md      # 中文用户模式
-│       └── workflow.md          # 8 步工作流与输出格式
-└── references/
-    ├── fair-metadata-checklist.md
-    ├── chinese-author-alignment.md
-    ├── policy-principles.md
-    ├── repository-and-identifiers.md
-    ├── source-basis.md
-    └── statement-patterns.md
-```
+## 产出
 
-## 适用场景
+- 可粘贴的英文 Data Availability statement。
+- 数据集到图表/结论的映射表。
+- 缺失信息清单和 FAIR / DataCite 元数据检查。
+- 对受限数据、第三方数据或补充材料数据的保守表述建议。
 
-- 为 Nature 系列或 Springer Nature 期刊准备 Data Availability statement。
-- 投稿前决定数据应存放在哪个仓储。
-- 修改含糊的 “available on request” 表述。
-- 处理受控访问、人类参与者、商业专有或第三方数据。
-- 引用带 DOI、accession number、Handle、ARK 或仓储记录的数据集。
-- 检查数据存储是否达到投稿所需的 FAIR 程度。
-- 将中文数据可用性说明转成准确的英文投稿文本。
+## 边界
 
-## 设计意图
+- 不会编造 accession、DOI、许可证、仓储记录或访问限制。
+- 信息缺失时，会给出可用草稿和短确认清单，而不是假装完整。
+- 受伦理、隐私、商业或第三方协议限制的数据，需要作者提供真实限制条件。
 
-该技能要求每个支撑论文结论的数据集都有明确可追踪的访问路径。它不会编造 accession、许可证、限制条件或仓储元数据。信息缺失时，应给出可用草稿，并列出作者必须确认的短清单；如果用户从中文草稿开始，应优先给出中文确认说明。
+## 相关技能
+
+- `nature-experiment-log`：把实验记录和原始附件整理成可追溯数据来源。
+- `nature-statistics`：检查统计报告和 source data 表述。
+- `nature-response`：回应审稿人关于数据可用性的质疑。

--- a/skills/nature-data/README_EN.md
+++ b/skills/nature-data/README_EN.md
@@ -2,46 +2,43 @@
 
 [中文说明](README.md)
 
-## What It Does
+`nature-data` prepares, audits, or revises Nature / Springer Nature-style Data Availability statements, repository plans, dataset citations, and FAIR metadata checklists.
 
-- Prepares Nature-ready Data Availability statements, repository plans, dataset citations, and FAIR metadata checklists.
+## What To Use It For
 
-## When to Use It
+- Draft a manuscript-ready Data Availability statement.
+- Check whether statements such as "data are available from the corresponding author" or "raw data are in supplementary materials" are sufficient.
+- Map every dataset supporting a conclusion to a repository, accession, DOI, license, or access condition.
+- Distinguish public data, controlled-access data, third-party data, supplementary-data cases, and not-applicable cases.
+- Turn Chinese author notes into submission-ready English and list facts that still need confirmation.
 
-- A manuscript needs a Data Availability statement.
-- You need to choose a repository or accession strategy.
-- The data include sensitive, restricted, proprietary, or third-party materials.
+## Typical Requests
 
-## Copy-Paste Prompts
+- "Write this manuscript's Data Availability statement in Nature style."
+- "Some data cannot be public; draft a controlled-access statement."
+- "Check whether my data statement is missing accessions, repositories, or licenses."
 
-- `Draft a Nature-ready Data Availability statement for this manuscript.`
-- `Choose a repository plan for these datasets and explain what metadata are required.`
-- `Audit this data-sharing plan against FAIR expectations.`
+## What You Need To Provide
 
-## Required Inputs
+- The data source supporting each figure, table, or conclusion.
+- Upload status, repository link, accession, DOI, embargo, or access restriction.
+- Availability boundaries for code, materials, protocols, and third-party data.
 
-- Dataset descriptions, file types, repository names, accession numbers, restrictions, and manuscript context.
-- Information about source data, supplementary data, code, and third-party datasets.
+## Outputs
 
-## Expected Outputs
+- Ready-to-paste English Data Availability statement.
+- Dataset-to-figure/conclusion mapping table.
+- Missing-information checklist and FAIR / DataCite metadata check.
+- Conservative wording for restricted, third-party, or supplementary-data cases.
 
-- Data Availability statement drafts.
-- Repository and accession checklists.
-- Dataset citation and FAIR metadata guidance.
-- Risk notes for restricted or sensitive data.
+## Boundaries
 
-## Dependencies / API Keys / Local Environment
-
-- No special runtime dependency for text-only drafting.
-- Repository-specific validation may require internet access.
-
-## FAQ
-
-- **Can it invent accession numbers?** No. It should use provided accession numbers or leave clear placeholders.
-- **Can restricted data still be described?** Yes. It should state access conditions, governance, and request paths clearly.
+- The skill does not invent accessions, DOIs, licenses, repository records, or access restrictions.
+- Missing information is handled with a usable draft plus a short confirmation checklist.
+- Data restricted by ethics, privacy, commercial terms, or third-party agreements need real restriction details from the author.
 
 ## Related Skills
 
-- [`nature-writing`](../nature-writing/README_EN.md)
-- [`nature-response`](../nature-response/README_EN.md)
-- [`nature-reader`](../nature-reader/README_EN.md)
+- `nature-experiment-log`: organize experiment logs and raw attachments into traceable data sources.
+- `nature-statistics`: check statistical reporting and source-data wording.
+- `nature-response`: respond to reviewer concerns about data availability.

--- a/skills/nature-downloader/README.md
+++ b/skills/nature-downloader/README.md
@@ -1,174 +1,48 @@
-# nature-downloader
+# `nature-downloader` 技能
 
 [English](README_EN.md)
 
-<p align="center">
-  <img src="assets/banner.jpg" alt="nature-downloader — 补齐 nature 工作流缺失的 PDF 落地环节" width="100%">
-</p>
+`nature-downloader` 用于在开放获取或用户本人机构授权范围内获取论文全文、PDF、HTML 全文或可追溯下载状态，补齐学术工作流中的“合法落地”环节。
 
-`nature-downloader` 是一个合法机构权限下的学术全文/PDF 下载 skill。它把两部分能力合在一起：
+## 适合用它做什么
 
-- **首次资源入口配置**：先记录用户实际使用的图书馆电子资源链接，再识别学校、SSO/CARSI/EZproxy/WebVPN/资源聚合平台信息，配置保存到 `~/.config/lit-dl/school.json`。
-- **真实全文落地**：通过用户已经登录的 Chrome 会话和 web-access CDP proxy，复用本人的图书馆/CARSI/出版社访问权限，把能合法访问的 PDF 保存到项目文件夹；如果馆藏只提供 HTML 全文，则保存 HTML/文本并明确说明没有 PDF。
-- **中文文献默认知网**：按中文题名下载时，默认优先走用户已登录/已授权的 CNKI/知网页面；可通过学校配置或 `--cnki-url` 指定图书馆提供的知网入口。
-- **开放获取优先**：若文献本身是开放获取或开源期刊文章，直接走合法开放 PDF；若图书馆资源明确无权限，直接告诉用户。
+- 首次配置学校图书馆、CARSI、EZproxy、WebVPN 或资源聚合平台入口。
+- 复用用户已经登录的 Chrome 机构会话下载可合法访问的论文 PDF。
+- 对 DOI、题名、出版社页面、PubMed 页面或 CNKI 中文题名尝试获取全文。
+- 如果没有 PDF，保存 HTML、文本或说明可访问状态。
+- 对无法访问的文献给出原因：无权限、需用户登录、验证码、人机验证或馆藏缺失。
 
-它不绕过付费墙，不使用镜像站，不破解验证码，不读取或导出 cookies、密码、localStorage、session 文件。遇到 jAccount/CARSI、验证码、Cloudflare、短信/OTP、人机验证时，会停下让用户本人在 Chrome 里完成。
+## 典型请求
 
-## 快速使用
+- “帮我配置学校图书馆入口，以后下载论文时复用。”
+- “用我已经登录的 Chrome 把这些 DOI 的 PDF 下载到当前项目。”
+- “这篇中文文献走知网授权入口下载，能下就保存，不能下说明原因。”
 
-把下面这句话复制给 agent，即可让它自动完成首次配置引导：
+## 你需要提供
 
-```text
-请使用 nature-downloader 帮我完成首次图书馆资源配置：先向我索要图书馆电子资源/数据库入口链接，识别授权路径并保存配置；如果需要登录，请引导我在 Chrome 中完成统一身份认证/CARSI 登录；最后运行配置展示和连通性自检，确认后续可复用该图书馆资源下载文献。
-```
+- DOI、标题、论文页面链接或中文文献题名。
+- 学校图书馆数据库入口或已登录的 Chrome 会话。
+- 目标保存目录和文件命名偏好。
 
-### 1. 配置资源入口
+## 产出
 
-全新用户优先提供图书馆电子资源/数据库入口链接，而不是先填学校名：
+- 下载到本地的 PDF、HTML 或文本文件。
+- 每篇文献的访问路径、保存路径和失败原因。
+- 可复用的学校入口配置，通常位于 `~/.config/lit-dl/school.json`。
 
-```bash
-python3 scripts/configure_school.py infer "https://whu.metaersp.cn/personalIndex"
-python3 scripts/configure_school.py url "https://whu.metaersp.cn/personalIndex"
-python3 scripts/configure_school.py show
-```
+## 运行和依赖
 
-`infer` 只判断授权路径不保存，`url` 会写入配置。比如武汉大学 `whu.metaersp.cn` 会被识别为资源聚合门户，后续需要登录时再跳转到 `cas.whu.edu.cn`。
+- 首次配置可使用 `scripts/configure_school.py` 识别和保存资源入口。
+- 真实下载依赖本机浏览器登录状态和可用的 web-access / CDP 控制能力。
+- 中文文献默认优先使用用户已授权的 CNKI 或图书馆知网入口。
 
-如果没有资源入口链接，再用预设学校兜底：
+## 边界
 
-```bash
-python3 scripts/configure_school.py preset 上海交通大学
-python3 scripts/configure_school.py show
-```
+- 不绕过付费墙，不使用镜像站，不破解验证码，不读取或导出 cookie、密码、localStorage 或 session 文件。
+- 遇到统一身份认证、CARSI、验证码、Cloudflare、短信或 OTP 时，需要用户本人在浏览器里完成。
+- 没有合法权限时，只报告状态和可选替代路径。
 
-查看可用预设：
+## 相关技能
 
-```bash
-python3 scripts/configure_school.py list
-```
-
-运行连通性自检：
-
-```bash
-python3 scripts/configure_school.py health --force
-```
-
-配置路径默认是 `~/.config/lit-dl/school.json`。测试或多 profile 场景可以用 `LIT_DL_CONFIG_DIR=/path/to/configdir` 覆盖。
-
-### 2. 准备浏览器登录态
-
-1. 在 Chrome 里打开本校图书馆或学术资源聚合入口。
-2. 用本人账号完成统一身份认证/CARSI 登录。
-3. 确认 Web of Science 或目标出版商页面能在 Chrome 中正常看到全文入口。
-4. 打开 `chrome://inspect/#remote-debugging`，允许当前浏览器实例远程调试。
-5. 启动 web-access CDP proxy。
-
-### 3. 下载文献
-
-按 DOI 下载：
-
-```bash
-node scripts/batch_download.mjs \
-  --dois "10.1007/s00122-021-03957-1,10.1111/pbi.14066" \
-  --out "./文献自动下载"
-```
-
-按中文题名下载，默认走知网：
-
-```bash
-node scripts/batch_download.mjs \
-  --title "乡村振兴背景下数字治理研究" \
-  --out "./文献自动下载"
-```
-
-如果只要 PDF、不要 CAJ，加 `--cnki-format pdf`。这样在知网没有明确 PDF 下载入口时，脚本会报出未找到可授权 PDF，而不会保存 `.caj`：
-
-```bash
-node scripts/batch_download.mjs \
-  --title "乡村振兴背景下数字治理研究" \
-  --cnki-format pdf \
-  --out "./文献自动下载"
-```
-
-如果学校图书馆提供了专用知网入口，可显式指定：
-
-```bash
-node scripts/batch_download.mjs \
-  --title "乡村振兴背景下数字治理研究" \
-  --cnki-url "https://kns.cnki.net/kns8s/defaultresult/index" \
-  --out "./文献自动下载"
-```
-
-按主题从 Web of Science 检索并下载前 N 篇：
-
-```bash
-node scripts/batch_download.mjs \
-  --topic "rice blast resistance gene" \
-  --count 10 \
-  --out "./文献自动下载"
-```
-
-按精确题名下载开放获取论文（适合 arXiv 论文、无 DOI 论文）：
-
-```bash
-node scripts/batch_download.mjs \
-  --title "Attention Is All You Need" \
-  --open-access \
-  --out "./文献自动下载"
-```
-
-已知 PDF 地址时直接下载并验证：
-
-```bash
-node scripts/batch_download.mjs \
-  --pdf-url "https://arxiv.org/pdf/1706.03762" \
-  --title "Attention Is All You Need" \
-  --out "./文献自动下载"
-```
-
-默认只下载主 PDF。只有明确需要补充材料时才加：
-
-```bash
-node scripts/batch_download.mjs --dois "10.xxxx/example" --out "./文献自动下载" --si
-```
-
-输出目录：
-
-```text
-文献自动下载/
-  PDFs/
-  SupportingInformation/
-```
-
-脚本会输出 JSON 状态，常见状态包括 `downloaded`、`open_access_downloaded`、`full_text_html_available`、`library_no_permission`、`carsi_waiting_user`、`publisher_verification_waiting_user`、`sciencedirect_robot_check`、`no_authorized_pdf_found`、`failed_after_retry`。当状态是 `full_text_html_available` 时，表示已拿到可读 HTML 全文，但当前授权路径没有有效 PDF，回复用户时必须说清楚；当状态是 `library_no_permission` 时，表示当前图书馆资源没有该文献全文权限，也必须直接说明。
-
-## 当前实现边界
-
-- 已实现：学校配置、配置文件读写、预设库、连通性自检、Web of Science 入口配置读取、Chrome 登录态下 PDF 下载、PDF 文件头验证、状态码体系。
-- 已实现：中文题名默认 CNKI/知网路由，复用 Chrome 中已有的图书馆/知网登录态下载可授权访问的 PDF/CAJ；可用 `--cnki-format pdf` 限制为只下载 PDF。
-- 已验证路径：以上海交通大学/SJTU + Web of Science + CARSI/Chrome 会话为主要真实下载路径。
-- 新用户首配策略：优先从图书馆资源入口链接识别授权链路；学校预设只作为兜底。
-- 已验证开放获取路径：`--title "Attention Is All You Need" --open-access` 会精确匹配 arXiv 标题并下载 PDF。
-- 工作流策略：开放获取文章直接下载；非开放获取文章走已配置图书馆资源；馆藏无权限时明确告知用户。
-- 可扩展路径：其他学校可通过 `data/schools.yaml` 配置 SSO/CARSI 和 `discovery.web_of_science_url`。
-- 不承诺：无登录态下载、绕过出版社限制、自动处理验证码/OTP/Cloudflare、无限批量下载。
-- 注意：`--topic` 是 Web of Science 主题检索，不保证精确题名命中；精确题名优先使用 `--title`。
-
-## 依赖
-
-```bash
-pip install -r requirements.txt
-node --version  # 推荐 Node.js 22+
-```
-
-## 验证
-
-```bash
-python3 -m unittest discover -s tests/python
-node --test tests/unit/*.test.mjs
-node --check scripts/batch_download.mjs
-node --check scripts/browser_pdf_downloader.mjs
-```
-
-详见 `SKILL.md` 了解完整工作流、安全边界、状态码体系和失败处理。
+- `nature-reader`：把已获取的 PDF/HTML 做成全文阅读材料。
+- `nature-academic-search`：从题名、DOI 或主题找到目标论文。

--- a/skills/nature-downloader/README_EN.md
+++ b/skills/nature-downloader/README_EN.md
@@ -2,46 +2,47 @@
 
 [中文说明](README.md)
 
-## What It Does
+`nature-downloader` obtains paper full text, PDFs, HTML full text, or auditable download status through open-access routes or the user's own institution-authorized access.
 
-- Helps legally obtain academic full text and PDFs through library access, browser login state, institutional routes, and open-access sources.
+## What To Use It For
 
-## When to Use It
+- Configure a school library, CARSI, EZproxy, WebVPN, or resource-portal entry point for first use.
+- Reuse the user's logged-in Chrome institutional session to download legally accessible PDFs.
+- Try to obtain full text from DOI, title, publisher page, PubMed page, or CNKI Chinese title.
+- Save HTML/text or explain access status when no PDF is available.
+- Report why access failed: no permission, user login required, CAPTCHA, human verification, or missing holdings.
 
-- You have a title, DOI, publisher URL, or database record and need the accessible full text.
-- You need to use CARSI, Web of Science, library proxy, or an existing browser login state.
-- You want an auditable path for how a PDF was obtained.
+## Typical Requests
 
-## Copy-Paste Prompts
+- "Configure my university library entry point so future paper downloads can reuse it."
+- "Use my logged-in Chrome session to download PDFs for these DOIs into the current project."
+- "Use the authorized CNKI route for this Chinese paper; save it if possible and explain why if not."
 
-- `Download the PDF for this DOI using legal library or open-access routes.`
-- `Use my logged-in browser state to obtain this paper from Web of Science or the publisher page.`
-- `Find the open-access version of this paper and save the PDF with metadata.`
+## What You Need To Provide
 
-## Required Inputs
-
-- Paper title, DOI, publisher URL, or database link.
-- Optional institution/library route and browser profile information.
+- DOI, title, paper page link, or Chinese paper title.
+- Library database entry point or logged-in Chrome session.
 - Target output directory and naming preference.
 
-## Expected Outputs
+## Outputs
 
-- Downloaded PDF or access-status report.
-- Source URL, access route, and metadata notes.
-- Failure reason when access is unavailable.
+- Local PDF, HTML, or text file.
+- Access path, save path, and failure reason for each paper.
+- Reusable school-entry configuration, usually at `~/.config/lit-dl/school.json`.
 
-## Dependencies / API Keys / Local Environment
+## Runtime and Dependencies
 
-- Library access or browser login may be required.
-- Chrome or another supported browser may be needed for login-state workflows.
-- The workflow must respect copyright, license, and institutional access rules.
+- First-time setup can use `scripts/configure_school.py` to identify and save resource entry points.
+- Real downloading depends on local browser login state and available web-access / CDP control.
+- Chinese papers default to the user's authorized CNKI or library CNKI entry point.
 
-## FAQ
+## Boundaries
 
-- **Does it bypass paywalls?** No. It uses legal access paths such as library subscriptions, author manuscripts, and open-access copies.
-- **What if no PDF is available?** It should return the best legal access route and explain the blocker.
+- The skill does not bypass paywalls, use mirror sites, break CAPTCHA, or read/export cookies, passwords, localStorage, or session files.
+- Unified identity login, CARSI, CAPTCHA, Cloudflare, SMS, or OTP challenges must be completed by the user in the browser.
+- Without legal access, the skill only reports status and possible alternatives.
 
 ## Related Skills
 
-- [`nature-reader`](../nature-reader/README_EN.md)
-- [`nature-academic-search`](../nature-academic-search/README_EN.md)
+- `nature-reader`: turn obtained PDF/HTML into a full-paper reader.
+- `nature-academic-search`: find target papers from title, DOI, or topic.

--- a/skills/nature-experiment-log/README.md
+++ b/skills/nature-experiment-log/README.md
@@ -1,64 +1,41 @@
-# experiment-log
+# `nature-experiment-log` 技能
 
 [English](README_EN.md)
 
-标准化实验日志记录工具。接收图片、语音、文字等原始材料，自动生成带 YAML frontmatter 的结构化日志。
+`nature-experiment-log` 用于把实验图片、语音、文字和零散观察整理成可追溯的结构化实验日志，并写入 Obsidian 或普通 Markdown 工作流。
 
-## 这是什么
+## 适合用它做什么
 
-不是"帮我记实验"——它是一套标准化的日志管线：接收原始材料 → 提取结构化信息 → 生成唯一 ID → 写出标准格式日志 → 归档原始文件。
+- 将当天实验记录整理成带 YAML frontmatter 的标准日志。
+- 从照片、显微图、称量记录、仪器截图或语音转写中提取实验要素。
+- 为样品、条件、观察、异常、下一步动作和原始附件建立稳定链接。
+- 把飞书、聊天记录或 CLI 输入中的原始材料归档为同一套实验记录格式。
 
-适用于任何需要规范实验记录的研究领域。
+## 典型请求
 
-## 安装
+- “记录一个实验：316L 在 500°C 氯盐腐蚀 300 h，Ar 气氛，失重 0.0032 g。”
+- “把这几张实验照片整理成今天的 Obsidian 实验日志。”
+- “根据这段语音转写补一条标准实验记录，并列出缺失信息。”
 
-```bash
-git clone https://github.com/Jiahao8595/research-pipeline.git
-cp -r research-pipeline/experiment-log ~/.hermes/skills/
-```
+## 你需要提供
 
-安装后 `/reload-skills`。
+- 实验日期、样品、条件、处理步骤、观察结果或原始附件。
+- 目标 vault / 输出目录；如果没有指定，技能会先生成可保存的 Markdown。
+- 需要固定的命名规则、项目编号或样品编号。
 
-**前置依赖：**
+## 产出
 
-```bash
-hermes skills install feishu-cli-integration   # 飞书消息接收（路径 B）
-hermes skills install obsidian                 # vault 文件管理
-```
+- 一条带 YAML frontmatter 的实验日志。
+- 对原始图片、音频、表格或聊天记录的附件索引。
+- 缺失字段清单和后续实验动作建议。
 
-## 使用方式
+## 边界
 
-**路径 A — CLI 直接提交：**
-```
-"记录一个实验：今天在 500°C 做了 316L 的氯盐腐蚀，300h，Ar 气氛，失重 0.0032g"
-```
-附上图片，agent 会 vision_analyze 提取信息并生成标准日志。
+- 不会替作者编造温度、时间、配比、设备型号或实验结果。
+- 对无法从材料中确认的信息，会保留 `AUTHOR_INPUT_NEEDED` 或中文确认项。
+- 飞书、Obsidian 等外部写入能力取决于本机是否已配置相应 CLI 或目录权限。
 
-**路径 B — 飞书提交：**
-把实验照片和语音发到配置好的飞书群，agent 自动扫描并处理。
+## 相关技能
 
-## 文件结构
-
-```
-experiment-log/
-├── SKILL.md                    ← 技能入口
-├── README.md                   ← 本文件
-└── references/
-    └── example-log.md          ← 完整日志示例
-```
-
-## 核心设计
-
-- **统一 ID 体系** — 体系代码 + 设备代码 + 日期 + 序号，跨实验可追踪
-- **样品批次追踪** — 同一批样品 ID 一致，dataview 可查
-- **YAML frontmatter** — 结构化数据 + 自由文本，既人可读又机器可查
-- **飞书 CLI 集成** — 手机拍照发群 → 自动入 vault
-- **异常追踪** — 自动检测异常并追加到异常记录
-
-## 自定义
-
-设备代码、体系代码、实验类型目录全部可按你的实验室配置。详见 SKILL.md 中的「自定义指南」。
-
-## 作者
-
-十五 (JL Lab)
+- `nature-data`：把实验数据整理成投稿用 Data Availability 与 FAIR 清单。
+- `nature-figure`：把实验数据或图像进一步做成投稿级图件。

--- a/skills/nature-experiment-log/README_EN.md
+++ b/skills/nature-experiment-log/README_EN.md
@@ -2,44 +2,40 @@
 
 [中文说明](README.md)
 
-## What It Does
+`nature-experiment-log` turns experiment images, voice notes, text, and scattered observations into traceable structured experiment logs for Obsidian or plain Markdown workflows.
 
-- Standardizes experiment images, voice notes, and text into structured Obsidian-compatible experiment logs with YAML frontmatter and archived source materials.
+## What To Use It For
 
-## When to Use It
+- Turn a day's experiment record into a standard log with YAML frontmatter.
+- Extract experiment elements from photos, microscopy images, weighing notes, instrument screenshots, or voice transcripts.
+- Link samples, conditions, observations, anomalies, next actions, and raw attachments.
+- Archive raw materials from Feishu, chat records, or CLI input into the same experiment-log format.
 
-- You need to turn raw experiment notes into a durable lab log.
-- You want consistent metadata, file naming, and source-material archiving.
-- You are collecting field, lab, or group-chat experiment evidence.
+## Typical Requests
 
-## Copy-Paste Prompts
+- "Record an experiment: 316L chloride-salt corrosion at 500°C for 300 h in Ar, mass loss 0.0032 g."
+- "Turn these experiment photos into today's Obsidian lab log."
+- "Use this voice transcript to create a standard experiment record and list missing information."
 
-- `Turn these photos and notes into a structured experiment log entry.`
-- `Archive these raw materials and create an Obsidian experiment note with YAML frontmatter.`
-- `Summarize today's experiment from these voice notes and images.`
+## What You Need To Provide
 
-## Required Inputs
+- Experiment date, sample, conditions, steps, observations, or raw attachments.
+- Target vault / output directory; if not specified, the skill generates Markdown that can be saved.
+- Required naming rules, project IDs, or sample IDs.
 
-- Images, voice transcripts, text notes, dates, project names, experiment IDs, and operator/context information.
-- Optional Obsidian vault or archive path.
+## Outputs
 
-## Expected Outputs
+- Experiment log with YAML frontmatter.
+- Attachment index for source images, audio, tables, or chat records.
+- Missing-field checklist and suggested next experiment actions.
 
-- Markdown experiment log with YAML frontmatter.
-- Archived source-material references.
-- Clean summaries, observations, and follow-up action items.
+## Boundaries
 
-## Dependencies / API Keys / Local Environment
-
-- Obsidian is optional but useful for vault workflows.
-- Messaging or Feishu integration may require local credentials and bot setup.
-
-## FAQ
-
-- **Does it replace a formal lab notebook?** No. It helps structure and archive notes; institutional record requirements still apply.
-- **Can it handle images without text?** Yes, but it should mark visual interpretation uncertainty.
+- The skill does not invent temperature, duration, recipe, device model, or results.
+- Unconfirmed information is preserved as `AUTHOR_INPUT_NEEDED` or Chinese confirmation items.
+- Feishu, Obsidian, or other external write paths depend on local CLI configuration or directory permissions.
 
 ## Related Skills
 
-- [`nature-literature-pipeline`](../nature-literature-pipeline/README_EN.md)
-- [`nature-data`](../nature-data/README_EN.md)
+- `nature-data`: turn experiment data into Data Availability and FAIR checklists.
+- `nature-figure`: turn experiment data or images into submission-grade figures.

--- a/skills/nature-figure/README.md
+++ b/skills/nature-figure/README.md
@@ -2,423 +2,70 @@
 
 [English](README_EN.md)
 
-`nature-figure` 用于生成可投稿级科研图，面向 Nature 级期刊和高影响力学术场景，同时支持 Python 与 R 两条绘图路径。若用户明确需要 AI 生成论文示意图、机制图或 graphical abstract，也支持通过 OpenRouter Images API 调用 `openai/gpt-image-2` 生成概念示意图草稿。
-
-该技能从“图件契约”开始，而不是直接套模板。开始绘图前，必须明确核心结论、证据层级、图件原型、后端选择、期刊与导出约束、统计说明和 source-data 可追溯性。第一次使用绘图路径时，用户选择 Python 或 R 后会写入默认偏好；后续默认沿用该后端，除非用户明确切换。只有在科学逻辑明确后，才使用绘图模板。
-
-Python 路径主要使用 `matplotlib`、`seaborn`、`subplot_mosaic` 和 `statsmodels`，适合精细低层布局控制。R 路径使用 `ggplot2`、`patchwork`、`ComplexHeatmap`、`ggrepel`、`svglite`、`cairo_pdf` 和 `ragg`。如果使用私有模板集合，不得在面向用户的输出中暴露私有路径、文件名或来源信息。
-
-该技能参考了 [figures4papers](https://github.com/ChenLiu-1996/figures4papers) 中来自 *Nature Machine Intelligence* 和顶级机器学习/生物信息学论文的生产脚本。原始 demo 脚本和预览图也打包在 `assets/figures4papers/` 中，供模式级改写使用。
-
----
-
-## OpenRouter AI 示意图生成
-
-当用户明确要求“用 OpenRouter / GPT Image 2 生成论文示意图、机制示意图、graphical abstract”时，走独立 AI-schematic route，不需要先询问 Python 或 R。
-
-```bash
-export OPENROUTER_API_KEY="sk-or-..."
-python skills/nature-figure/scripts/generate_openrouter_schematic.py \
-  --title "Paper title" \
-  --abstract-file abstract.txt \
-  --panel-map "left: problem; center: proposed mechanism; right: validated outcome" \
-  --outdir outputs/schematic \
-  --basename graphical_abstract
-```
+`nature-figure` 用于设计、生成和审查投稿级科研图件，面向 Nature 系列、高影响力期刊、论文图版、机制示意图和 graphical abstract 草稿。
 
-这个功能生成的是概念视觉草稿，不应作为定量数据面板。正式投稿前，建议检查科学元素是否被幻觉扩写，并把关键文字、箭头和标注重画成可编辑矢量对象。
-
----
+## 适合用它做什么
 
-## 示例图库
+- 根据数据、图注或论文结论生成 Python / R 绘图脚本和可编辑图件。
+- 将已有图件重画为更清楚的多面板论文 figure。
+- 规划 Figure 1、机制图、workflow、graphical abstract 或补充图。
+- 检查面板标签、配色、字体、统计标注、source data 和导出格式。
+- 在用户明确要求时，通过 OpenRouter Images API 调用 `openai/gpt-image-2` 生成 AI 概念示意图草稿。
 
-下面的图像是按本技能规则生成的模拟数据 mockup：优先导出可编辑 SVG、使用克制的语义配色、小写 panel label，并采用非对称多面板信息结构。README 中展示的是 PNG 预览；正式使用时仍应从绘图脚本导出 SVG/PDF。
+## 工作方式
 
-| 图件 | 预览 | 展示能力 |
-|--------|---------|-----------------------------|
-| 材料设计与物理验证 | <a href="assets/gallery/fig1-material-mechanism-rich.png"><img src="assets/gallery/fig1-material-mechanism-rich.png" width="260" alt="Material design and physical validation"></a> | 机制示意主导的复合图、SEM-like 图像面板、流变、释放动力学、滞留图、相关性与终点定量 |
-| 空间滞留与摄取 | <a href="assets/gallery/fig2-spatial-imaging-rich.png"><img src="assets/gallery/fig2-spatial-imaging-rich.png" width="260" alt="Spatial retention and uptake"></a> | 深色显微图版、通道行、局部放大、深度剖面、摄取直方图、3D 穿透热图和图像衍生相关性 |
-| 体内疗效与耐受性 | <a href="assets/gallery/fig3-in-vivo-efficacy-rich.png"><img src="assets/gallery/fig3-in-vivo-efficacy-rich.png" width="260" alt="In vivo efficacy and tolerability"></a> | 实验时间线、肿瘤纵向曲线、个体生长轨迹、waterfall response、forest plot、组织学、免疫组成和毒性面板 |
-| 单细胞系统图 | <a href="assets/gallery/fig4-single-cell-systems-rich.png"><img src="assets/gallery/fig4-single-cell-systems-rich.png" width="260" alt="Single-cell systems figure"></a> | UMAP-style embedding、组成、marker heatmap、pseudotime、volcano plot、enrichment、ligand-receptor bubble matrix 和空间邻域关系 |
-| 扰动验证 | <a href="assets/gallery/fig5-validation-perturbation-rich.png"><img src="assets/gallery/fig5-validation-perturbation-rich.png" width="260" alt="Perturbation validation"></a> | 机制扰动时间线、复发终点、polar summary、剂量反应、synergy matrix、生物分布、细胞因子、flow-like scatter 和安全评分 |
+绘图前先建立图件契约，而不是直接套模板：
 
-**图库文件策略**：`assets/gallery/` 中只保留轻量 PNG 预览。除非教程确实需要，不提交大型生成 SVG/PDF，因为真实用户应从源数据和脚本重新生成可编辑输出。
+- 核心结论：这张图要证明什么。
+- 证据层级：哪些面板是主证据，哪些是补充解释。
+- 图件原型：散点、箱线、热图、机制图、流程图、多面板组合等。
+- 后端选择：Python 或 R；第一次选择后会作为默认偏好复用。
+- 投稿约束：尺寸、字体、色彩、分辨率、矢量格式和 source-data 可追溯性。
 
----
+## 典型请求
 
-## 图表类型图谱
+- “把这组数据做成 Nature 风格多面板图，优先 Python。”
+- “参考 figures4papers 里 Nature Machine Intelligence 的布局，帮我补一个方法对比图。”
+- “重画这个机制示意图，导出 SVG/PDF，并给我 source data 表。”
+- “用 OpenRouter 生成 graphical abstract 草稿，但不要当作定量数据图。”
 
-下面的图库按 chart family 分类。每张预览都是紧凑的 4 x 4 小面板 atlas，用来展示可组合进 Nature 风格结果图的视觉语法范围。
+## 示例预览
 
-| 类型 | 预览 | 常见用途 |
-|------|---------|------------|
-| 柱状图 | <a href="assets/chart-atlas/atlas-01-bar-charts.png"><img src="assets/chart-atlas/atlas-01-bar-charts.png" width="240" alt="Bar chart atlas"></a> | 组间比较、有符号差值、组内分组设计、堆叠组成 |
-| 折线与纵向趋势 | <a href="assets/chart-atlas/atlas-02-line-trends.png"><img src="assets/chart-atlas/atlas-02-line-trends.png" width="240" alt="Line chart atlas"></a> | 时间过程、不确定性带、干预标记、个体轨迹 |
-| 热图 | <a href="assets/chart-atlas/atlas-03-heatmaps.png"><img src="assets/chart-atlas/atlas-03-heatmaps.png" width="240" alt="Heatmap atlas"></a> | Z-score 矩阵、连续丰度图、带注释表格、聚类块 |
-| 散点与气泡图 | <a href="assets/chart-atlas/atlas-04-scatter-bubble.png"><img src="assets/chart-atlas/atlas-04-scatter-bubble.png" width="240" alt="Scatter and bubble atlas"></a> | 相关性、簇、volcano-style 检验、象限总结、第三变量编码 |
-| 雷达与极坐标图 | <a href="assets/chart-atlas/atlas-05-radar-polar.png"><img src="assets/chart-atlas/atlas-05-radar-polar.png" width="240" alt="Radar and polar atlas"></a> | 多轴 benchmarking、圆形摘要、polar histogram、方向密度 |
-| 分布图 | <a href="assets/chart-atlas/atlas-06-distributions.png"><img src="assets/chart-atlas/atlas-06-distributions.png" width="240" alt="Distribution plot atlas"></a> | 直方图、小提琴图、箱线图、ridgeline 和样本级分布 |
-| Forest 与区间图 | <a href="assets/chart-atlas/atlas-07-forest-interval.png"><img src="assets/chart-atlas/atlas-07-forest-interval.png" width="240" alt="Forest and interval atlas"></a> | 效应量、置信区间、点范围、配对斜率比较 |
-| 面积与堆叠趋势 | <a href="assets/chart-atlas/atlas-08-area-stacked.png"><img src="assets/chart-atlas/atlas-08-area-stacked.png" width="240" alt="Area and stacked trend atlas"></a> | 填充轨迹、份额堆叠、累计曲线、stream-like 构图 |
-| 图像板 | <a href="assets/chart-atlas/atlas-09-image-plates.png"><img src="assets/chart-atlas/atlas-09-image-plates.png" width="240" alt="Image plate atlas"></a> | 显微通道、叠加图、裁剪、比例尺和暗色面板 |
-| 网络与矩阵图 | <a href="assets/chart-atlas/atlas-10-network-matrix.png"><img src="assets/chart-atlas/atlas-10-network-matrix.png" width="240" alt="Network and matrix atlas"></a> | 气泡矩阵、邻接图、node-link 图和二分互作面板 |
+| 方向 | 预览 | 可借鉴模式 |
+|------|------|------------|
+| 多面板论文图 | <a href="assets/gallery/fig1-material-mechanism-rich.png"><img src="assets/gallery/fig1-material-mechanism-rich.png" width="220" alt="Material design and physical validation"></a> | 机制示意、图像面板、定量结果和相关性放在同一证据链中 |
+| 图表类型 atlas | <a href="assets/chart-atlas/atlas-03-heatmaps.png"><img src="assets/chart-atlas/atlas-03-heatmaps.png" width="220" alt="Heatmap atlas"></a> | 热图、注释矩阵、聚类块和发散色标的组合模式 |
+| figures4papers demo | <a href="assets/figures4papers/figure_VIGIL/figures/comparison_radar.png"><img src="assets/figures4papers/figure_VIGIL/figures/comparison_radar.png" width="220" alt="VIGIL comparison radar"></a> | 从真实论文脚本中抽取 layout、legend 和多指标比较语法 |
 
----
+## 你需要提供
 
-## 文件结构
+- 原始数据、已有图、图注、论文 claim 或想表达的机制。
+- 目标期刊、单栏/双栏尺寸、输出格式和是否需要 source data。
+- Python / R 偏好；如果没有偏好，技能会先询问或沿用本机记录。
 
-该技能采用 router/static-dynamic 结构：短 `SKILL.md` 路由配合 `manifest.yaml`，加载常驻 core、用户选择的后端片段，以及按需 references。
+## 产出
 
-```text
-nature-figure/
-├── SKILL.md                     # 短路由：后端 gate，加载 fragments
-├── manifest.yaml                # always_load core + backend axis + 按需 references
-├── README.md                    # 本文件
-├── scripts/
-│   ├── generate_openrouter_schematic.py
-│   └── nature_figure_backend.py
-├── static/
-│   ├── core/                    # 始终加载
-│   │   ├── contract.md          # 图件契约、后端 gate、互斥规则、运行时缺失处理
-│   │   └── stance.md            # 配色策略、默认立场、隐私、何时加载
-│   └── fragments/
-│       └── backend/             # 在 Python-or-R gate 解决后加载
-│           ├── python.md        # Python-only 规则与 matplotlib quick-start
-│           └── r.md             # R-only 规则与 ggplot2 quick-start
-├── assets/
-│   ├── gallery/                 # 结果图预览 PNG
-│   ├── chart-atlas/             # 图表类型预览 PNG
-│   └── figures4papers/          # 原始 demo 脚本和预览资产
-└── references/                  # 按需打开
-    ├── figure-contract.md       # 核心结论、证据层级、panel map
-    ├── backend-selection.md     # Python vs R 选择规则
-    ├── r-workflow.md            # R scaffold、patchwork、ComplexHeatmap、导出
-    ├── r-template-index.md      # 本地 R template atlas
-    ├── qa-contract.md           # 投稿/返修 QA 清单
-    ├── api.md                   # PALETTE 常量、helper 函数签名
-    ├── design-theory.md         # 字体、色彩理论、布局、导出策略
-    ├── common-patterns.md       # 可复用代码模式
-    ├── openrouter-image-generation.md
-    ├── tutorials.md             # 端到端教程
-    ├── chart-types.md           # radar、3D sphere、scatter、fill_between、log-scale
-    └── demos.md                 # figures4papers demo map 与路由指南
-```
+- 可运行的 Python 或 R 绘图脚本。
+- SVG/PDF/PNG 等图件文件，优先保留可编辑矢量版本。
+- 面板说明、source data 映射和投稿前 QA 清单。
+- AI 示意图任务中，输出概念草稿和需要人工重画/核实的元素列表。
 
----
+## 内置参考
 
-## 后端与图件契约规则
+- `references/api.md`：OpenRouter AI 示意图生成参数。
+- `references/chart-types.md`：常见图型选择和视觉规则。
+- `references/demos.md`：`figures4papers` demo 与可借鉴模式。
+- `references/qa-contract.md`：导出前检查项和 source-data 约束。
+- `assets/figures4papers/`：打包的 demo 脚本与预览图。
 
-绘图任务优先使用用户已经指定的后端；如果没有指定，则读取 `scripts/nature_figure_backend.py` 保存的默认偏好。第一次使用且尚未保存偏好时，再询问用户选择 **Python 或 R**，并把答案保存为后续默认后端。如果用户需要推荐，参考 `references/backend-selection.md`。
+## 边界
 
-后端一旦选定，绘图、预览、导出和视觉 QA 都必须只使用该后端。如果所选运行时或包缺失，应停止并报告 blocker；不要用另一种语言临时替代。该规则双向适用：不能用 Python 替代 R，也不能用 R 替代 Python。
+- 不会把 AI 生成图片当作真实实验结果或定量数据面板。
+- 不会凭空补统计检验、样本量、误差线含义或实验条件。
+- 私有模板可以在本机使用，但不应在面向用户输出中暴露私有路径、文件名或来源。
 
-绘图前必须写明或推断核心结论、图件原型、panel map、证据层级、目标输出、统计/source-data 需求和导出包。图件首先服务科学逻辑，美观和模板匹配是次级目标。
+## 相关技能
 
-面向用户的输出不得暴露私有本地路径、私有文件名、内部参考文档、模板编号或私有材料来源，除非用户明确要求审计轨迹。
-
----
-
-## Python 强制规则
-
-### 1. 三个必需 rcParams：保留 SVG 可编辑文本
-
-```python
-plt.rcParams['font.family'] = 'sans-serif'
-plt.rcParams['font.sans-serif'] = ['Arial', 'DejaVu Sans', 'Liberation Sans']
-plt.rcParams['svg.fonttype'] = 'none'
-```
-
-`svg.fonttype = 'none'` 可以避免 matplotlib 默认把每个字形转为 bezier 曲线。这样导出的 SVG 中，文字仍是 `<text>` 节点，可选择、可搜索，也方便在 Illustrator 或 Inkscape 中重新对齐。
-
-字体栈中包含 `Arial`、`DejaVu Sans` 和 `Liberation Sans`：`Arial` 是 macOS/Windows 常见字体，`DejaVu Sans` 随 matplotlib 提供，`Liberation Sans` 在 RHEL/Ubuntu 上与 Arial 度量兼容。这个级联能提高跨平台字距一致性。
-
-### 2. 主输出格式是 SVG
-
-```python
-fig.savefig('figure.svg', bbox_inches='tight')           # 主输出：可编辑文本
-fig.savefig('figure.png', dpi=300, bbox_inches='tight')  # 可选栅格预览
-```
-
-当图要进入论文或需要后期文字微调的 slide deck 时，不要只导出 PNG。
-
-### 3. 始终关闭 figure
-
-```python
-plt.close(fig)
-```
-
----
-
-## 快速模板
-
-```python
-import matplotlib
-matplotlib.use('Agg')                    # headless / server rendering
-import matplotlib.pyplot as plt
-import matplotlib.gridspec as gridspec
-import numpy as np
-
-# 必需设置
-plt.rcParams['font.family'] = 'sans-serif'
-plt.rcParams['font.sans-serif'] = ['Arial', 'DejaVu Sans', 'Liberation Sans']
-plt.rcParams['svg.fonttype'] = 'none'
-
-# 基础样式
-plt.rcParams.update({
-    'font.size': 12,
-    'axes.spines.right': False,
-    'axes.spines.top': False,
-    'axes.linewidth': 2.0,
-    'legend.frameon': False,
-    'xtick.major.width': 1.5,
-    'ytick.major.width': 1.5,
-})
-
-# 图件
-fig, ax = plt.subplots(figsize=(8, 5))
-ax.spines['bottom'].set_linewidth(2)
-ax.spines['left'].set_linewidth(2)
-
-# ... 在这里写绘图代码 ...
-
-fig.tight_layout(pad=2)
-fig.savefig('output.svg', bbox_inches='tight')
-fig.savefig('output.png', dpi=300, bbox_inches='tight')
-plt.close(fig)
-```
-
----
-
-## 配色方案
-
-```python
-PALETTE = {
-    # 主方法 / 核心系列
-    'blue_main':      '#0F4D92',
-    'blue_secondary': '#3775BA',
-
-    # 正向 / 提升色阶
-    'green_1': '#DDF3DE',
-    'green_2': '#AADCA9',
-    'green_3': '#8BCF8B',
-
-    # 基线 / 对照
-    'red_1':      '#F6CFCB',
-    'red_2':      '#E9A6A1',
-    'red_strong': '#B64342',
-
-    # 中性辅助
-    'neutral_light': '#CFCECE',
-    'neutral_mid':   '#767676',
-    'neutral_dark':  '#4D4D4D',
-    'neutral_black': '#272727',
-
-    # 强调色，谨慎使用
-    'gold':    '#FFD700',
-    'teal':    '#42949E',
-    'violet':  '#9A4D8E',
-    'magenta': '#EA84DD',
-}
-```
-
-语义映射约定：`blue_main` 表示本文方法或核心系列，`green_3` 表示正向变体，`red_strong` 表示基线，`neutral_light` 表示参考或背景。所有 panel 中必须保持一致。
-
-推荐在近期 Nature Machine Intelligence 风格的密集多面板图中使用统一低饱和配色：一个 coherent baseline family 加一个 coherent hero family，绿色/红色只用于差值标记或真正有方向性的语义。
-
-```python
-PALETTE_NMI_PASTEL = {
-    # 基线 / 对照家族
-    'baseline_dark': '#484878',
-    'baseline_mid':  '#7884B4',
-    'baseline_soft': '#B4C0E4',
-
-    # 本文方法家族
-    'ours_tiny':  '#E4E4F0',
-    'ours_base':  '#E4CCD8',
-    'ours_large': '#F0C0CC',
-
-    # 概览 / 概念面板背景块
-    'bg_lilac': '#E0E0F0',
-    'bg_aqua':  '#E0F0F0',
-    'bg_peach': '#F0E0D0',
-
-    # 中性辅助
-    'neutral_light': '#D8D8D8',
-    'neutral_mid':   '#A8A8A8',
-    'neutral_dark':  '#606060',
-
-    # 仅用于方向性标注
-    'delta_up':   '#2E9E44',
-    'delta_down': '#E53935',
-}
-
-DEFAULT_COLORS_NMI_PASTEL = [
-    PALETTE_NMI_PASTEL['baseline_dark'],
-    PALETTE_NMI_PASTEL['baseline_mid'],
-    PALETTE_NMI_PASTEL['baseline_soft'],
-    PALETTE_NMI_PASTEL['ours_tiny'],
-    PALETTE_NMI_PASTEL['ours_base'],
-    PALETTE_NMI_PASTEL['ours_large'],
-]
-```
-
-适用场景：
-
-- 比较 `Tiny / Base / Large` 等相关模型家族。
-- 构建 1 页 result atlas，需要多个 panel 视觉统一。
-- 追求低饱和编辑风格，而不是最大化类别区分。
-
-实践规则：同一方法家族在所有 panel 中保持同一 hue family。不要因为某个 panel 需要对比，就把 panel `a` 中的蓝灰模型在 panel `d` 里改成绿色。
-
----
-
-## 支持的图表类型
-
-| 图表 | 文件 | 关键模式 |
-|-------|------|-------------|
-| 分组柱状图 | `tutorials.md` | `ax.bar()` 配合 `x + offset`，最后一个 panel 只放 legend |
-| 堆叠柱状图 | `common-patterns.md` | 遍历 `col_order`，累计 `bottom` |
-| 横向 ablation bar | `tutorials.md` | `ax.barh()`，用 alpha-gradient 编码完整性 |
-| 趋势 / 折线 | `tutorials.md` + `api.md` | `make_trend()`，用 `fill_between` 表示不确定性 |
-| 连续热图 | `api.md` | `make_heatmap()`、`YlOrRd`、按亮度决定 cell annotation 颜色 |
-| 发散 / z-score 热图 | `design-theory.md §11` | `RdBu_r`，`vmin=-2.5, vmax=2.5` |
-| 气泡散点图 | `design-theory.md §11` | x/y 表示两个维度，`s=` 表示第三变量 |
-| 雷达 / 极坐标图 | `chart-types.md` | `projection='polar'`，自定义 spokes，逐轴归一化 |
-| 3D sphere / illustration | `chart-types.md` | 用 numpy 网格 ray-cast 实现 Lambertian shading |
-| Fill-between / 堆叠面积 | `chart-types.md` | 使用 hatch 保证灰度打印安全 |
-| Log-scale bar | `chart-types.md` | `set_yscale('log')`，顶部留出标注空间 |
-| 多面板 GridSpec | `chart-types.md` | `GridSpec(rows, cols)`，用 `gs[0, :]` 做全宽 panel |
-
----
-
-## 多面板信息结构
-
-多面板图中的每个 panel 都必须回答一个**唯一**科学问题。遮住任意一个 panel 后，其他 panel 不应能完全替代它。
-
-### 推荐的三层递进复杂度
-
-| 层级 | 问题 | 编码方式 |
-|-------|----------|----------|
-| Overview | “整体格局是什么？” | 堆叠柱、组成图 |
-| Deviation | “每组的独特性是什么？” | Z-score 热图、发散色图 |
-| Relationship | “变量之间如何共变？” | 气泡散点、相关性图 |
-
-### 常见冗余陷阱
-
-| 陷阱 | 示例 | 修正 |
-|------|---------|-----|
-| 绝对值 + 绝对值 | 堆叠柱百分比 + 同一百分比热图 | 把热图换成 z-score deviation |
-| 父集的子集 | tumor-only ranked bar 只是堆叠柱的一列 | 换成 tumor % vs immune % 散点 |
-| 两个排序 | 两个相关指标的 ranked bar | 将其中一个换成气泡散点 |
-| 图形不同但数据相同 | 饼图 + 堆叠柱 | 合并或换成关系图 |
-
-### Z-score deviation 热图
-
-```python
-z = (heat - heat.mean(axis=0)) / heat.std(axis=0)
-im = ax.imshow(z.values, cmap='RdBu_r', aspect='auto', vmin=-2.5, vmax=2.5)
-cbar.set_label('Z-score vs pan-cohort mean')
-```
-
-`RdBu_r` 中红色表示高于平均富集，蓝色表示低于平均。它与 panel a 中展示的绝对百分比形成正交信息。
-
-### 带象限标签的气泡散点
-
-```python
-ax.scatter(x, y, s=size_var * scale, c=colors, edgecolors='white', linewidth=0.8, alpha=0.9)
-ax.axvline(np.median(x), lw=1.2, ls='--', color='#767676', alpha=0.6)
-ax.axhline(np.median(y), lw=1.2, ls='--', color='#767676', alpha=0.6)
-```
-
-象限标签放在角落，使用小号灰色斜体文字，例如 `fontsize=7.5, color='#888888', style='italic'`。
-
----
-
-## 布局规则
-
-### Figure 尺寸
-
-| 类型 | `figsize` |
-|------|-----------|
-| 多指标柱状图（3-4 个指标 + legend panel） | `(28-45, 6-12)` |
-| 大型多面板图（3 panels，2-row GridSpec） | `(22, 17)` |
-| 紧凑单柱状图 | `(9-16, 5-8)` |
-| 趋势 / 折线多面板 | `(14, 4)` 或 `(9, 8)` |
-| 单热图 | `(8-20, 5-9)` |
-| 雷达极坐标 | `(12, 10)` |
-
-规则：比较型柱状面板的宽度通常约为高度的 3-4 倍。
-
-### Panel labels
-
-```python
-ax.text(-0.05, 1.06, 'a', transform=ax.transAxes,
-        fontsize=22, fontweight='bold', va='top', ha='right')
-```
-
-每个 subplot 左上角使用小写粗体 `a`、`b`、`c`，通过 `transAxes` 放置。
-
-### Legend
-
-- 多轴图件中，legend 应有独立 axis，例如 `ax.set_axis_off()`。
-- 始终使用 `frameon=False`。
-- 如果 legend 较大，放在 panel 下方：`bbox_to_anchor=(0.5, -0.24), loc='upper center'`。
-
----
-
-## 字号层级
-
-| 场景 | `font.size` |
-|---------|-------------|
-| 基础紧凑子图 | 12-16 |
-| 大型柱状 panel（figsize > 28 in） | 24 |
-| 大 panel 坐标轴标题 | 32-54，可逐标签覆盖 |
-| 柱内 / cell 内注释 | 6.5-12 |
-| Panel letter label | 20-22 |
-| Legend | 8-14 |
-
----
-
-## 坐标轴与边框规则
-
-```python
-plt.rcParams['axes.spines.right'] = False
-plt.rcParams['axes.spines.top'] = False
-plt.rcParams['legend.frameon'] = False
-
-ax.spines['bottom'].set_linewidth(2)
-ax.spines['left'].set_linewidth(2)
-```
-
-默认不使用 gridline。用稀疏 `set_yticks` 引导阅读。Y 轴范围要贴近数据，不要在所有值都落在 `80-95` 时使用 `0-100`。
-
----
-
-## Cell / bar 内文字对比度
-
-```python
-def luminance_text_color(hex_color):
-    c = hex_color.lstrip('#')
-    r, g, b = int(c[0:2],16)/255, int(c[2:4],16)/255, int(c[4:6],16)/255
-    return 'white' if 0.299*r + 0.587*g + 0.114*b < 0.5 else '#333333'
-```
-
----
-
-## 复现检查清单
-
-- [ ] 核心结论和 panel map 在美化前已经明确。
-- [ ] 后端已明确为 Python 或 R。
-- [ ] **前 3 个设置**包含 `font.family`、`font.sans-serif` 三字体栈、`svg.fonttype = 'none'`。
-- [ ] 主输出为 **SVG**，并使用 `bbox_inches='tight'`。
-- [ ] 右侧和顶部 spines 关闭，`legend.frameon = False`。
-- [ ] 字号符合最终用途：密集期刊图通常 5-7 pt，只有 slide-sized panel 才使用更大字号。
-- [ ] 颜色来自同一个 coherent palette system：语义 `PALETTE` 或统一 `PALETTE_NMI_PASTEL`。
-- [ ] 相关模型大小或变体共享同一 hue family，不给同胞系列分配不相关的高饱和颜色。
-- [ ] 绿色 / 红色只用于提升、下降、阈值或真正有方向性的语义。
-- [ ] Y 轴范围贴近数据范围。
-- [ ] 多面板图中每个 panel 回答**不同**问题，已通过反冗余检查。
-- [ ] Panel labels 使用粗体小写 `a`、`b`、`c`，字号适合最终输出。
-- [ ] 面向手稿时，已记录统计、`n`、source data 和图像完整性说明。
-- [ ] 保存前调用 `tight_layout(pad=2)`。
-- [ ] 保存后调用 `plt.close(fig)`。
+- `nature-statistics`：检查统计标注、n 定义和 p 值表述。
+- `nature-writing`：把图件结论放回手稿叙事。
+- `nature-paper2ppt`：把论文图件整理成汇报幻灯片。

--- a/skills/nature-figure/README_EN.md
+++ b/skills/nature-figure/README_EN.md
@@ -2,50 +2,70 @@
 
 [中文说明](README.md)
 
-## What It Does
+`nature-figure` designs, generates, and audits submission-grade scientific figures for Nature-series papers, high-impact journals, manuscript panels, mechanism schematics, and graphical-abstract drafts.
 
-- Creates, revises, and audits submission-grade scientific figures for Nature and other high-impact journals using Python or R workflows, with optional OpenRouter GPT Image 2 schematic drafting.
+## What To Use It For
 
-## When to Use It
+- Generate Python / R plotting scripts and editable figures from data, legends, or manuscript claims.
+- Redraw existing figures into clearer multi-panel manuscript figures.
+- Plan Figure 1, mechanism diagrams, workflows, graphical abstracts, or supplementary figures.
+- Check panel labels, color, typography, statistical annotations, source data, and export formats.
+- When explicitly requested, call `openai/gpt-image-2` through the OpenRouter Images API to draft AI concept schematics.
 
-- You need publication-quality plots, multi-panel figures, graphical abstracts, or manuscript schematics.
-- You want to convert rough analysis into editable SVG/PDF/TIFF figure outputs.
-- You need a figure QA pass for typography, labels, color, panel logic, and journal constraints.
+## Workflow
 
-## Copy-Paste Prompts
+Start with a figure contract rather than a template:
 
-- `Create a Nature-style multi-panel figure from this dataset and methods description.`
-- `Polish this matplotlib figure for submission and export editable SVG plus high-resolution TIFF.`
-- `Use OpenRouter GPT Image 2 to draft a manuscript schematic from this mechanism description.`
-- `Audit this figure for Nature-style readability, color, labels, and panel layout.`
+- Core conclusion: what the figure must demonstrate.
+- Evidence hierarchy: which panels are primary evidence and which are explanatory.
+- Figure prototype: scatter, box plot, heatmap, mechanism diagram, workflow, multi-panel composition, and so on.
+- Backend choice: Python or R; the first choice can be reused as the default preference.
+- Submission constraints: size, typography, color, resolution, vector format, and source-data traceability.
 
-## Required Inputs
+## Typical Requests
 
-- Data files, analysis code, sketch, figure goal, target journal, panel plan, and preferred backend.
-- Optional Python/R preference. The skill can persist the first backend choice for future use.
-- Optional OpenRouter API key for GPT Image 2 schematic drafting.
+- "Make a Nature-style multi-panel figure from this dataset, preferably in Python."
+- "Use the figures4papers Nature Machine Intelligence layout as a reference and add a method-comparison figure."
+- "Redraw this mechanism schematic, export SVG/PDF, and give me the source-data table."
+- "Use OpenRouter to draft a graphical abstract, but do not treat it as a quantitative data figure."
 
-## Expected Outputs
+## Example Preview
 
-- Editable figure files such as SVG/PDF and high-resolution raster exports when requested.
-- Plotting scripts and reproducibility notes.
-- Schematic-generation prompts or image drafts.
-- Figure QA checklist and revision suggestions.
+| Direction | Preview | Reusable Pattern |
+|-----------|---------|------------------|
+| Multi-panel manuscript figure | <a href="assets/gallery/fig1-material-mechanism-rich.png"><img src="assets/gallery/fig1-material-mechanism-rich.png" width="220" alt="Material design and physical validation"></a> | Mechanism schematic, image panels, quantitative results, and correlation in one evidence chain |
+| Chart-type atlas | <a href="assets/chart-atlas/atlas-03-heatmaps.png"><img src="assets/chart-atlas/atlas-03-heatmaps.png" width="220" alt="Heatmap atlas"></a> | Heatmaps, annotation matrices, cluster blocks, and diverging color scales |
+| figures4papers demo | <a href="assets/figures4papers/figure_VIGIL/figures/comparison_radar.png"><img src="assets/figures4papers/figure_VIGIL/figures/comparison_radar.png" width="220" alt="VIGIL comparison radar"></a> | Layout, legend, and multi-metric comparison grammar from real paper scripts |
 
-## Dependencies / API Keys / Local Environment
+## What You Need To Provide
 
-- Python or R plotting environment depending on the selected backend.
-- Optional OpenRouter credentials for GPT Image 2 image generation.
-- Some outputs may require fonts, vector-export support, or image-conversion tools.
+- Raw data, existing figure, legend, manuscript claim, or intended mechanism.
+- Target journal, single-column / double-column size, output format, and whether source data is required.
+- Python / R preference; if absent, the skill asks or reuses the local preference.
 
-## FAQ
+## Outputs
 
-- **Should I choose Python or R every time?** No. The workflow should ask the first time if needed and reuse the stored preference later.
-- **Can GPT Image 2 generate final publication figures?** Treat generated schematics as drafts; scientific accuracy and editable redraw should still be verified.
-- **What is the preferred output format?** Editable vector output is preferred for manuscript figures, with journal-required raster exports generated as needed.
+- Runnable Python or R plotting script.
+- SVG/PDF/PNG figure files, with editable vector output preferred.
+- Panel notes, source-data mapping, and pre-submission QA checklist.
+- For AI-schematic tasks, a concept draft and a list of elements that need human redrawing or verification.
+
+## Built-In References
+
+- `references/api.md`: OpenRouter AI schematic-generation parameters.
+- `references/chart-types.md`: chart selection and visual rules.
+- `references/demos.md`: `figures4papers` demos and reusable patterns.
+- `references/qa-contract.md`: export QA and source-data constraints.
+- `assets/figures4papers/`: packaged demo scripts and previews.
+
+## Boundaries
+
+- AI-generated images are not treated as real experimental results or quantitative data panels.
+- The skill does not invent statistical tests, sample sizes, error-bar meanings, or experiment conditions.
+- Private templates can be used locally, but user-facing outputs should not expose private paths, filenames, or sources.
 
 ## Related Skills
 
-- [`nature-paper2ppt`](../nature-paper2ppt/README_EN.md)
-- [`nature-writing`](../nature-writing/README_EN.md)
-- [`nature-response`](../nature-response/README_EN.md)
+- `nature-statistics`: check statistical annotations, n definitions, and p-value wording.
+- `nature-writing`: align figure conclusions with manuscript narrative.
+- `nature-paper2ppt`: turn manuscript figures into presentation slides.

--- a/skills/nature-literature-pipeline/README.md
+++ b/skills/nature-literature-pipeline/README.md
@@ -1,102 +1,46 @@
-# nature-literature-pipeline
+# `nature-literature-pipeline` 技能
 
 [English](README_EN.md)
 
-文献管线引擎 + 每日推送应用层。一套完整的自动化文献发现和跟进系统。
+`nature-literature-pipeline` 用于搭建持续运行的文献发现管线：多源检索、六维评分、精读摘要、推送和归档，适合每天或每周跟踪一个研究方向。
 
-## 这是什么
+## 适合用它做什么
 
-不是简单的"帮我搜几篇论文"——它是一个结构化管线：多源检索 → 六维评分筛选 → 精读 → 格式化推送 → 归档。支持 cron 每日自动运行。
+- 为固定主题建立自动化文献监测。
+- 从 arXiv、OpenAlex、Crossref、Semantic Scholar 等来源收集候选论文。
+- 对候选文献按方向匹配、方法价值、期刊质量、网络关联、工程价值和归档价值打分。
+- 把 Top 文献整理成可推送的中文/英文精读摘要。
+- 维护 DOI、arXiv ID、主题标签和已读状态，减少重复阅读。
 
-## 与 nature-academic-search 的关系
+## 与 `nature-academic-search` 的关系
 
-`nature-academic-search` 是**按需搜索**（"现在帮我找几篇 XX 的论文"），本 skill 是**自动化订阅**（"每天帮我盯着这个领域，有新论文推送给我"）。互补关系，建议两个都装。
+`nature-academic-search` 适合一次性检索和引用核查；`nature-literature-pipeline` 适合持续订阅和周期性推送。前者回答“现在帮我找”，后者回答“持续帮我盯”。
 
-## 管线架构
+## 典型请求
 
-```
-多源检索（30 篇候选）
-  arXiv / OpenAlex / Crossref / Semantic Scholar（自动降级）
-       ↓
-六维粗筛（30 → 5 篇）
-  方向匹配 × 35 + 方法论 × 20 + 期刊质量 × 15
-  + 网络关联 × 10 + 工程价值 × 10 + 归档价值 × 10
-       ↓
-精读（top 5）
-  标注来源：Full-text / Abstract only / Metadata only
-       ↓
-推送
-  🏅 排名 | 标题 | 期刊 | ⭐ 评分 | 💡 一句话 | 🔬 方法 | 📊 关键数据 | 🧭 点评
-       ↓
-归档
-  DOI/arXiv 去重 → 分类 → 笔记 → 更新索引
-```
+- “每天早上帮我跟踪海洋混凝土氯离子扩散和机器学习方向的新论文。”
+- “为这个关键词组建一条每周推送的文献管线。”
+- “把过去 7 天候选论文按六维评分筛到 Top 5，并归档。”
 
-## 安装
+## 你需要提供
 
-```bash
-# Codex
-请从这个仓库安装 nature-literature-pipeline：
-https://github.com/Yuan1z0825/nature-skills.git
-请把 skills/nature-literature-pipeline/ 完整安装，包括 references/ 和 templates/
+- 研究主题、关键词、排除词、重点期刊或重点作者。
+- 推送频率、每次候选数量和最终精读数量。
+- 输出位置，例如 Markdown 目录、飞书/Telegram 接口或本地归档文件夹。
 
-# Hermes / Claude Code
-git clone https://github.com/Yuan1z0825/nature-skills.git
-cp -r nature-skills/skills/nature-literature-pipeline ~/.hermes/skills/research/
-# 重启 session 或 /reload-skills
-```
+## 产出
 
-## 首次配置
+- 候选文献表和去重后的 Top 列表。
+- 每篇重点论文的精读卡片：问题、方法、关键数据、局限和与你课题的关系。
+- 可复用的管线配置、归档索引和失败/降级说明。
 
-装好后告诉 agent：
+## 边界
 
-```
-我的研究领域是钙钛矿太阳能电池，关键词：perovskite solar cell, PSC stability,
-hole transport layer, interface passivation,
-文献推送到飞书群"每日文献"，归档到 ~/research/literature/
-```
+- 自动推送依赖本机 cron、消息接口或用户配置的调度器。
+- 无法访问全文时，会明确标注 `Abstract only` 或 `Metadata only`。
+- 不会把评分当作论文质量的最终判断；高分候选仍需要人工阅读确认。
 
-Agent 会配置关键词、推送目标、归档路径。之后设置 cron：
+## 相关技能
 
-```
-帮我设一个每天早上 8:30 的文献推送，30 篇候选，推送 top 5
-```
-
-## 文件结构
-
-```
-nature-literature-pipeline/
-├── SKILL.md                                ← 技能入口
-├── README.md                               ← 本文件
-├── references/
-│   ├── scoring-system.md                   ← 六维评分体系
-│   ├── gap-analysis.md                     ← 文献 gap 分析方法
-│   ├── note-template.md                    ← 标准化文献笔记模板
-│   ├── push-format.md                      ← 推送消息格式规范
-│   ├── cron-setup.md                       ← cron 创建/验证/故障恢复
-│   └── review-compilation-workflow.md      ← 综述文献汇编工作流
-└── templates/
-    └── literature-push-template.md         ← 可分享的通用配置模板
-```
-
-## 内置保护
-
-- **评分校验**：每个维度不超过上限，总分自动重算
-- **三重去重**：DOI / arXiv ID / OpenAlex ID
-- **自动降级**：Semantic Scholar 不可用 → 自动切 OpenAlex + Crossref + arXiv
-- **只写文献库**：每日管线只写 `raw/` 目录，不自动改 wiki/知识库
-
-## 常见问题
-
-**Q: 和 nature-citation 怎么配合？**
-管线发现新论文 → 用 nature-citation 导出 CNS 格式引用插入手稿。
-
-**Q: 需要什么模型？**
-推荐 DeepSeek V3 以上。每日 cron 可用 flash 模型降低成本。
-
-**Q: 我的领域不是材料/化学？**
-全部可配置。关键词换成你的领域即可——医学、生物、CS、社科都一样用。
-
-## 作者
-
-十五 (JL Lab) — 基于真实科研工作流构建，已稳定运行数月。
+- `nature-academic-search`：一次性多源检索、引用指标和严格他引审计。
+- `nature-reader`：把候选论文做成全文中英对照阅读材料。

--- a/skills/nature-literature-pipeline/README_EN.md
+++ b/skills/nature-literature-pipeline/README_EN.md
@@ -2,46 +2,45 @@
 
 [中文说明](README.md)
 
-## What It Does
+`nature-literature-pipeline` builds a recurring literature-discovery pipeline: multi-source retrieval, six-dimension scoring, deep-reading summaries, delivery, and archiving.
 
-- Runs an automated literature-discovery pipeline with multi-source retrieval, scoring, deep-reading delivery, and local archiving.
+## What To Use It For
 
-## When to Use It
+- Set up automated literature monitoring for a fixed research topic.
+- Collect candidate papers from arXiv, OpenAlex, Crossref, Semantic Scholar, and related sources.
+- Score candidates by topic match, methodological value, journal quality, network relation, engineering value, and archive value.
+- Turn top papers into Chinese or English deep-reading digests for delivery.
+- Maintain DOI, arXiv ID, topic tags, and read status to reduce duplicate reading.
 
-- You want daily or scheduled literature discovery for a topic.
-- You need ranked papers, summaries, and archive-ready notes.
-- You want a pipeline rather than a one-off literature search.
+## Relationship With `nature-academic-search`
 
-## Copy-Paste Prompts
+`nature-academic-search` is for one-off search and citation checks; `nature-literature-pipeline` is for continuous subscription and periodic delivery. The former answers "find papers now"; the latter answers "keep watching this area."
 
-- `Set up a daily literature push for this research topic.`
-- `Run the literature pipeline for these keywords and rank papers by novelty and relevance.`
-- `Archive today's top papers with summaries and source links.`
+## Typical Requests
 
-## Required Inputs
+- "Track new papers on marine concrete chloride diffusion and machine learning every morning."
+- "Create a weekly literature pipeline for this keyword set."
+- "Score papers from the last seven days, keep the Top 5, and archive them."
 
-- Topic, keywords, sources, schedule, scoring preferences, and delivery target.
-- Optional chat, Feishu, Obsidian, or local archive path configuration.
+## What You Need To Provide
 
-## Expected Outputs
+- Research topic, keywords, exclusion terms, priority journals, or priority authors.
+- Delivery frequency, number of candidates per run, and number of deep-read papers.
+- Output target, such as Markdown directory, Feishu/Telegram interface, or local archive folder.
 
-- Ranked literature digest.
-- Deep-reading notes and local archive records.
-- Scheduled-task configuration guidance when supported.
+## Outputs
 
-## Dependencies / API Keys / Local Environment
+- Candidate-paper table and deduplicated Top list.
+- Deep-reading card for each key paper: problem, method, key data, limitations, and relation to your project.
+- Reusable pipeline configuration, archive index, and failure/degradation notes.
 
-- Search providers or MCP tools may require credentials.
-- Hermes cron is local; the machine or profile must be running for scheduled tasks.
-- Messaging integrations require local bot credentials.
+## Boundaries
 
-## FAQ
-
-- **Is this the same as nature-academic-search?** No. `nature-academic-search` is a search and verification skill; this is a recurring pipeline around discovery, scoring, and delivery.
-- **Can it run in the cloud automatically?** Only if the selected agent/runtime is deployed there; local Hermes cron is not a cloud service by itself.
+- Automatic delivery depends on local cron, messaging interfaces, or the user's configured scheduler.
+- When full text is unavailable, the output is marked as `Abstract only` or `Metadata only`.
+- Scores are not final judgments of paper quality; high-scoring candidates still need human reading.
 
 ## Related Skills
 
-- [`nature-academic-search`](../nature-academic-search/README_EN.md)
-- [`nature-reader`](../nature-reader/README_EN.md)
-- [`nature-experiment-log`](../nature-experiment-log/README_EN.md)
+- `nature-academic-search`: one-off multi-source search, citation metrics, and strict external-citation audit.
+- `nature-reader`: turn candidate papers into full Chinese-English reading materials.

--- a/skills/nature-paper-to-patent/README.md
+++ b/skills/nature-paper-to-patent/README.md
@@ -2,136 +2,48 @@
 
 [English](README_EN.md)
 
-`nature-paper-to-patent` 是一个有证据约束的工作流，用于把科研论文、学位论文、技术报告、源代码、图表和发明人笔记转换为结构化中国发明专利草稿。
+`nature-paper-to-patent` 用于把科研论文、学位论文、技术报告、源代码、图表或发明人笔记转换为证据约束的中国发明专利草稿。
 
-该技能面向研究生、高校科研人员和技术团队。它生成中文正式专利文档，同时让面向 agent 的分析和路由说明保持可跨 AI agent 迁移。
+## 适合用它做什么
 
-## 功能
+- 从论文或技术资料中识别可专利化技术贡献。
+- 建立 source ID 和 evidence ledger，再起草权利要求。
+- 将算法、装置、系统、工艺、材料或混合型发明路由到对应规则。
+- 生成权利要求书、说明书、摘要、摘要附图和完整审阅稿。
+- 检查每个权利要求特征是否能回溯到来源证据。
 
-- 将论文正文、公式、图表、代码和补充证据映射到稳定 source ID。
-- 提取技术问题、协同技术手段、实施链条和具体技术输出。
-- 在起草权利要求前建立 evidence ledger。
-- 将每个实质性权利要求特征映射到来源证据。
-- 支持完整草案、仅权利要求、技术交底分析和 paper-patent comparison。
-- 处理可选中文本 PDF、扫描 PDF、粘贴文本和混合项目文件夹。
-- 将算法/软件、装置/系统、工艺/材料和混合型发明路由到不同起草规则。
-- 保留来源支持的核心公式，并在 DOCX 中渲染为可编辑 Office Math。
-- 生成与权利要求对齐的黑白流程图 SVG 和 PNG。
-- 复用主权利要求流程图作为摘要附图和说明书附图。
-- 分别生成中文 DOCX：权利要求书、说明书、说明书摘要、摘要附图和完整审阅稿。
-- 校验权利要求结构、证据可追溯性、公式覆盖、附图对齐、术语一致性和质量阈值。
+## 典型请求
 
-## 文件结构
+- “把这篇论文转成中国发明专利交底书和权利要求草稿。”
+- “只提取可专利点，先不要写完整说明书。”
+- “对比论文 claim 和专利 claim，看看哪些技术特征缺证据。”
 
-```text
-nature-paper-to-patent/
-├── README.md
-├── SKILL.md
-├── manifest.yaml
-├── requirements.txt
-├── static/
-│   ├── core/
-│   │   ├── principles.md
-│   │   ├── workflow.md
-│   │   └── output-contract.md
-│   └── fragments/
-│       ├── source/
-│       ├── task/
-│       └── invention/
-├── references/
-│   ├── cn-patent-drafting-guide.md
-│   ├── corpus-derived-patterns.md
-│   ├── corpus-pair-audit.md
-│   ├── draft-schema.md
-│   └── patent-figure-guide.md
-├── scripts/
-│   ├── audit_claims.py
-│   ├── build_patent_package.py
-│   ├── extract_pdf_text.py
-│   ├── init_patent_project.py
-│   ├── math_to_omml.py
-│   ├── render_flowchart_svg.py
-│   ├── render_patent_docx.py
-│   └── validate_patent_draft.py
-├── evals/
-│   └── evals.json
-└── tests/
-    └── test_validation.py
-```
+## 你需要提供
 
-## 路由模型
+- 论文 PDF、技术报告、代码、图表、实验记录或发明人补充说明。
+- 希望保护的对象：方法、系统、装置、材料、工艺或软件流程。
+- 已知现有技术、不能公开的信息和必须保留的术语。
 
-短 `SKILL.md` 作为路由器。`manifest.yaml` 只选择当前请求需要的片段：
+## 产出
 
-- `source_format`：`pdf-text`、`scanned-pdf`、`pasted-text` 或 `mixed-project`
-- `task_mode`：`full-draft`、`claim-set`、`disclosure-analysis` 或 `paper-patent-audit`
-- `invention_type`：`algorithm-software`、`apparatus-system`、`process-material` 或 `mixed`
+- 技术问题、技术方案、实施链条和有益效果分析。
+- 权利要求草稿及每个特征的证据映射。
+- 说明书、摘要、附图说明和黑白流程图。
+- 可选 DOCX、SVG、PNG 和审阅报告。
 
-始终加载的 core 定义证据纪律、分阶段起草工作流和输出契约。
+## 运行和依赖
 
-## 默认工作流
+- 完整功能依赖技能目录中的 `manifest.yaml`、`static/`、`references/`、`scripts/` 和 `requirements.txt`。
+- 需要生成 DOCX、公式或流程图时，会使用本机 Python 依赖和脚本。
 
-1. 记录输入、发表状态、发明人问题和权属问题。
-2. 建立全文 source map。
-3. 建立术语、公式、图表和输入-操作-输出清单。
-4. 建立 evidence ledger。
-5. 形成发明构思和权利要求策略。
-6. 起草并审查权利要求。
-7. 对齐说明书、公式、附图、实施例和摘要。
-8. 校验并生成完整申请文件包。
+## 边界
 
-每个阶段都有明确 gate。无支撑特征会被排除在正式权利要求之外，未解决事实会保留为发明人问题，而不会被编造。
+- 这是技术起草辅助，不替代专利代理师或法律意见。
+- 不会虚构实施例、实验数据、权利要求特征或现有技术对比。
+- 证据不足的特征会被标记为缺口，而不是写进主权利要求。
 
-## 安装
+## 相关技能
 
-安装完整目录，而不是只安装 `SKILL.md`，因为路由器依赖 `manifest.yaml`、`static/`、`references/` 和 `scripts/`。
-
-安装依赖：
-
-```bash
-python -m pip install -r requirements.txt
-```
-
-运行自动检查：
-
-```bash
-python -m unittest discover -s tests -v
-```
-
-## 示例请求
-
-```text
-请读取并遵循 nature-paper-to-patent 技能。
-分析 paper/paper.pdf，并生成中国发明专利草稿。
-请分别创建中文权利要求书、说明书、说明书摘要和摘要附图 DOCX 文件。
-保留来源支持的核心公式，并以可编辑 Office Math 呈现；
-生成与权利要求对齐的主流程图和方法附图；
-将每个实质性权利要求特征映射到来源证据。
-```
-
-## 默认交付物
-
-```text
-outputs/
-├── patent-权利要求书.docx
-├── patent-说明书.docx
-├── patent-说明书摘要.docx
-├── patent-摘要附图.docx
-├── patent-完整审阅稿.docx
-├── patent-结构化草稿.json
-├── patent-权利要求检查.txt
-├── patent-草稿验证报告.txt
-└── patent-figures/
-    ├── figure-1.svg
-    └── figure-1.png
-```
-
-## 状态与边界
-
-状态：**Beta**。
-
-确定性校验脚本和合成测试覆盖权利要求映射、核心公式要求、附图生成、可编辑 Office Math 和 DOCX 打包。输出仍是起草辅助材料，不构成专利性、新颖性、发明人资格、权属、侵权或可提交性意见；正式使用前需要发明人确认，并由合格中国专利专业人员审阅。
-
-贡献者：[`snipp-zha`](https://github.com/snipp-zha)。
-
-独立开发仓库：[`snipp-zha/Paper-to-patent-Skill`](https://github.com/snipp-zha/Paper-to-patent-Skill)。
+- `nature-reader`：先把论文转成可追溯阅读材料。
+- `nature-writing`：提炼论文贡献和技术叙事。
+- `nature-figure`：生成专利流程图或结构示意图草稿。

--- a/skills/nature-paper-to-patent/README_EN.md
+++ b/skills/nature-paper-to-patent/README_EN.md
@@ -2,45 +2,48 @@
 
 [中文说明](README.md)
 
-## What It Does
+`nature-paper-to-patent` converts papers, theses, technical reports, source code, figures, or inventor notes into evidence-constrained Chinese invention patent drafts.
 
-- Converts papers, theses, technical reports, source code, figures, or manuscripts into evidence-grounded Chinese invention patent drafts.
+## What To Use It For
 
-## When to Use It
+- Identify patentable technical contributions from papers or technical materials.
+- Build source IDs and an evidence ledger before drafting claims.
+- Route algorithm, device, system, process, material, or hybrid inventions to the right drafting rules.
+- Generate claims, specification, abstract, abstract drawing, and full review draft.
+- Check whether every claim feature can be traced back to source evidence.
 
-- You want to identify patentable technical contributions from research material.
-- You need claims, specification sections, abstract, and drawings aligned to source evidence.
-- You need a patent draft that avoids unsupported invention details.
+## Typical Requests
 
-## Copy-Paste Prompts
+- "Convert this paper into a Chinese invention patent disclosure and claim draft."
+- "Extract only the patentable points first; do not write the full specification yet."
+- "Compare the paper claims and patent claims, and find features without evidence."
 
-- `Convert this paper into a Chinese invention patent draft with evidence-linked claims.`
-- `Extract patentable technical contributions from this manuscript and draft independent and dependent claims.`
-- `Generate a claim-aligned method flowchart from these source materials.`
+## What You Need To Provide
 
-## Required Inputs
+- Paper PDF, technical report, code, figures, experiment records, or inventor notes.
+- Protection target: method, system, device, material, process, or software workflow.
+- Known prior art, confidential information, and terms that must be preserved.
 
-- Paper, thesis, technical report, manuscript, figures, code, or experimental evidence.
-- Any known inventors, application scope, technical field, and preferred claim strategy.
+## Outputs
 
-## Expected Outputs
+- Technical problem, technical solution, implementation chain, and beneficial-effect analysis.
+- Claim draft with evidence mapping for each feature.
+- Specification, abstract, drawing description, and black-and-white flowchart.
+- Optional DOCX, SVG, PNG, and review report.
 
-- Chinese patent claim set.
-- Specification draft, abstract, background, summary, embodiments, and drawings guidance.
-- Evidence map connecting claim elements to source material.
+## Runtime and Dependencies
 
-## Dependencies / API Keys / Local Environment
+- Full functionality depends on the skill directory's `manifest.yaml`, `static/`, `references/`, `scripts/`, and `requirements.txt`.
+- DOCX, formula, or flowchart generation uses local Python dependencies and scripts.
 
-- May use Python scripts or document tooling depending on the requested deliverables.
-- Legal review by a qualified patent professional is still required before filing.
+## Boundaries
 
-## FAQ
-
-- **Can it invent missing implementation details?** No. It should preserve evidence constraints and mark gaps clearly.
-- **Is the output ready to file?** It is a drafting aid, not legal advice or a substitute for patent-agent review.
+- This is technical drafting support, not a replacement for a patent attorney or legal opinion.
+- The skill does not invent embodiments, experimental data, claim features, or prior-art comparisons.
+- Features without evidence are marked as gaps rather than written into the independent claim.
 
 ## Related Skills
 
-- [`nature-writing`](../nature-writing/README_EN.md)
-- [`nature-figure`](../nature-figure/README_EN.md)
-- [`nature-data`](../nature-data/README_EN.md)
+- `nature-reader`: turn the paper into traceable reading material first.
+- `nature-writing`: extract contribution and technical narrative.
+- `nature-figure`: draft patent flowcharts or structural schematics.

--- a/skills/nature-paper2ppt/README.md
+++ b/skills/nature-paper2ppt/README.md
@@ -2,109 +2,43 @@
 
 [English](README_EN.md)
 
-`nature-paper2ppt` 用于把科研论文转换为简洁中文 PowerPoint，用于文献汇报、组会、实验室会议或论文分享，并以 Nature 风格证据叙事组织内容。
+`nature-paper2ppt` 用于把科研论文、预印本、PDF、图注或阅读笔记转换为中文 PowerPoint，适合组会、文献汇报、论文分享和答辩前讲稿准备。
 
-该技能可以接收论文 PDF、预印本、文章文本、摘要加图注，或结构化阅读笔记。它会识别论文类型、提取科学论证、只选择支撑论证的关键图表，撰写中文幻灯片内容和演讲备注，生成真实 `.pptx`，并做轻量级包体 QA。
+## 适合用它做什么
 
-## 功能
+- 将论文重组为 10-16 页中文汇报，而不是照搬原文章节。
+- 提取研究问题、关键 claim、核心证据、局限和可复用价值。
+- 选择支撑叙事的关键图表，并对密集图版进行裁剪或拆分。
+- 生成可编辑 `.pptx`、speaker notes 和轻量 QA 报告。
+- 将 Nature 风格证据叙事转化为现场报告的短句和页面结构。
 
-- 将科研论文转换为 10-16 页中文演示文稿。
-- 使用论文的科学论证作为幻灯片主线，而不是照搬章节顺序。
-- 先判断论文类型，再选择叙事逻辑。
-- 把关键图、表或面板作为证据，而不是装饰。
-- 当完整大图难以阅读时，对密集图版进行裁剪或拆分。
-- 撰写中文标题、精简 bullet、图注、takeaway 和 speaker notes。
-- 生成可编辑的 `.pptx` 作为主交付物。
-- 提取图表时记录 asset manifest。
-- 对页数、嵌入媒体、speaker notes、图片裁剪、版式对齐、AI 模板化表达和 PPTX 包结构做轻量 QA。
+## 典型请求
 
-## 来源与设计层级
+- “把这篇 Nature Communications 论文做成 12 页中文组会 PPT。”
+- “根据摘要和图注先做一版文献汇报，不要太密。”
+- “把这篇机器学习论文做成方法、结果、局限都清楚的 PPT。”
 
-- Nature 风格科学叙事：问题、缺口、claim、证据、验证、复用价值、局限和讨论。
-- 学术 journal club 实践：面向现场报告的短幻灯片，而不是密集读书笔记。
-- 证据优先的幻灯片设计：结果页尽量以一个主图或主表为核心。
-- 低开销生产：只有在实质提升成稿质量时，才做耗时的 OCR、图像提取和渲染。
+## 你需要提供
 
-## 文件结构
+- 论文 PDF、DOI、arXiv 链接、出版社页面、摘要加图注或阅读笔记。
+- 报告时长、听众背景、页数范围和是否需要 speaker notes。
+- 是否必须保留原图、是否允许裁剪或重画示意图。
 
-该技能采用 router/static-dynamic 结构：短 `SKILL.md` 路由配合 `manifest.yaml`，只加载当前任务需要的片段。
+## 产出
 
-```text
-nature-paper2ppt/
-├── SKILL.md                     # 短路由：识别 paper_type，加载 fragments
-├── manifest.yaml                # always_load core + paper_type axis + 按需 references
-├── README.md
-├── scripts/
-│   └── audit_pptx_quality.py     # PPTX XML 质量审计：越界、裁剪、对齐、套话
-├── static/
-│   ├── core/                    # 始终加载
-│   │   ├── principles.md        # 目的、核心原则、lean mode、输入、语言
-│   │   ├── toolchain.md         # 跨平台 Python 栈与默认快速路径
-│   │   ├── workflow.md          # 9 步主线
-│   │   └── output-and-quality.md# 输出包、引用、质量、fallback 规则
-│   └── fragments/
-│       └── paper_type/          # 每类论文一条汇报弧线
-│           ├── discovery.md     # question-to-evidence
-│           ├── methods.md       # problem-to-solution
-│           ├── resource.md      # workflow-to-validation
-│           ├── clinical.md      # design-to-inference
-│           ├── materials.md     # property-to-mechanism / design-to-performance
-│           └── review.md        # evidence-map
-└── references/                  # 按需打开
-    ├── design-and-layout.md     # 构图、版式、字体、反模板、页面原型
-    ├── figure-assets.md         # 图表选择、提取、裁剪自查
-    └── self-review.md           # 自审循环、严重程度、程序检查、验证
-```
+- 可编辑 PowerPoint 文件。
+- 图表资产清单和裁剪/引用说明。
+- 每页标题、要点、takeaway 和 speaker notes。
+- 包体检查结果，例如媒体嵌入、页数、备注和布局风险。
 
-共享术语表 `../_shared/core/terminology-ledger.md` 会在每次任务中加载，以保证幻灯片中的技术术语一致。
+## 边界
 
-## 适用场景
+- 不会把论文内容改写成无法回溯来源的泛泛介绍。
+- 图像质量不足、PDF 扫描质量差或原图无法提取时，会说明替代方案。
+- 如果任务是全文翻译或逐段阅读，优先使用 `nature-reader`。
 
-- 根据研究论文 PDF 制作 PPT 或 PPTX。
-- 准备 journal club、组会、实验室会议、论文分享或学位汇报。
-- 将 Nature 系列论文总结成中文幻灯片。
-- 把文章文本、图注或阅读笔记转成演示文稿。
-- 需要图文结合的 deck，而不只是大纲或摘要。
-- 需要 speaker notes、来源标签和 QA 报告。
+## 相关技能
 
-## 默认输出包
-
-默认输出是一个小型工作目录：
-
-```text
-output/
-├── final_presentation_cn.pptx
-├── qa_report.md
-├── asset_manifest.md          # 提取源图表时生成
-└── assets/
-    └── figures/
-```
-
-如果有助于审阅或调试，可以额外生成大纲或讲稿文件，但 `.pptx` 始终是主交付物。
-
-## 汇报逻辑
-
-默认叙事弧线帮助听众回答：
-
-1. 这个问题为什么重要？
-2. 论文解决了什么缺口或瓶颈？
-3. 作者做了什么？
-4. 关键证据是什么？
-5. 为什么结果可信？
-6. 新意、可复用价值或广泛意义在哪里？
-7. 边界和开放问题是什么？
-
-技能会按论文类型调整这条弧线。Discovery paper 使用 question-to-evidence 逻辑；methods、AI 和工具论文使用 problem-to-solution；resource 和 atlas 论文使用 workflow-to-validation；review 使用 evidence-map 结构。
-
-## 设计意图
-
-该技能应创建可直接用于学术口头报告的 deck。它应简洁、图表主导、证据敏感，不能编造源论文没有支持的数值、方法、机制、数据集或图像解释。
-
-密集结果图应裁剪、拆分或单独成页，不能压缩进不可读的对称双栏版式。幻灯片正文要短，深入解释放进 speaker notes。
-
-## 注意事项
-
-- 默认语言为简体中文，同时保留重要技术术语、缩写、基因名、模型名、公式和统计术语的英文。
-- 该技能适用于多个研究领域，不限于生物医学论文。
-- 如果没有可靠的 headless renderer，技能会进行结构 QA，并记录跳过渲染预览 QA 的原因。
-- 生成 PPTX 后应运行 `scripts/audit_pptx_quality.py`；高严重度问题需要修复后再交付。
+- `nature-reader`：先建立全文中英对照和图表 source map。
+- `nature-figure`：重画汇报中的机制图或方法图。
+- `presentations`：对生成的 PPTX 做进一步版式编辑。

--- a/skills/nature-paper2ppt/README_EN.md
+++ b/skills/nature-paper2ppt/README_EN.md
@@ -2,46 +2,43 @@
 
 [中文说明](README.md)
 
-## What It Does
+`nature-paper2ppt` converts scientific papers, preprints, PDFs, figure legends, or reading notes into Chinese PowerPoint decks for group meetings, journal clubs, paper sharing, and pre-defense preparation.
 
-- Builds Chinese PPTX journal-club or paper-presentation decks from scientific papers, with figure-crop QA, alignment checks, and de-template Chinese academic expression rules.
+## What To Use It For
 
-## When to Use It
+- Reorganize a paper into a 10-16 slide Chinese presentation instead of copying the article structure.
+- Extract the research question, key claims, core evidence, limitations, and reusable value.
+- Select figures and tables that support the narrative, cropping or splitting dense plates when needed.
+- Generate editable `.pptx`, speaker notes, and lightweight QA reports.
+- Translate Nature-style evidence narrative into short slide text and live-presentation structure.
 
-- You need a group-meeting, journal-club, thesis-seminar, or department-report deck from a paper.
-- You want key figures, source labels, and narrative structure preserved.
-- You need a draft deck plus QA warnings rather than a purely decorative summary.
+## Typical Requests
 
-## Copy-Paste Prompts
+- "Turn this Nature Communications paper into a 12-slide Chinese group-meeting PPT."
+- "Use the abstract and figure legends to make a first paper-presentation draft; keep it concise."
+- "Make this machine-learning paper into a deck with clear method, results, and limitations."
 
-- `Create a Chinese journal-club PPT from this paper, keeping key figures and source labels.`
-- `Audit this generated PPT for incomplete figure crops, alignment problems, and AI-template wording.`
-- `Revise this deck so the figures are complete and the Chinese academic expression is less templated.`
+## What You Need To Provide
 
-## Required Inputs
+- Paper PDF, DOI, arXiv link, publisher page, abstract plus figure legends, or reading notes.
+- Presentation duration, audience background, slide-count range, and whether speaker notes are needed.
+- Whether original figures must be preserved and whether cropping or redrawing schematics is allowed.
 
-- PDF, article text, DOI, abstract, figure legends, or reading notes.
-- Audience, presentation duration, slide count, and preferred emphasis.
-- Optional source figures or existing PPTX to audit.
+## Outputs
 
-## Expected Outputs
+- Editable PowerPoint file.
+- Figure-asset manifest and crop/source notes.
+- Slide titles, bullets, takeaways, and speaker notes.
+- Package checks for embedded media, slide count, notes, and layout risks.
 
-- PPTX deck and related assets.
-- Slide-level notes, source labels, and figure attributions.
-- Quality-audit findings for crop completeness, alignment, text density, and template-like wording.
+## Boundaries
 
-## Dependencies / API Keys / Local Environment
-
-- PPTX generation and XML-level QA scripts may require Python packages available in the local environment.
-- Visual verification is recommended before using the deck directly in a talk.
-
-## FAQ
-
-- **Can the output be used directly for a talk?** Treat it as a strong draft unless visual QA passes and the scientific content has been checked.
-- **What was recently improved?** The workflow now emphasizes complete figure crops, alignment stability, and less templated Chinese academic phrasing.
+- The skill does not turn paper content into generic, untraceable summaries.
+- If image quality is poor, the PDF is scanned, or figures cannot be extracted, the limitation and alternative are stated.
+- For full translation or paragraph-level reading, use `nature-reader` first.
 
 ## Related Skills
 
-- [`nature-reader`](../nature-reader/README_EN.md)
-- [`nature-figure`](../nature-figure/README_EN.md)
-- [`nature-polishing`](../nature-polishing/README_EN.md)
+- `nature-reader`: build full Chinese-English reading material and a figure source map first.
+- `nature-figure`: redraw mechanism or method diagrams for the deck.
+- `presentations`: further edit the generated PPTX layout.

--- a/skills/nature-polishing/README.md
+++ b/skills/nature-polishing/README.md
@@ -2,69 +2,48 @@
 
 [English](README_EN.md)
 
-`nature-polishing` 用于把学术手稿文本润色、重构或翻译成更接近 `Nature` 风格的简洁英文。
+`nature-polishing` 用于把学术手稿文本润色、重构或翻译成更接近 Nature 风格的简洁英文，同时保持作者原意、证据边界和引用意图。
 
-## 来源层级
+## 适合用它做什么
 
-- `Main strategy`：`Chapter1-Week1-7 full version.pdf` 中的写作课程笔记。
-- `Published article patterns`：精选 Nature 与 Nature Communications 论文范式。
-- `Reference support`：`Academic-Phrasebank-Navigable-PDF-2023.pdf`。
+- 将中文学术段落翻译为投稿可用英文。
+- 精简冗长句子，增强论证顺序和段落推进。
+- 按 Nature / Nature Communications 论文范式调整摘要、引言、结果、讨论或标题。
+- 区分 research paper 与 methods paper 的写作重点。
+- 检查 AI 味、夸张声称、过度因果表达和不自然搭配。
 
-## 当前变化
+## 方法来源
 
-- 主 `SKILL.md` 已按第一份 PDF 的架构重写：论文类型、读者工作流、沙漏结构、写作顺序、各部分职责、intellectual debt 以及 AI/ethics 边界。
-- 全文级润色可以使用已发表论文范式，覆盖摘要、引言、结果、讨论、结论和标题。
-- `references/` 现在承担更窄的职责：短语族、move template 和风格检查主要来自第二份 PDF。
-- 技能会区分 `research papers` 与 `methods papers`。
-- 技能把 `core argument ownership` 视为核心规则，而不是附带提醒。
+- 写作策略：学术写作课程笔记中的沙漏结构、读者工作流和章节职责。
+- 发表论文模式：精选 Nature 与 Nature Communications 文章的 section moves。
+- 短语支持：Academic Phrasebank 中适合学术论文的表达族。
 
-## 文件结构
+## 典型请求
 
-```text
-nature-polishing/
-├── SKILL.md
-├── README.md
-└── references/
-    ├── published-article-patterns.md
-    ├── phrasebank-playbook.md
-    ├── section-moves.md
-    ├── style-guardrails.md
-    ├── writing-strategy.md
-    └── latex-layout.md
-```
+- “把这段中文结果翻译成 Nature 风格英文，保持克制。”
+- “润色 abstract，不要改变事实和引用意图。”
+- “这段 introduction 太像 AI 写的，帮我重构逻辑和语言。”
 
-## 适用场景
+## 你需要提供
 
-- 润色摘要、引言、结果、讨论、结论或标题。
-- 润色 methods section，或处理强调公平比较逻辑的 methods paper。
-- 将中文学术文本翻译成可投稿英文。
-- 投稿前收紧章节逻辑。
-- 降低过度声称，修正证据强度不匹配的措辞。
-- 在不编造内容的前提下，让文本更像高水平期刊英文。
-- 修复 LaTeX 排版问题：页面过松、标题孤立、图片未填满页面或跨页、`Float too large`、多面板图排列、Supplementary Information 页面稀疏等。
+- 原文、目标章节、论文类型和希望保留的术语。
+- 不能改变的事实、数据、引用和专有表达。
+- 期望输出：只给改写版，还是给修改说明和风险标记。
 
-## 设计意图
+## 产出
 
-该技能应当：
+- 可粘贴的英文改写或中英对照版本。
+- 关键修改说明：逻辑重排、语气收敛、术语统一和声称边界。
+- 需要作者确认的事实或引用意图。
 
-- 保留事实、引用意图和作者责任。
-- 以第一份 PDF 作为主导写作策略。
-- 改善段落层面的修辞顺序。
-- 保持句子短、清楚、可读。
-- 只把第二份 PDF 作为短语和参考层。
-- 避免通用 AI 腔和无支撑声称。
+## 边界
 
-## 参考文件
+- 不会替作者新增结果、机制、统计意义或未给出的引用。
+- 不会为了更像 Nature 而夸大 novelty、causality 或 generality。
+- 如果需要从零搭建论文章节，优先使用 `nature-writing`。
 
-- `section-moves.md`：各章节顺序与 move pattern。
-- `published-article-patterns.md`：精选 Nature 与 Nature Communications 论文写法。
-- `phrasebank-playbook.md`：hedging、过渡、证据、局限和未来工作表达。
-- `style-guardrails.md`：英式风格、冠词、缩写、单位、语域和过度声称控制。
-- `writing-strategy.md`：段落与章节层面的论证逻辑。
-- `latex-layout.md`：LaTeX 浮动体和页面排版，包括顶端对齐、`\clearpage` + `[H]` 标题-图片单元、`placeins` 注意点、源头重绘又宽又矮的图、多面板堆叠，以及渲染后生成 contact sheet 的诊断流程。
+## 相关技能
 
-## 注意事项
-
-- 该技能用于润色和结构重组，不用于编造科学内容。
-- 主要策略规则位于 `SKILL.md`；参考文件不应覆盖这些规则。
-- 参考文件有意保持选择性，用于辅助判断，而不是鼓励套话堆砌。
+- `nature-writing`：章节级起草和论证重建。
+- `nature-response`：返修回复信和 cover letter 语言。
+- `nature-statistics`：统计文本、图注和审稿统计回复。

--- a/skills/nature-polishing/README_EN.md
+++ b/skills/nature-polishing/README_EN.md
@@ -2,43 +2,48 @@
 
 [中文说明](README.md)
 
-## What It Does
+`nature-polishing` polishes, restructures, or translates academic manuscript text into concise Nature-leaning English while preserving author meaning, evidence boundaries, and citation intent.
 
-- Polishes, restructures, or translates academic prose into Nature-leaning English while preserving scientific meaning and argument structure.
+## What To Use It For
 
-## When to Use It
+- Translate Chinese academic paragraphs into submission-ready English.
+- Shorten long sentences and improve argument order and paragraph movement.
+- Adjust abstracts, introductions, results, discussions, or titles using Nature / Nature Communications article patterns.
+- Distinguish research-paper and methods-paper writing priorities.
+- Check AI-like phrasing, exaggerated claims, excessive causal language, and unnatural collocations.
 
-- You have a draft paragraph, abstract, introduction, discussion, title, or methods section that needs academic English improvement.
-- You want Chinese-to-English rewriting for manuscript prose.
-- You need phrase-level alternatives without changing the claim.
+## Method Sources
 
-## Copy-Paste Prompts
+- Writing strategy: hourglass structure, reader workflow, and section roles from academic-writing course notes.
+- Published article patterns: section moves from selected Nature and Nature Communications papers.
+- Phrase support: expression families from Academic Phrasebank.
 
-- `Rewrite this Chinese paragraph into Nature-style academic English without changing the meaning.`
-- `Polish this introduction paragraph and explain the main changes.`
-- `Give three title alternatives for this manuscript in a Nature-style tone.`
+## Typical Requests
 
-## Required Inputs
+- "Translate this Chinese Results paragraph into Nature-style English, keeping it conservative."
+- "Polish this abstract without changing facts or citation intent."
+- "This introduction sounds too AI-written; rebuild its logic and language."
 
-- Draft text, target section, journal style, key claims, terminology constraints, and any phrases that must remain unchanged.
+## What You Need To Provide
 
-## Expected Outputs
+- Source text, target section, paper type, and terms that must be preserved.
+- Facts, data, citations, and specialized expressions that must not change.
+- Desired output: rewritten text only, or rewritten text with change notes and risk flags.
 
-- Polished English text.
-- Optional change explanation, alternatives, and terminology notes.
-- Warnings when the source meaning is ambiguous or unsupported.
+## Outputs
 
-## Dependencies / API Keys / Local Environment
+- Ready-to-paste English rewrite or Chinese-English paired version.
+- Key change notes: logic reordering, tone tightening, terminology alignment, and claim boundaries.
+- Facts or citation intent that require author confirmation.
 
-- No special runtime dependency for text-only polishing.
+## Boundaries
 
-## FAQ
-
-- **Will it make the writing sound artificially fancy?** It should prioritize clarity, precision, and scientific restraint rather than decorative language.
-- **Can it change scientific claims?** No. It should preserve meaning unless the user asks for argument restructuring and provides evidence.
+- The skill does not add results, mechanisms, statistical significance, or citations not provided by the author.
+- It does not exaggerate novelty, causality, or generality to sound more like Nature.
+- For building a manuscript section from scratch, use `nature-writing` first.
 
 ## Related Skills
 
-- [`nature-writing`](../nature-writing/README_EN.md)
-- [`nature-response`](../nature-response/README_EN.md)
-- [`nature-reviewer`](../nature-reviewer/README_EN.md)
+- `nature-writing`: section-level drafting and argument rebuilding.
+- `nature-response`: reviewer response and cover-letter language.
+- `nature-statistics`: statistical text, figure legends, and statistical reviewer responses.

--- a/skills/nature-proposal-writer/README.md
+++ b/skills/nature-proposal-writer/README.md
@@ -1,114 +1,50 @@
-# researchwrite
+# `nature-proposal-writer` 技能
 
 [English](README_EN.md)
 
-Proposal-first 科研写作状态机。不是"帮我写论文"——它强制执行写作前的论证架构，写完跑四层 QA pipeline。
+`nature-proposal-writer` 是 proposal-first 的科研写作工作流，用于把题目、想法、草稿或章节扩展为有论证结构、证据边界和质量闸门的科研文本。
 
-## 这是什么
+## 适合用它做什么
 
-三个模式 + 四层质量闸门：
+- 从模糊研究方向搭建 research canon、问题链和章节契约。
+- 修改已有段落，使论证顺序、贡献边界和证据支撑更清楚。
+- 将已有草稿扩写为 proposal、论文章节、综述框架或项目说明。
+- 在写作后执行内容、语言、引用和格式层面的 QA。
 
-```
-你的输入                  模式           做什么
-─────────────            ─────          ──────────────────
-题目、方向、模糊想法  →  compose       9步：从 research canon 到 .docx 导出
-已有段落/章节          →  revise        9步：差距分析 → 对比润色前后
-已有草稿 + 要扩写      →  hybrid        compose + revise 组合
-```
+## 三种模式
 
-写完后自动跑 QA：
+| 模式 | 输入 | 适合场景 |
+|------|------|----------|
+| `compose` | 题目、方向、粗略想法 | 从零建立论证和章节 |
+| `revise` | 已有段落或章节 | 做差距分析、重排和润色 |
+| `hybrid` | 草稿加扩写目标 | 保留已有文本，同时补足结构 |
 
-```
-Gate 2: professor 专家审查（内容层）
-  ├── 论文 → 方法论专家 + 领域专家
-  ├── proposal → 可行性专家 + 创新性专家
-  └── 综述 → 覆盖面专家 + 批判深度专家
-      ↓
-Gate 1: avoid-ai-writing（语言层，仅英文）
-      ↓
-Gate 3: 自动校验（citation？可复现？编号连续？）
-      ↓
-Gate 4: 评分阈值（≥7.0 通过，<7.0 定向回退 ≤3 轮）
-```
+## 典型请求
 
-## 核心原则
+- “我有一个基金题目，帮我先拆科学问题和研究内容，不要直接写正文。”
+- “这段 introduction 太散，按 proposal-first 的方式重构。”
+- “把这份草稿扩成 proposal 框架，并标出证据缺口。”
 
-| # | 原则 | 说明 |
-|---|------|------|
-| 1 | 证据先于文字 | 起草前必须建立 research_canon 和 evidence_table |
-| 2 | 论证先于章节 | 写正文前必须完成 argument_map |
-| 3 | 契约先于段落 | 每节需要 purpose / allowed claims / forbidden claims |
-| 4 | 动态专家 | 按失败模式召唤对应审查专家 |
-| 5 | 内容先于语言 | 诊断科学逻辑后再做语言打磨 |
-| 6 | 该停就停 | 平台期、证据缺失是停止理由 |
+## 你需要提供
 
-## 安装
+- 研究主题、目标读者、拟投稿/申报类型和已有材料。
+- 已确认的事实、数据、图表、参考文献或不能改动的表述。
+- 希望输出的长度、语言和文件格式。
 
-```bash
-# Hermes / Claude Code
-git clone https://github.com/Jiahao8595/research-pipeline.git
-cp -r research-pipeline/researchwrite ~/.hermes/skills/
-```
+## 产出
 
-安装后 `/reload-skills`。
+- 论证架构、章节契约和写作顺序。
+- 可粘贴的正文草稿或修订版。
+- QA 结果：内容缺口、语言风险、引用/编号问题和需要作者确认的事实。
 
-**前置依赖：**
+## 边界
 
-```bash
-hermes skills install brainstorm     # 入口追问
-hermes skills install professor      # 动态专家审查
-hermes skills install avoid-ai-writing  # 英文去 AI 味
-hermes skills install docx           # Word 文档导出
-```
+- 不会替作者虚构实验结果、参考文献、合作基础或可行性证据。
+- 对缺失事实会标记 `AUTHOR_INPUT_NEEDED`，而不是用流畅文字掩盖。
+- 如果只是句子级英文润色，优先使用 `nature-polishing`。
 
-## 使用示例
+## 相关技能
 
-```
-# 从零写 proposal
-"用 researchwrite 帮我写一个关于钙钛矿稳定性优化的研究计划"
-
-# 审查已有文本
-"用 researchwrite 审查这段 discussion，paper 挡位"
-
-# 快速扫读
-"快速扫一下这个摘要"（只标记问题，不全跑 QA）
-```
-
-## 四挡位
-
-| 挡位 | 场景 | 阈值 | 说明 |
-|------|------|:---:|------|
-| `paper` | 投稿论文 | 7.0 | 全跑 |
-| `proposal` | 研究方案/开题 | 7.0 | 全跑 |
-| `internal` | 内部汇报 | 5.0 | 跳过专家审查 |
-| `quick` | 快速扫读 | — | 只标记 P0 问题 |
-
-## 文件结构
-
-```
-researchwrite/
-├── SKILL.md                       ← 技能入口
-├── README.md                      ← 本文件
-├── references/
-│   ├── evaluation-rubric.md       ← 8 维 × 4 锚点评分体系
-│   ├── stopping-rules.md          ← 迭代终止条件
-│   ├── foundation-files.md        ← 建立 foundation 五文件
-│   └── validation-checklist.md    ← 自动校验清单
-├── scripts/
-│   └── build_proposal_docx.py     ← .md → .docx 构建脚本
-└── templates/                     ← 空模板（新建项目用）
-    ├── 00_scope.md
-    ├── 01_research_canon.md
-    ├── 02_evidence_table.md
-    ├── 03_argument_map.md
-    ├── 04_section_contracts.md
-    ├── 05_style_guide.md
-    ├── qa_report.md
-    └── revision_brief.md
-```
-
-> **完整 reference 文件**（compose/revise/hybrid 模式详解、专家分派、导出归档、综述框架等 12 份）未包含在公开版本中。如需获取，请通过 [GitHub issue](https://github.com/Jiahao8595/research-pipeline/issues) 或邮件联系作者。
-
-## 作者
-
-十五 (JL Lab) — 基于博士研究实战构建的写作框架。
+- `nature-writing`：Nature 风格手稿章节起草。
+- `nature-polishing`：英文稿件润色、重构和翻译。
+- `nsfc-proposal`：国家自然科学基金申请书的专项写作。

--- a/skills/nature-proposal-writer/README_EN.md
+++ b/skills/nature-proposal-writer/README_EN.md
@@ -2,45 +2,49 @@
 
 [中文说明](README.md)
 
-## What It Does
+`nature-proposal-writer` is a proposal-first research-writing workflow for turning topics, ideas, drafts, or sections into academic text with argument structure, evidence boundaries, and quality gates.
 
-- A proposal-first research-writing state machine that establishes evidence, argument, and section contracts before drafting or reviewing proposal text.
+## What To Use It For
 
-## When to Use It
+- Build a research canon, problem chain, and section contracts from a rough research direction.
+- Revise existing paragraphs so argument order, contribution boundaries, and evidence support are clearer.
+- Expand existing drafts into proposals, manuscript sections, review frameworks, or project narratives.
+- Run content, language, citation, and formatting QA after drafting.
 
-- You need to draft a proposal, opening report, research plan, or structured research-writing document.
-- You want a QA pass that checks evidence, argument, feasibility, and section logic.
-- You need to move from rough notes to a coherent proposal skeleton.
+## Three Modes
 
-## Copy-Paste Prompts
+| Mode | Input | Best For |
+|------|-------|----------|
+| `compose` | Topic, direction, rough idea | Build argument and sections from scratch |
+| `revise` | Existing paragraph or section | Gap analysis, reordering, and polishing |
+| `hybrid` | Draft plus expansion target | Preserve existing text while filling structure |
 
-- `Build a proposal outline from these notes and identify missing evidence.`
-- `Review this research plan for argument gaps, feasibility, and section logic.`
-- `Draft the opening-report background and research objectives from these materials.`
+## Typical Requests
 
-## Required Inputs
+- "I have a grant title; first break down the scientific questions and research content, do not write prose yet."
+- "This introduction is scattered; rebuild it with the proposal-first workflow."
+- "Expand this draft into a proposal framework and mark evidence gaps."
 
-- Research topic, background notes, preliminary evidence, target format, constraints, and review criteria.
-- Optional existing draft for QA or rewrite.
+## What You Need To Provide
 
-## Expected Outputs
+- Research topic, target reader, submission/application type, and available materials.
+- Confirmed facts, data, figures, references, or wording that must not change.
+- Desired length, language, and file format.
 
-- Proposal outline, section contract, and evidence map.
-- Drafted or revised proposal sections.
-- QA findings and next-step checklist.
+## Outputs
 
-## Dependencies / API Keys / Local Environment
+- Argument architecture, section contracts, and writing order.
+- Ready-to-paste draft text or revised text.
+- QA results: content gaps, language risks, citation/numbering issues, and facts that need author confirmation.
 
-- May integrate with Hermes or Claude Code workflows depending on the local setup.
-- No special dependency for plain text drafting.
+## Boundaries
 
-## FAQ
-
-- **Is this only for grant proposals?** No. It also fits opening reports, research plans, and proposal-like academic documents.
-- **Does it write before checking evidence?** The intended workflow is evidence and argument first, drafting second.
+- The skill does not invent experimental results, references, collaboration basis, or feasibility evidence.
+- Missing facts are marked as `AUTHOR_INPUT_NEEDED` rather than hidden under fluent prose.
+- For sentence-level English polishing only, use `nature-polishing`.
 
 ## Related Skills
 
-- [`nature-writing`](../nature-writing/README_EN.md)
-- [`nature-polishing`](../nature-polishing/README_EN.md)
-- [`nature-reviewer`](../nature-reviewer/README_EN.md)
+- `nature-writing`: Nature-style manuscript-section drafting.
+- `nature-polishing`: English manuscript polishing, restructuring, and translation.
+- `nsfc-proposal`: dedicated National Natural Science Foundation of China proposal writing.

--- a/skills/nature-reader/README.md
+++ b/skills/nature-reader/README.md
@@ -2,41 +2,43 @@
 
 [English](README_EN.md)
 
-`nature-reader` 是以 Markdown 为核心的全文论文阅读工作流。
+`nature-reader` 用于把论文 PDF、DOI、arXiv、出版社 HTML 或粘贴文本转换为可回溯的全文 Markdown 阅读材料，包含中英对照、图表定位和 source map。
 
-## 功能
+## 适合用它做什么
 
-`nature-reader` 可以把 PDF、DOI、arXiv 链接、出版社 HTML 页面或粘贴的手稿文本转化为完整 Markdown 阅读材料，包含：
+- 制作论文全文中英对照 Markdown。
+- 在首次实质性讨论处插入对应图表和图注翻译。
+- 为每段文本、图、表建立页码和来源锚点。
+- 从 PDF、HTML 或预印本文本中提取可复核阅读材料。
+- 生成适合后续写作、汇报或引用核查的阅读底稿。
 
-- 段落级原文与中文翻译，并以正文形式呈现。
-- 提取出的图和表，放在首次实质性讨论它们的位置附近。
-- 原始图注和中文图注翻译。
-- 稳定的页码与文本块锚点，便于回溯来源。
-- 紧凑图像裁剪和完整文档 source map。
+## 典型请求
 
-## 主要产物
+- “把这篇 PDF 做成中英对照全文 Markdown。”
+- “翻译并解读这篇论文，图表要放在对应正文附近。”
+- “根据 DOI 获取论文内容，生成带 source map 的阅读材料。”
 
-- `paper.md`
-- `source_map.json`
-- `translation_notes.md`
-- `assets/`
+## 你需要提供
 
-`reader.html` 可以作为二级预览生成，但该技能默认以 Markdown 为中心，不默认生成交互式问答面板。
+- PDF、DOI、arXiv 链接、出版社 HTML、题名或粘贴文本。
+- 输出目录和是否需要图片裁剪。
+- 是否保留英文原文、中文翻译、图表、表格和翻译备注。
 
-## 触发短语
+## 产出
 
-当用户提出以下需求时使用该技能：
+- `paper.md`：全文阅读材料。
+- `source_map.json`：页码、文本块和图表来源映射。
+- `translation_notes.md`：术语、无法确认内容和翻译说明。
+- `assets/`：图表、裁剪图片和必要附件。
 
-- 全文翻译
-- 原文对照
-- 中英文对照
-- 图文对应
-- 图表提取
-- 翻译解读
-- 全文 Markdown
-- paper md
-- source-grounded reading notes
+## 边界
 
-## 注意事项
+- 默认以 Markdown 为中心，不默认生成交互式问答面板。
+- 扫描 PDF、双栏错序、图片化公式或版权受限全文可能需要额外人工校对。
+- 无法合法获取全文时，会基于可用摘要/元数据说明限制。
 
-不要把该技能用于摘要、关键词列表或只做引用检索的任务。一旦触发，默认产物应是带有可见 `Original` / `中文` 对照和图表卡片的 `paper.md`，不能只输出中文摘要。
+## 相关技能
+
+- `nature-downloader`：先合法获取 PDF 或 HTML 全文。
+- `nature-paper2ppt`：把阅读材料转成中文汇报 PPT。
+- `nature-citation`：从阅读材料中抽取需要引用支撑的 claim。

--- a/skills/nature-reader/README_EN.md
+++ b/skills/nature-reader/README_EN.md
@@ -2,46 +2,43 @@
 
 [中文说明](README.md)
 
-## What It Does
+`nature-reader` converts paper PDFs, DOIs, arXiv links, publisher HTML, or pasted text into traceable full-paper Markdown readers with Chinese-English text, figure/table placement, and a source map.
 
-- Creates source-grounded full-paper Markdown readers with Chinese-English side-by-side translation, figure/table awareness, and source anchors.
+## What To Use It For
 
-## When to Use It
+- Create full-paper Chinese-English Markdown readers.
+- Insert figures, tables, and translated legends near the first substantive discussion.
+- Build page and source anchors for every paragraph, figure, and table.
+- Extract reviewable reading materials from PDFs, HTML, or preprint text.
+- Produce reading notes that can support later writing, presentations, or citation checks.
 
-- You want to read or translate a complete paper rather than only summarize it.
-- You need figures and tables placed near relevant text.
-- You want source-grounded notes that preserve structure and citations.
+## Typical Requests
 
-## Copy-Paste Prompts
+- "Turn this PDF into a full Chinese-English Markdown reader."
+- "Translate and explain this paper, placing figures near the relevant text."
+- "Use this DOI to get the paper content and generate a reader with a source map."
 
-- `Turn this PDF into a figure-aware Chinese-English Markdown reader.`
-- `Create a full-paper Markdown reading note with figures placed near the relevant sections.`
-- `Translate this paper with original text, Chinese translation, and source anchors.`
+## What You Need To Provide
 
-## Required Inputs
+- PDF, DOI, arXiv link, publisher HTML, title, or pasted text.
+- Output directory and whether image cropping is needed.
+- Whether to keep English original text, Chinese translation, figures, tables, and translation notes.
 
-- PDF, DOI, arXiv link, publisher HTML, pasted article text, or extracted figures/tables.
-- Optional output path and language preferences.
+## Outputs
 
-## Expected Outputs
+- `paper.md`: full reading material.
+- `source_map.json`: mapping for pages, text blocks, and figures/tables.
+- `translation_notes.md`: terminology, uncertain content, and translation notes.
+- `assets/`: figures, cropped images, and required attachments.
 
-- Full Markdown reader.
-- Chinese-English side-by-side sections.
-- Figure/table placement notes and source anchors.
-- Uncertainty notes when extraction is incomplete.
+## Boundaries
 
-## Dependencies / API Keys / Local Environment
-
-- PDF extraction or rendering tools may be required for scanned or layout-heavy papers.
-- Internet access may be needed for DOI or publisher retrieval.
-
-## FAQ
-
-- **Does it summarize or translate?** It focuses on full-paper reading and translation, with summaries included only when helpful.
-- **Can it handle scanned PDFs?** Only if OCR or visual extraction is available; otherwise it should report the limitation.
+- The default output is Markdown-centered; it does not generate an interactive Q&A panel by default.
+- Scanned PDFs, two-column ordering, image-only formulas, or copyright-restricted full text may need additional human checking.
+- If full text cannot be legally obtained, the skill states the limitation and works from available abstract/metadata.
 
 ## Related Skills
 
-- [`nature-paper2ppt`](../nature-paper2ppt/README_EN.md)
-- [`nature-academic-search`](../nature-academic-search/README_EN.md)
-- [`nature-polishing`](../nature-polishing/README_EN.md)
+- `nature-downloader`: legally obtain PDF or HTML full text first.
+- `nature-paper2ppt`: turn reading materials into Chinese presentation slides.
+- `nature-citation`: extract claims that need citation support.

--- a/skills/nature-ref-verifier/README.md
+++ b/skills/nature-ref-verifier/README.md
@@ -1,62 +1,44 @@
----
-name: nature-ref-verifier
-description: >-
-  学术参考文献多源交叉验证技能。逐条对比作者、标题、年份、卷期、页码，
-  标记卷年/DOI年冲突、作者顺序异常、页码偏差等问题，输出结构化验证报告。
----
-
-# nature-ref-verifier
+# `nature-ref-verifier` 技能
 
 [English](README_EN.md)
 
-## 用途
+`nature-ref-verifier` 用于对参考文献逐条执行多源交叉验证，比较作者、题名、年份、卷期、页码、DOI 和出版状态，并输出可修正的结构化报告。
 
-逐条验证参考文献的元数据准确性。适合论文提交前自查、审稿意见回复时的引用核查、Zotero 库定期养护。
+## 适合用它做什么
 
-## 工作流概要
+- 投稿前检查整篇论文参考文献是否准确。
+- 针对审稿意见核查某几条引用是否写错。
+- 清理 Zotero / BibTeX 库中的错误元数据。
+- 标记卷年与 DOI 年冲突、作者顺序异常、页码偏差、题名不一致和 DOI 指向错误。
+- 对中文参考文献结合 CNKI 或中文来源核验作者名、刊名和页码。
 
-1. **解析输入** — 接受整篇论文的参考文献列表、单条引用、BibTeX 文件或 Zotero item key
-2. **多源并行查询** — 根据可用工具，同时查 Crossref / IEEE Xplore / 网络搜索 / CNKI / Zotero
-3. **字段级对比** — 逐字段比对，按严重程度分为 🔴 必须修正 / 🟡 建议核对 / 🟢 仅供参考
-4. **置信度评估** — 输出 ✅ Verified / ⚠️ Check suggested / ❌ Needs fix / ❓ Unverifiable
-5. **输出报告** — Markdown 摘要 / BibTeX patch / Zotero 更新指令
+## 典型请求
 
-## 设计背景
+- “帮我逐条检查这 50 条参考文献，标出必须修正的。”
+- “这几条 DOI 好像不对，帮我查真实题名和页码。”
+- “把 BibTeX 里的错误字段整理成 patch 建议。”
 
-本技能源于实际开题报告参考文献核查中遇到的问题：
+## 你需要提供
 
-| 问题类型 | 示例 | 发现方式 |
-|---------|------|---------|
-| 作者完全编造 | Smogavec P → Leckebusch J | CrossRef 查 DOI |
-| 作者顺序颠倒 | Vainikainen→Mikhnev | IEEE 官网 |
-| 卷年 vs DOI 年 | Dadrass 卷2025/上线2024 | 多源对比 |
-| 页码完全错误 | Noon: 1444-1449→1309-1319 | IEEE Xplore |
-| 中文作者名搞混 | 赵延刚→赵廷刚 | 知网 |
-| DOI 指向不同论文 | Abidi: 错误 DOI | CrossRef |
+- 参考文献列表、单条引用、BibTeX、RIS、Zotero item key 或论文参考文献页。
+- 允许使用的数据源，例如 Crossref、PubMed、IEEE、CNKI、出版社页面或 Zotero。
+- 是否需要生成可直接导入的修正文件。
 
-单一搜索引擎（谷歌学术 / Bing / Crossref）都不足以覆盖所有问题，必须多源交叉验证。
+## 产出
 
-## 环境和依赖
+- 字段级核查表：原始值、可信来源值、差异和证据链接。
+- 严重程度分级：必须修正、建议核对、仅供参考、无法验证。
+- 可选 BibTeX patch、Zotero 更新建议或 Markdown 审查报告。
+- 对不确定条目的人工核查清单。
 
-可选工具，有则启用：
+## 边界
 
-- `zotero-cli` / `zotero-mcp` — 读取 Zotero 库、修正条目
-- `kimi-datasource (scholar)` — 学术搜索
-- `kimi-webbridge` — 带校园网登录态的知网查询
-- `WebSearch` / `FetchURL` — 通用网络搜索兜底
+- 不会把单一搜索结果当作最终事实；关键字段优先回到 DOI、出版社或权威数据库。
+- DOI、卷期和在线发表年份不一致时，会解释冲突而不是强行合并。
+- 无法访问的数据库或中文来源会被标注为未验证。
 
-## 使用方式
+## 相关技能
 
-直接告诉 agent：
-
-```
-帮我校验这篇论文的参考文献
-```
-
-```
-验证这条引用：Farquharson G, Langman A. ... 1999
-```
-
-```
-检查我的 bib 文件，输出修正后的版本
-```
+- `nature-academic-search`：检索论文元数据和引用指标。
+- `nature-citation`：为手稿 claim 选择候选引用。
+- `nature-response`：回应审稿人关于参考文献错误的意见。

--- a/skills/nature-ref-verifier/README_EN.md
+++ b/skills/nature-ref-verifier/README_EN.md
@@ -2,44 +2,43 @@
 
 [中文说明](README.md)
 
-## What It Does
+`nature-ref-verifier` performs multi-source cross-verification of references, comparing authors, title, year, volume, issue, pages, DOI, and publication status, then outputs a structured fixable report.
 
-- Verifies reference lists across multiple sources and flags bibliographic inconsistencies such as author, title, year, volume, issue, page, and DOI mismatches.
+## What To Use It For
 
-## When to Use It
+- Check an entire manuscript reference list before submission.
+- Verify a few citations raised in reviewer comments.
+- Clean incorrect metadata in a Zotero / BibTeX library.
+- Flag volume-year conflicts, author-order problems, page mismatches, title differences, and wrong DOI targets.
+- Verify Chinese references through CNKI or Chinese-language sources for author names, journal names, and pages.
 
-- You need to check whether a reference list contains fabricated, inconsistent, or malformed entries.
-- You want a field-by-field verification table before submission.
-- You need to distinguish minor formatting issues from serious metadata conflicts.
+## Typical Requests
 
-## Copy-Paste Prompts
+- "Check these 50 references one by one and mark the ones that must be fixed."
+- "These DOIs may be wrong; find the real titles and page ranges."
+- "Turn the incorrect fields in this BibTeX file into patch suggestions."
 
-- `Verify this reference list and flag author, title, year, volume, issue, page, and DOI problems.`
-- `Check whether these references are real and return corrected metadata candidates.`
-- `Audit these references before journal submission.`
+## What You Need To Provide
 
-## Required Inputs
+- Reference list, single citation, BibTeX, RIS, Zotero item key, or manuscript bibliography page.
+- Allowed sources such as Crossref, PubMed, IEEE, CNKI, publisher pages, or Zotero.
+- Whether a directly importable correction file is needed.
 
-- Reference list, BibTeX, RIS, DOI list, manuscript bibliography, or pasted citations.
-- Optional target journal citation style.
+## Outputs
 
-## Expected Outputs
+- Field-level verification table: original value, trusted-source value, difference, and evidence link.
+- Severity labels: must fix, check suggested, reference only, or unverifiable.
+- Optional BibTeX patch, Zotero update suggestion, or Markdown review report.
+- Human-check checklist for uncertain records.
 
-- Verification table with per-field comparisons.
-- Severity labels for fabricated, conflicting, missing, or formatting-only issues.
-- Corrected metadata candidates and source links when available.
+## Boundaries
 
-## Dependencies / API Keys / Local Environment
-
-- Internet or bibliographic-source access may be required for fresh verification.
-- Some databases may require credentials.
-
-## FAQ
-
-- **Does it rewrite the bibliography automatically?** It should first report verified corrections; rewriting can be requested after review.
-- **Can it prove a citation is fabricated?** It can flag strong evidence of non-existence or conflict, but should report source coverage and uncertainty.
+- A single search result is not treated as final truth; key fields are verified against DOI records, publishers, or authoritative databases.
+- DOI year, volume year, and online-publication year conflicts are explained rather than force-merged.
+- Inaccessible databases or Chinese sources are marked as unverified.
 
 ## Related Skills
 
-- [`nature-academic-search`](../nature-academic-search/README_EN.md)
-- [`nature-citation`](../nature-citation/README_EN.md)
+- `nature-academic-search`: retrieve paper metadata and citation indicators.
+- `nature-citation`: choose candidate citations for manuscript claims.
+- `nature-response`: respond to reviewer comments about reference errors.

--- a/skills/nature-response/README.md
+++ b/skills/nature-response/README.md
@@ -2,119 +2,44 @@
 
 [English](README_EN.md)
 
-`nature-response` 用于起草、审查和修改返修通信材料，包括逐点回复审稿人的 response letter、返修 cover letter、标红修改稿和可编辑 LaTeX 模板，适用于 Nature 系列和其他高影响力期刊的返修场景。
+`nature-response` 用于起草、审查和修改返修通信材料，包括逐点 reviewer response、revision cover letter、标红修改稿摘录和可编辑 LaTeX 模板。
 
-该技能支持中英文输入。它可以接收中文或英文审稿意见、编辑决定信、编辑部返修邮件、作者修改说明和 rebuttal 草稿，并生成英文回复包；需要作者确认的信息会用中文提示。
+## 适合用它做什么
 
-## 功能
+- 解析编辑部决定信、返修邮件和 reviewer reports。
+- 将意见拆成稳定编号，例如 `E.1`、`R1.1`、`R2.3`。
+- 为每条意见制定回应策略、手稿修改动作和证据需求。
+- 起草正式、克制、可提交的英文逐点回复和 cover letter。
+- 审查 rebuttal 草稿中的遗漏回复、防御性语气、无支撑声称和行号缺口。
 
-- 将审稿意见拆分为稳定编号，例如 `R1.1`、`R1.2`、`R2.1`。
-- 直接解析粘贴进来的编辑部返修邮件，抽取稿件号、题名、decision type、截止日期、必须提交的文件、editor instruction 和 reviewer reports，并自动进入回复包流程。
-- 按类型、严重程度、所需行动、证据需求和风险对每条意见分类。
-- 在正式起草前生成 response strategy summary。
-- 根据任务需要路由到起草、审查、修改、只做分诊或类似 appeal 的处理。
-- 如果决定信包含编辑要求，先生成 `E.1` 等 editor instruction ID，再处理 reviewer ID。
-- 起草编辑可读的逐点回复信。
-- 起草返修 cover letter，概述主要修改并指向逐点回复文件。
-- 提供 `templates/cover-letter.tex`、`templates/response-to-reviewers.tex` 和 `templates/revised-manuscript-redline.tex`。
-- 修改稿必须基于备份/复制的原稿件制作，修改处用红色标出。
-- 回复信中回答完意见后，如需粘贴修改后的原文，原文必须用斜体显示。
-- 在 LaTeX 或面向 PDF/打印的回复信中，切换到下一位审稿人的回复时必须换页。
-- 将每条回复映射到手稿修改动作、修改位置或缺失信息标记。
-- 把防御性或含糊的作者笔记改写成专业回复语言。
-- 处理困难情况，例如超出范围的实验、审稿人事实错误、审稿人意见冲突、统计质疑和合规问题。
-- 标记缺失实验、分析、行号、引用、图版和手稿改动，不能编造这些内容。
+## 典型请求
 
-## 适用场景
+- “这是编辑邮件和审稿意见，帮我生成逐点回复框架。”
+- “把我的中文修改说明改成英文 reviewer response。”
+- “检查这份 rebuttal 是否漏回、语气是否太强、有没有缺证据。”
 
-- 准备 Nature、Nature Portfolio、Springer Nature 或类似高影响力期刊返修。
-- 将编辑部邮件内容直接交给 agent，自动拆出返修要求并开始生成回复包。
-- 回复大修或小修意见。
-- 将审稿意见转化为手稿修改清单。
-- 审查 rebuttal 草稿中遗漏回复、语气问题或无支撑声称。
-- 将中文作者笔记转成可提交的英文逐点回复。
-- 将中文作者笔记转成可提交的英文 cover letter 或 LaTeX response package。
-- 判断如何礼貌反驳审稿人，或解释研究范围边界。
-- 需要 LaTeX 格式的 cover letter、rebuttal letter、response to reviewers 或标红修改稿。
+## 你需要提供
 
-## 默认返回内容
+- 编辑决定信、审稿意见、返修要求或已有 rebuttal 草稿。
+- 已完成或计划完成的实验、分析、图表、行号和手稿修改位置。
+- 目标期刊、稿件号、题名和提交材料要求。
 
-除非用户要求其他格式，技能会返回：
+## 产出
 
-1. response strategy summary
-2. comment-response tracker
-3. draft point-by-point response letter
-4. draft revision cover letter（如用户要求）
-5. marked manuscript changes（如用户要求修改原稿）
-6. LaTeX 文件或模板路径（如用户要求）
-7. manuscript change checklist
-8. missing information / risk flags
-9. 用户使用中文时的中文确认说明
+- Response strategy summary。
+- 逐点回复信、返修 cover letter 或 LaTeX response package。
+- 手稿修改清单、缺失信息清单和风险提示。
+- 可选标红修改稿摘录；原文修改必须基于作者提供的文本。
 
-## 核心规则
+## 边界
 
-- 回复前必须忠实保留审稿意见。
-- 每条意见都要得到回应、交叉引用或标记为未解决。
-- 每条回复必须映射到具体动作，例如 `ACCEPT_TEXT`、`ACCEPT_ANALYSIS`、`SOFTEN_CLAIM`、`DISAGREE` 或 `AUTHOR_INPUT_NEEDED`。
-- 不得编造实验、分析、引用、行号、图版、补充材料、审稿人身份、编辑要求或手稿修改。
-- 使用合作、证据优先、非防御性的语言。
-- 将 response letter 视为给编辑核查的验证文件，而不只是礼貌文本。
-- 将 cover letter 视为给编辑看的返修摘要，不能替代逐点回复。
-- 修改原稿时在备份稿上标红，不直接覆盖干净稿。
-- 回复信中粘贴的修改后原文必须是斜体。
-- 换审稿人回复时换页；LaTeX 模板通过 `\ReviewerSection{...}` 执行。
+- 不会编造实验、分析、行号、图版、统计结果或编辑要求。
+- 对需要作者确认的信息会用中文标记，而不是直接写成事实。
+- 如果任务是模拟投稿前审稿意见，优先使用 `nature-reviewer`。
 
-## 来源层级
+## 相关技能
 
-- 目标期刊说明与决定信要求。
-- Nature / Nature Portfolio / Springer Nature 返修和同行评审流程说明。
-- Springer Nature 关于 rebuttal letter 的编辑建议。
-- 作者提供的本地手稿事实。
-
-来源依据汇总在 `references/source-basis.md` 中，包含 URL、规则摘要和来源类型标签。
-
-## 文件结构
-
-该技能采用 router/static-dynamic 结构：`SKILL.md` 负责短路由，`manifest.yaml` 加载常驻 core 和按需 references。`nature-response` 是线性工作流，没有内容轴。
-
-```text
-nature-response/
-├── README.md
-├── SKILL.md                     # 短路由
-├── manifest.yaml                # always_load core + 按需 references
-├── static/
-│   └── core/                    # 始终加载
-│       ├── stance.md            # 目的、默认立场、红线、来源层级
-│       └── workflow.md          # 输入类型、返修通信工作流、输出格式
-├── references/
-│   ├── source-basis.md
-│   ├── response-structure.md
-│   ├── latex-templates.md
-│   ├── comment-taxonomy.md
-│   ├── action-mapping.md
-│   ├── tone-and-stance.md
-│   ├── chinese-author-alignment.md
-│   ├── difficult-cases.md
-│   ├── intake-and-routing.md
-│   └── qa-checklist.md
-├── templates/
-│   ├── cover-letter.tex
-│   ├── response-to-reviewers.tex
-│   └── revised-manuscript-redline.tex
-├── tests/
-    ├── conflicting-reviewers.md
-    ├── defensive-draft-audit.md
-    ├── evaluation-summary.md
-    ├── minor-revision.md
-    ├── major-revision-missing-evidence.md
-    ├── impossible-experiment.md
-    └── rubric.md
-└── examples/
-    ├── conflicting-reviewers.md
-    ├── major-revision-with-missing-evidence.md
-    └── minor-revision.md
-```
-
-## 状态
-
-Beta。当前行为由合成 Markdown fixtures 和示例定义。只有在经过真实匿名返修包、且获得作者许可的验证后，才应提升到 Stable。
+- `nature-reviewer`：投稿前模拟审稿人意见。
+- `nature-polishing`：回复信和 cover letter 的英文语气打磨。
+- `nature-statistics`：处理统计相关审稿意见。
+- `nature-ref-verifier`：核查参考文献错误类意见。

--- a/skills/nature-response/README_EN.md
+++ b/skills/nature-response/README_EN.md
@@ -2,47 +2,44 @@
 
 [中文说明](README.md)
 
-## What It Does
+`nature-response` drafts, audits, and revises revision correspondence, including point-by-point reviewer responses, revision cover letters, red-marked manuscript excerpts, and editable LaTeX templates.
 
-- Drafts, audits, and revises point-by-point reviewer response letters, revision cover letters, red-marked manuscript plans, and LaTeX response templates.
+## What To Use It For
 
-## When to Use It
+- Parse editor decision letters, revision emails, and reviewer reports.
+- Split comments into stable IDs such as `E.1`, `R1.1`, and `R2.3`.
+- Build response strategy, manuscript-change actions, and evidence needs for each comment.
+- Draft formal, restrained, submission-ready English point-by-point responses and cover letters.
+- Audit rebuttal drafts for missed replies, defensive tone, unsupported claims, and missing line numbers.
 
-- You receive a major or minor revision decision.
-- You need to parse editor and reviewer comments into actionable response items.
-- You need a cover letter, reviewer-by-reviewer replies, redline guidance, or LaTeX template.
+## Typical Requests
 
-## Copy-Paste Prompts
+- "Here is the editor email and reviewer comments; generate a point-by-point response framework."
+- "Turn my Chinese revision notes into English reviewer responses."
+- "Check whether this rebuttal misses anything, sounds too strong, or lacks evidence."
 
-- `Use this revision email to draft point-by-point replies and a cover letter.`
-- `Revise this response letter so each reviewer comment is answered clearly and politely.`
-- `Create a LaTeX response template where each reviewer starts on a new page and quoted manuscript text is italicized.`
+## What You Need To Provide
 
-## Required Inputs
+- Editor decision letter, reviewer comments, revision requirements, or existing rebuttal draft.
+- Completed or planned experiments, analyses, figures, line numbers, and manuscript-change locations.
+- Target journal, manuscript ID, title, and required submission files.
 
-- Decision letter, reviewer comments, manuscript changes, response draft, and target journal constraints.
-- Optional original manuscript, revised manuscript, or change log.
+## Outputs
 
-## Expected Outputs
+- Response strategy summary.
+- Point-by-point response letter, revision cover letter, or LaTeX response package.
+- Manuscript-change checklist, missing-information checklist, and risk notes.
+- Optional red-marked manuscript excerpts; manuscript text must come from the author.
 
-- Point-by-point response letter.
-- Revision cover letter.
-- Redline/change-location plan for the manuscript.
-- LaTeX templates and formatting guidance when requested.
+## Boundaries
 
-## Dependencies / API Keys / Local Environment
-
-- LaTeX is optional and only needed for compiling templates.
-- Manuscript redlining may require document tooling depending on file format.
-
-## FAQ
-
-- **Should quoted revised manuscript text be formatted specially?** Yes. The current convention is to answer the comment, then paste revised manuscript text in italics.
-- **Should reviewer sections start on new pages?** Yes, when producing formal reviewer-response letters.
-- **Can it start from an email?** Yes. The workflow should parse the email and begin the response plan automatically.
+- The skill does not invent experiments, analyses, line numbers, figures, statistical results, or editor requirements.
+- Information that needs author confirmation is marked in Chinese rather than written as fact.
+- For pre-submission simulated review, use `nature-reviewer`.
 
 ## Related Skills
 
-- [`nature-reviewer`](../nature-reviewer/README_EN.md)
-- [`nature-polishing`](../nature-polishing/README_EN.md)
-- [`nature-writing`](../nature-writing/README_EN.md)
+- `nature-reviewer`: simulate reviewer comments before submission.
+- `nature-polishing`: polish reviewer-response and cover-letter English.
+- `nature-statistics`: handle statistical reviewer comments.
+- `nature-ref-verifier`: verify reference-error comments.

--- a/skills/nature-reviewer/README.md
+++ b/skills/nature-reviewer/README.md
@@ -2,92 +2,43 @@
 
 [English](README_EN.md)
 
-`nature-reviewer` 用于从审稿人视角模拟 `Nature` 风格的预投稿评审包，而不是从作者 rebuttal 视角写回复。
+`nature-reviewer` 用于从审稿人视角模拟 Nature 风格的预投稿评审，帮助作者在投稿前发现 novelty、significance、technical soundness 和读者价值上的风险。
 
-该技能专门基于 `Nature` 官方 `Editorial criteria and processes` 页面中的审稿相关内容创建：
+## 适合用它做什么
 
-```text
-https://www-nature-com/nature/for-authors/editorial-criteria-and-processes
-```
+- 对手稿、摘要、图表或结果故事线做投稿前压力测试。
+- 按 Nature 官方审稿维度评估 originality、scientific importance、interdisciplinary readership、technical soundness 和 readability。
+- 生成三份重点不同的 reviewer reports 和一份 cross-review synthesis。
+- 标记无支撑声称、技术缺陷、证据链断点和非专业读者理解障碍。
+- 判断哪些读者会关心这项工作，以及为什么。
 
-它的动机非常明确：
+## 典型请求
 
-- 提取该官方 `Nature` 来源中与审稿人相关的规则。
-- 让模拟审稿行为尽可能保持在这些规则范围内。
-- 避免滑向泛化的同行评审习惯或虚构审稿人设定。
-- 形成一个可复用的 `nature-reviewer` 技能，并尽量贴合仓库的技能格式。
+- “像 Nature reviewer 一样审这篇 introduction 和 Figure 1。”
+- “投稿前帮我找最可能被审稿人攻击的技术问题。”
+- “给我三份 reviewer reports 和一个综合判断，不要写 rebuttal。”
 
-因此，该技能刻意保持保守。它以 `references/editorial criteria and processes.md` 中的本地来源副本为依据，并转换成稳定输出约定：`3 reviewer reports + 1 cross-review synthesis`。三个报告只在关注重点上不同，因为来源支持审稿功能和报告内容，但不支持虚构具体审稿人身份或专业人设。
+## 你需要提供
 
-## 功能
+- 手稿全文、摘要、关键章节、图表、图注或作者说明。
+- 目标期刊、学科领域和你最担心的审稿风险。
+- 已有补充实验或不能新增实验的限制。
 
-- 将手稿草稿、摘要、选定章节、图表或作者说明作为审稿输入包读取。
-- 按来源约束的 `Nature` 风格维度评估工作：`originality`、`scientific importance`、`interdisciplinary readership`、`technical soundness` 和 `readability for nonspecialists`。
-- 当稿件有明确技术领域时，按需调用领域证据链 gate，覆盖化学、工程、材料、大气、气候生态、水文和遥感等常见稿件类型。
-- 生成 `3` 份 reviewer report；差异只体现在重点，不编造身份或专业背景。
-- 说明哪些读者会对结果感兴趣，以及原因。
-- 识别作者论证成立前必须解决的技术缺陷。
-- 综合三份报告的共识与重点差异。
-- 标记无支撑声称和无法从已提供证据判断的内容。
+## 产出
 
-## 适用场景
+- 三份 peer-review style reports。
+- Cross-review synthesis：共识问题、分歧重点和编辑层风险。
+- 必须补强的实验、分析、叙事或图表证据清单。
+- 对无证据判断的明确标记。
 
-- 投稿前模拟 `Nature` 审稿意见。
-- 压力测试手稿是否具有可信的 broad-interest 叙事。
-- 从审稿人视角评估 novelty、significance 或 technical soundness。
-- 生成预投稿同行评审式批评。
-- 判断手稿是否能被非本领域专家读懂。
-- 获得有边界的 peer-review style response，而不是作者回复信。
+## 边界
 
-如果用户要写逐点回复或返修信，请使用 `nature-response`。
+- 不会虚构具体审稿人身份、专业人设或编辑决定。
+- 只基于用户提供材料和技能内官方审稿规则做保守模拟。
+- 如果目标是写返修回复，优先使用 `nature-response`。
 
-## 默认返回内容
+## 相关技能
 
-除非用户要求其他格式，技能会返回：
-
-1. `Review setup`
-2. `Reviewer 1`
-3. `Reviewer 2`
-4. `Reviewer 3`
-5. `Cross-review synthesis`
-6. `Risk / unsupported claims`
-
-## 核心规则
-
-- 评估只能基于本地 reviewer 来源和用户提供的手稿事实。
-- 三位审稿人使用同一事实基础，只改变事实权重。
-- 不得编造审稿人身份、细分专业角色、机构或隐藏知识。
-- 领域 gate 只能用于强化技术证据链判断，不能把三份报告改写成虚构的“化学审稿人”“统计审稿人”等人设。
-- 必须明确回答 `who will be interested in the new results and why`。
-- 必须明确识别阻碍作者论证成立的 `technical failings`。
-- 区分技术有效性和 broad-interest 适配度；来源认为两者相关但并不等同。
-- 对无法判断的地方使用 `AUTHOR_INPUT_NEEDED`、`Not assessable from provided material` 或类似不确定性标签，不能补造细节。
-
-## 来源层级
-
-- `references/editorial criteria and processes.md` 是首要权威本地来源。
-- 用户提供的手稿事实和证据。
-- `references/source-basis.md` 中总结的保守本地实现规则。
-
-该技能不得静默扩展到泛化审稿人角色、虚构人设或期刊政策猜测。
-
-## 文件结构
-
-```text
-nature-reviewer/
-├── README.md
-├── SKILL.md
-└── references/
-    ├── editorial criteria and processes.md
-    ├── source-basis.md
-    ├── reviewer-workflow.md
-    ├── review-axes.md
-    ├── domain-specific-review-gates.md
-    ├── report-structure.md
-    ├── role-boundaries.md
-    └── qa-checklist.md
-```
-
-## 状态
-
-Draft。第一版由来源定义，并已结构化为有依据的审稿模拟，但尚未用真实匿名手稿-审稿示例库验证。
+- `nature-response`：把真实审稿意见转成回复包。
+- `nature-writing`：根据评审风险重建手稿叙事。
+- `nature-statistics`：深入审查统计设计和报告。

--- a/skills/nature-reviewer/README_EN.md
+++ b/skills/nature-reviewer/README_EN.md
@@ -2,45 +2,43 @@
 
 [中文说明](README.md)
 
-## What It Does
+`nature-reviewer` simulates Nature-style pre-submission review from the reviewer perspective, helping authors find risks in novelty, significance, technical soundness, and reader value before submission.
 
-- Simulates Nature-style peer review from the reviewer perspective and returns multiple reviewer reports plus a synthesis.
+## What To Use It For
 
-## When to Use It
+- Stress-test a manuscript, abstract, figure set, or result storyline before submission.
+- Evaluate originality, scientific importance, interdisciplinary readership, technical soundness, and readability using Nature-style review dimensions.
+- Generate three differently focused reviewer reports and one cross-review synthesis.
+- Mark unsupported claims, technical defects, evidence-chain breaks, and barriers for non-specialist readers.
+- Identify which readers would care about the work and why.
 
-- You want a pre-submission critique before journal submission.
-- You need novelty, significance, technical soundness, evidence, and presentation assessed from reviewer perspectives.
-- You want likely reviewer objections and revision priorities.
+## Typical Requests
 
-## Copy-Paste Prompts
+- "Review this introduction and Figure 1 like a Nature reviewer."
+- "Before submission, find the technical issues reviewers are most likely to attack."
+- "Give me three reviewer reports and one synthesis, not a rebuttal."
 
-- `Evaluate this manuscript from a Nature reviewer perspective and produce three reviewer reports.`
-- `Give me a pre-submission review focused on novelty, significance, and technical soundness.`
-- `Identify the strongest reasons this paper could be rejected and how to fix them.`
+## What You Need To Provide
 
-## Required Inputs
+- Manuscript, abstract, key sections, figures, legends, or author notes.
+- Target journal, field, and the review risks you are most worried about.
+- Existing supplementary experiments or constraints on adding new experiments.
 
-- Manuscript, abstract, figures, methods, results, or paper draft.
-- Optional target journal and field context.
+## Outputs
 
-## Expected Outputs
+- Three peer-review style reports.
+- Cross-review synthesis: consensus problems, divergent emphases, and editor-level risks.
+- List of experiments, analyses, narrative changes, or figure evidence that must be strengthened.
+- Explicit labels for judgments that cannot be made from the supplied evidence.
 
-- Three reviewer-style reports.
-- Synthesis of major risks and recommendation.
-- Prioritized revision checklist.
+## Boundaries
 
-## Dependencies / API Keys / Local Environment
-
-- No special runtime dependency for text-only review.
-- Literature comparison may require search access if novelty claims need verification.
-
-## FAQ
-
-- **Is this a rebuttal skill?** No. It critiques from the reviewer perspective. Use `nature-response` for rebuttal and revision replies.
-- **Can it replace real peer review?** No. It is a pre-submission stress test.
+- The skill does not invent specific reviewer identities, expert personas, or editorial decisions.
+- It makes conservative simulations only from the provided material and the skill's official review rules.
+- For writing responses to real reviewer comments, use `nature-response`.
 
 ## Related Skills
 
-- [`nature-response`](../nature-response/README_EN.md)
-- [`nature-writing`](../nature-writing/README_EN.md)
-- [`nature-polishing`](../nature-polishing/README_EN.md)
+- `nature-response`: turn real reviewer comments into a response package.
+- `nature-writing`: rebuild manuscript narrative based on review risks.
+- `nature-statistics`: deeply audit statistical design and reporting.

--- a/skills/nature-statistics/README.md
+++ b/skills/nature-statistics/README.md
@@ -2,69 +2,43 @@
 
 [English](README_EN.md)
 
-`nature-statistics` 用于审查、改写或起草 Nature / 高影响力期刊投稿中的统计报告文本。它关注的是论文中统计信息是否足够透明、可复核、与实验设计一致，而不是把所有统计问题简化成“p 值是否显著”。
+`nature-statistics` 用于审查、改写或起草 Nature / 高影响力期刊投稿中的统计报告文本，重点是透明、可复核、与实验设计一致，而不只是 p 值是否显著。
 
-该技能适合处理中文作者常见的投稿场景：作者可以用中文描述样本量、重复数、统计检验、图注或审稿意见；技能会把这些信息整理成保守的英文 Statistical analysis、Results 统计表述或图注统计说明，并标记仍需作者确认的事实。
+## 适合用它做什么
 
-## 功能
+- 检查 Statistical analysis / Methods 中统计方法是否完整。
+- 改写 Results、figure legends 和 source data 中的统计说明。
+- 区分 biological replicates、technical replicates、重复测量、视野/细胞/子样本和独立实验单位。
+- 识别伪重复、嵌套数据、多重比较、交互解释、相关性过度解释和显著性滥用。
+- 根据审稿人统计意见生成保守回应或修改建议。
 
-- 审查 Statistical analysis / Methods 中的统计报告是否完整。
-- 检查 Results 里 p 值、置信区间、效应量、样本量和检验名称是否表述清楚。
-- 区分 biological replicates、technical replicates、重复测量、细胞/视野/子样本和独立实验单位。
-- 识别伪重复、嵌套数据、未校正多重比较、错误的交互解释、过度依赖显著性、相关性过度解释等常见问题。
-- 改写图注中的统计说明，包括 error bars、box plots、violin plots、stars、exact p values、source data 和 n 定义。
-- 根据审稿人统计意见，生成逐点修改建议或可粘贴的保守回应文本。
-- 在信息缺失时输出 `AUTHOR_INPUT_NEEDED`，不替作者编造统计细节。
+## 典型请求
 
-## 适用场景
+- “帮我检查这段 Statistical analysis 是否符合 Nature 风格。”
+- “图注里的 error bars、n 和 p 值怎么写更清楚？”
+- “审稿人说统计不充分，帮我列修改方案和回复草稿。”
 
-- 投稿前检查 Statistical analysis 小节。
-- 审稿人指出 “statistical analysis is unclear / insufficient”。
-- 图中星号、误差线、n 数和检验方法需要统一说明。
-- 需要把中文统计描述改成英文稿件可用文本。
-- 需要判断某个结果是否存在伪重复、多重比较或模型假设问题。
-- 需要让 Results 中的统计语言更克制，避免把显著性写成机制或因果。
+## 你需要提供
 
-## 默认返回内容
+- 样本量、重复层级、实验单位、分组、检验方法和多重比较方式。
+- 图表、图注、Results 文本、统计输出或审稿意见。
+- 哪些事实已确认，哪些需要保守标注。
 
-常规审查会返回：
+## 产出
 
-1. `Statistics review scope`
-2. `Major statistical issues`
-3. `Ready-to-paste revision`
-4. `AUTHOR_INPUT_NEEDED`
-5. `Reviewer-risk note`
+- 统计报告审查：主要问题、风险等级和需要作者确认的信息。
+- 可粘贴的 Statistical analysis、Results 或 figure legend 改写。
+- 审稿统计问题的逐点回应草稿。
+- `AUTHOR_INPUT_NEEDED` 清单，用于标记缺失样本量、检验或设计事实。
 
-如果用户只是要求起草统计方法，技能会返回更短的：
+## 边界
 
-1. `Draft Statistical analysis`
-2. `Reporting notes`
+- 不会替作者编造样本量、重复数、p 值、效应量、模型假设或检验名称。
+- 不直接替代统计师或完整再分析；如需重新建模，应要求原始数据和分析代码。
+- 不能仅凭图像判断实验单位和独立重复，需要作者确认设计。
 
-## 核心规则
+## 相关技能
 
-- 先确认实验设计和独立分析单位，再讨论统计检验。
-- 不把细胞、图像、技术重复、重复读数或模拟次数默认当作独立样本。
-- 优先报告效应量、置信区间、样本量、检验方法和校正策略，而不是只报告星号。
-- 不编造 p 值、自由度、样本量、软件版本、排除标准、随机化、盲法或 power analysis。
-- 当材料不足时，给出保守文本和短问题清单，而不是替作者补事实。
-- 统计结果不能自动证明机制、因果或生物学重要性。
-
-## 文件结构
-
-```text
-nature-statistics/
-├── README.md
-├── README_EN.md
-├── SKILL.md
-├── manifest.yaml
-└── references/
-    ├── source-basis.md
-    ├── statistical-reporting.md
-    ├── common-failure-modes.md
-    ├── figure-statistics.md
-    └── reviewer-checklist.md
-```
-
-## 状态
-
-Draft。第一版聚焦统计报告与审稿风险检查，尚未用真实匿名稿件库做系统回归测试。
+- `nature-figure`：把统计信息落实到图件和 source data。
+- `nature-response`：回应统计类审稿意见。
+- `nature-polishing`：润色统计描述的英文表达。

--- a/skills/nature-statistics/README_EN.md
+++ b/skills/nature-statistics/README_EN.md
@@ -2,89 +2,43 @@
 
 [中文说明](README.md)
 
-## What It Does
+`nature-statistics` audits, rewrites, or drafts statistical reporting for Nature / high-impact journal submissions, focusing on transparency, reproducibility, and alignment with study design rather than only whether p values are significant.
 
-`nature-statistics` audits, revises, or drafts statistical reporting for Nature
-and other high-impact journal manuscripts. It focuses on whether statistical
-information is transparent, checkable, and aligned with the study design, rather
-than reducing statistical quality to whether a p value is significant.
+## What To Use It For
 
-## When to Use It
+- Check whether the Statistical analysis / Methods section is complete.
+- Rewrite statistical statements in Results, figure legends, and source-data notes.
+- Distinguish biological replicates, technical replicates, repeated measures, fields/cells/subsamples, and independent experimental units.
+- Identify pseudoreplication, nested data, multiple comparisons, interaction interpretation, overinterpreted correlations, and significance abuse.
+- Draft conservative responses or revision suggestions for reviewer statistics comments.
 
-- Before submission, to check a Statistical analysis / Methods section.
-- When reviewers say the statistical analysis is unclear or insufficient.
-- When figure legends need consistent reporting of error bars, n definitions,
-  statistical tests, exact p values, and source-data notes.
-- When Chinese author notes need to be converted into conservative English
-  statistical reporting.
-- When a result may involve pseudoreplication, multiple comparisons, nested
-  data, repeated measures, or overinterpretation of significance.
+## Typical Requests
 
-## Copy-Paste Prompts
+- "Check whether this Statistical analysis paragraph is Nature-style."
+- "How should I write the error bars, n, and p values in this figure legend?"
+- "The reviewer says the statistics are insufficient; list revision options and draft a response."
 
-```text
-Use nature-statistics to audit this Statistical analysis section and list missing information before submission.
-```
+## What You Need To Provide
 
-```text
-Rewrite these figure-legend statistics in conservative Nature-style English, and mark anything that still needs author confirmation.
-```
+- Sample size, replicate level, experimental unit, groups, statistical tests, and multiple-comparison method.
+- Figures, legends, Results text, statistical output, or reviewer comments.
+- Which facts are confirmed and which need conservative marking.
 
-```text
-Use nature-statistics to answer this reviewer comment about unclear statistical analysis.
-```
+## Outputs
 
-## Required Inputs
+- Statistical reporting review with major issues, risk level, and facts needing author confirmation.
+- Ready-to-paste Statistical analysis, Results, or figure-legend rewrite.
+- Point-by-point response draft for statistical reviewer comments.
+- `AUTHOR_INPUT_NEEDED` checklist for missing sample size, test, or design facts.
 
-- The Statistical analysis / Methods text, Results text, figure legends, or
-  reviewer comments to check.
-- Sample size, replicate type, independent analysis unit, statistical tests,
-  p-value handling, and software information when available.
-- Any known design details such as paired data, repeated measures, nesting,
-  randomization, blinding, or exclusion rules.
+## Boundaries
 
-## Expected Outputs
-
-- `Statistics review scope`
-- `Major statistical issues`
-- `Ready-to-paste revision`
-- `AUTHOR_INPUT_NEEDED`
-- `Reviewer-risk note`
-
-For drafting-only requests, the skill can return a shorter `Draft Statistical
-analysis` plus `Reporting notes`.
-
-## Manifest / On-Demand References
-
-`manifest.yaml` keeps the core statistics workflow lightweight:
-
-- `source-basis.md` and `statistical-reporting.md` are always loaded.
-- `common-failure-modes.md`, `figure-statistics.md`, and
-  `reviewer-checklist.md` are loaded only when nested data, figure legends,
-  reviewer response, or final audit QA requires them.
-
-## Dependencies / API Keys / Local Environment
-
-No external API key is required by default. Statistical software names, package
-versions, exact p values, sample sizes, exclusion rules, and power-analysis
-details must come from the author or project materials.
-
-## FAQ
-
-**Can this skill invent missing p values or sample sizes?**  
-No. Missing facts are marked as `AUTHOR_INPUT_NEEDED`.
-
-**Does it perform statistical tests from raw data?**  
-It is primarily a reporting and review skill. If raw-data analysis is required,
-provide the data and requested analysis separately.
-
-**Does significance prove mechanism or causality?**  
-No. The skill keeps statistical language conservative and separates statistical
-evidence from mechanism, causality, and biological importance.
+- The skill does not invent sample sizes, replicate counts, p values, effect sizes, model assumptions, or test names.
+- It does not replace a statistician or a full reanalysis; raw-data modeling requires the original data and analysis code.
+- Experimental units and independent replicates cannot be inferred from figures alone and need author confirmation.
 
 ## Related Skills
 
-- [`nature-figure`](../nature-figure/README_EN.md)
-- [`nature-response`](../nature-response/README_EN.md)
-- [`nature-reviewer`](../nature-reviewer/README_EN.md)
-- [`nature-writing`](../nature-writing/README_EN.md)
+- `nature-figure`: put statistical information into figures and source data.
+- `nature-response`: respond to statistical reviewer comments.
+- `nature-polishing`: polish the English wording of statistical descriptions.

--- a/skills/nature-writing/README.md
+++ b/skills/nature-writing/README.md
@@ -4,61 +4,40 @@
 
 `nature-writing` 用于根据作者提供的 claims、图表、结果、笔记或中文草稿，起草或重建 Nature 风格手稿章节。
 
-## 功能
+## 适合用它做什么
 
-`nature-writing` 可帮助撰写：
+- 构建标题、摘要、引言、结果叙事、讨论、结论或 significance paragraph。
+- 根据图表和数据组织 claim-evidence 叙事。
+- 将中文研究笔记转成英文手稿段落。
+- 为 Introduction 建立背景、缺口、问题和贡献链。
+- 对 Results 或 Discussion 做章节级重排，而不是只做句子润色。
 
-- 标题
-- 摘要
-- 引言
-- 结果叙事
-- 讨论
-- 结论
-- significance paragraph
-- 手稿大纲
+## 典型请求
 
-该技能用于论证构建和章节起草。如果已有英文草稿只需要句子级润色，应使用 `nature-polishing`。
+- “根据这些图和结果写一个 Nature 风格 abstract。”
+- “帮我重建 introduction 的逻辑，不要只润色句子。”
+- “把这些中文结果整理成英文 Results 叙事。”
 
-## 来源基础
+## 你需要提供
 
-该技能来自对材料、能源系统、建筑脱碳和机器学习等领域 Nature 与 Nature Communications 研究论文的细读，并结合仓库中已有的 writing-strategy 规则。
+- 核心 claim、图表、关键结果、实验事实和目标读者。
+- 目标章节、长度、语言和需要保留的术语。
+- 已确认引用、限制条件和不能新增的结论。
 
-章节级写作和面向审稿人的自审规则也参考了彭思达老师公开的科研写作笔记：
+## 产出
 
-- https://pengsida.notion.site/c1a22465a0fa4b15a12985223916048e
-- https://github.com/pengsida/learning_research
+- 章节大纲、claim-evidence map 或可粘贴正文。
+- 对 novelty、significance、证据链和读者路径的修改建议。
+- 需要作者确认的事实、引用或图表说明。
 
-## 文件结构
+## 边界
 
-```text
-nature-writing/
-├── README.md
-├── SKILL.md
-└── references/
-    ├── abstract.md
-    ├── article-architecture.md
-    ├── chinese-author-workflow.md
-    ├── conclusion.md
-    ├── experiments.md
-    ├── introduction.md
-    ├── method.md
-    ├── nature-summary-paragraph.md
-    ├── paper-review.md
-    ├── paragraph-flow.md
-    ├── related-work.md
-    └── examples/
-```
+- 不会替作者虚构实验结果、统计意义、机制解释或参考文献。
+- 如果已有英文草稿只需要句子级润色，优先使用 `nature-polishing`。
+- 如果需要先找文献支撑 claim，优先使用 `nature-citation` 或 `nature-academic-search`。
 
-## 核心规则
+## 相关技能
 
-| 领域 | 规则 |
-|---|---|
-| 证据优先 | 不编造数据、机制、统计量、样本量或创新性 |
-| 摘要 | 背景、缺口、方法、关键结果、意义、边界 |
-| 引言 | 领域尺度、瓶颈、已有尝试、未解决缺口、本文工作；面向 `Nature` 时使用分阶段 summary-paragraph funnel |
-| 方法 | 解释模块动机、设计、正向流程和技术优势 |
-| 结果 | 构建证据阶梯，而不是按实验流水账写作 |
-| 实验 | 每个主要 claim 都要对应比较、消融、指标或压力测试证据 |
-| 讨论 | 解释意义、与既有工作的关系、约束和未来使用 |
-| 自审 | 投稿前做 adversarial self-review |
-| 中文笔记 | 翻译意图和论证，不照搬中文句序 |
+- `nature-polishing`：英文润色、翻译和风格收束。
+- `nature-citation`：为 claim 匹配支撑文献。
+- `nature-figure`：把图件结论和面板设计对齐到正文叙事。

--- a/skills/nature-writing/README_EN.md
+++ b/skills/nature-writing/README_EN.md
@@ -2,44 +2,42 @@
 
 [中文说明](README.md)
 
-## What It Does
+`nature-writing` drafts or rebuilds Nature-style manuscript sections from author-provided claims, figures, results, notes, or Chinese drafts.
 
-- Drafts, restructures, or plans Nature-style manuscript sections from claims, results, figures, notes, or Chinese drafts.
+## What To Use It For
 
-## When to Use It
+- Build titles, abstracts, introductions, result narratives, discussions, conclusions, or significance paragraphs.
+- Organize claim-evidence narrative from figures and data.
+- Turn Chinese research notes into English manuscript paragraphs.
+- Build the background, gap, question, and contribution chain for an Introduction.
+- Reorder Results or Discussion at the section level rather than only polishing sentences.
 
-- You need to write an abstract, introduction, related work, methods, experiments, discussion, conclusion, or title.
-- You need to rebuild the argument rather than only polish finished prose.
-- You have results and figures but need a coherent manuscript narrative.
+## Typical Requests
 
-## Copy-Paste Prompts
+- "Write a Nature-style abstract from these figures and results."
+- "Rebuild the logic of this introduction; do not only polish the sentences."
+- "Turn these Chinese results into an English Results narrative."
 
-- `Using these results and figures, draft a Nature-style abstract and introduction.`
-- `Rebuild the argument of this introduction around the main scientific gap.`
-- `Write a discussion section that links these findings to mechanism, limitation, and implication.`
+## What You Need To Provide
 
-## Required Inputs
+- Core claim, figures, key results, experimental facts, and target reader.
+- Target section, length, language, and terminology that must be preserved.
+- Confirmed references, limitations, and conclusions that must not be added.
 
-- Claims, results, figure summaries, methods, draft paragraphs, target journal, and audience.
-- Evidence constraints and terminology that must be preserved.
+## Outputs
 
-## Expected Outputs
+- Section outline, claim-evidence map, or ready-to-paste prose.
+- Revision suggestions for novelty, significance, evidence chain, and reader path.
+- Facts, references, or figure notes requiring author confirmation.
 
-- Draft manuscript sections.
-- Argument outline and section plan.
-- Revision suggestions for evidence flow and narrative logic.
+## Boundaries
 
-## Dependencies / API Keys / Local Environment
-
-- No special runtime dependency for text-only drafting.
-
-## FAQ
-
-- **How is this different from polishing?** `nature-writing` builds or restructures the argument; `nature-polishing` improves already drafted prose.
-- **Can it write from vague ideas?** It can outline questions and missing evidence, but strong drafting needs concrete claims and results.
+- The skill does not invent experimental results, statistical significance, mechanism explanations, or references.
+- If an English draft only needs sentence-level polishing, use `nature-polishing`.
+- If claim support requires literature search first, use `nature-citation` or `nature-academic-search`.
 
 ## Related Skills
 
-- [`nature-polishing`](../nature-polishing/README_EN.md)
-- [`nature-reviewer`](../nature-reviewer/README_EN.md)
-- [`nature-citation`](../nature-citation/README_EN.md)
+- `nature-polishing`: English polishing, translation, and style tightening.
+- `nature-citation`: match supporting references for claims.
+- `nature-figure`: align figure conclusions and panel design with manuscript narrative.


### PR DESCRIPTION
## Summary
- rewrite Chinese skill README files as concise user-facing entry pages
- align all English README files as one-to-one mirrors of the Chinese structure and content
- remove stale Hermes/research-pipeline wording and overlong internal implementation detail

## Validation
- git diff --check
- bash -n scripts/update-codex-skills.sh
- verified 17 README/README_EN pairs have matching line counts and heading counts
- verified bilingual links and stale-term scan