### PR TITLE
fix: bust stale Star History image cache

### DIFF
--- a/.github/workflows/update-star-history.yml
+++ b/.github/workflows/update-star-history.yml
@@ -22,16 +22,18 @@ jobs:
         run: |
           python3 scripts/generate-star-history.py \
             --repo "$GITHUB_REPOSITORY" \
-            --output assets/star-history.svg
+            --output assets/star-history.svg \
+            --cache-bust-readme README.md \
+            --cache-bust-readme README_EN.md
 
       - name: Commit updated chart
         run: |
-          if git diff --quiet -- assets/star-history.svg; then
+          if git diff --quiet -- assets/star-history.svg README.md README_EN.md; then
             echo "Star history is already up to date."
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add assets/star-history.svg
+          git add assets/star-history.svg README.md README_EN.md
           git commit -m "chore: update star history"
           git push

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ OpenClaw、OpenCode、Hermes 的具体接入方式见 [OpenClaw / OpenCode / Her
 
 ## Star 历史
 
-[![Star History Chart](assets/star-history.svg)](https://star-history.com/#Yuan1z0825/nature-skills&Date)
+[![Star History Chart](assets/star-history.svg?v=20260715T1629Z)](https://star-history.com/#Yuan1z0825/nature-skills&Date)
 
 ## 技能索引
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -378,7 +378,7 @@ For manual or other-agent use:
 
 ## Star History
 
-[![Star History Chart](assets/star-history.svg)](https://star-history.com/#Yuan1z0825/nature-skills&Date)
+[![Star History Chart](assets/star-history.svg?v=20260715T1629Z)](https://star-history.com/#Yuan1z0825/nature-skills&Date)
 
 ## Skill Index
 

--- a/scripts/generate-star-history.py
+++ b/scripts/generate-star-history.py
@@ -12,6 +12,7 @@ import json
 import math
 import os
 import pathlib
+import re
 import subprocess
 import sys
 import time
@@ -33,6 +34,16 @@ def parse_args() -> argparse.Namespace:
         "--output",
         default="assets/star-history.svg",
         help="Output SVG path.",
+    )
+    parser.add_argument(
+        "--cache-bust-readme",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help=(
+            "Update the output image reference in this Markdown file with a generated "
+            "version query. Repeat for multiple README files."
+        ),
     )
     parser.add_argument(
         "--token",
@@ -205,7 +216,11 @@ def month_ticks(start: dt.date, end: dt.date, limit: int = 8) -> list[dt.date]:
     return ticks
 
 
-def generate_svg(repo: str, points: list[tuple[dt.date, int]]) -> str:
+def generate_svg(
+    repo: str,
+    points: list[tuple[dt.date, int]],
+    generated_at: dt.datetime | None = None,
+) -> str:
     start = points[0][0]
     end = points[-1][0]
     total = points[-1][1]
@@ -249,7 +264,8 @@ def generate_svg(repo: str, points: list[tuple[dt.date, int]]) -> str:
         grid.append(f'<line x1="{x:.1f}" y1="{top}" x2="{x:.1f}" y2="{top + plot_height}" stroke="#f3f4f6" stroke-width="1"/>')
         grid.append(f'<text x="{x:.1f}" y="{height - 38}" text-anchor="middle" font-size="12" fill="#6b7280">{html.escape(label)}</text>')
 
-    updated = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    generated_at = generated_at or dt.datetime.now(dt.timezone.utc)
+    updated = generated_at.strftime("%Y-%m-%d %H:%M UTC")
     escaped_repo = html.escape(repo, quote=True)
     total_text = f"{total:,}"
     font = "Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif"
@@ -274,6 +290,18 @@ def generate_svg(repo: str, points: list[tuple[dt.date, int]]) -> str:
 '''
 
 
+def update_readme_cache_buster(path: pathlib.Path, output_ref: str, token: str) -> None:
+    """Version a Markdown image URL so GitHub does not reuse a stale render."""
+    original = path.read_text(encoding="utf-8")
+    pattern = re.compile(rf"{re.escape(output_ref)}(?:\?v=[A-Za-z0-9._-]+)?")
+    updated, replacements = pattern.subn(f"{output_ref}?v={token}", original)
+    if replacements == 0:
+        raise RuntimeError(f"Could not find {output_ref!r} in {path}")
+    if updated != original:
+        path.write_text(updated, encoding="utf-8")
+    print(f"Updated cache-busting reference in {path} ({replacements} occurrence(s))")
+
+
 def main() -> int:
     args = parse_args()
     if "/" not in args.repo:
@@ -283,7 +311,12 @@ def main() -> int:
     points = build_daily_points(items)
     output = pathlib.Path(args.output)
     output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(generate_svg(args.repo, points), encoding="utf-8")
+    generated_at = dt.datetime.now(dt.timezone.utc)
+    output.write_text(generate_svg(args.repo, points, generated_at), encoding="utf-8")
+    cache_token = generated_at.strftime("%Y%m%dT%H%M%SZ")
+    output_ref = pathlib.PurePosixPath(args.output).as_posix()
+    for readme in args.cache_bust_readme:
+        update_readme_cache_buster(pathlib.Path(readme), output_ref, cache_token)
     print(f"Wrote {output} with {points[-1][1]:,} stars and {len(points):,} daily points")
     return 0
 


### PR DESCRIPTION
## Problem

PR #122 updated `assets/star-history.svg` from 28,085 to 28,894 stars, but the README continued to render the old 28,085-star image for some viewers because the relative image URL did not change.

## Fix

- add a version query to the Star History image in both READMEs, forcing a new rendered image URL
- add `--cache-bust-readme` to the generator so future scheduled updates refresh that version automatically
- update the workflow to track and commit the two README cache tokens with the SVG
- use one generation timestamp for both SVG metadata and cache-token generation

## Validation

- cache-buster replacement test passes for an existing versioned URL
- Python compilation passes
- GitHub Markdown API preserves the version query in the rendered image URL
- workflow YAML parses successfully
- current SVG passes XML validation
- `git diff --check` passes