### PR TITLE
feat: Claude Code 会话启动自动更新技能 + 统一安装小节标题

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@
 
 `nature-skills` 是一组围绕 `SKILL.md` 组织的可复用技能包。`skills/` 下的每个顶层技能目录都是一个可安装单元，例如 `nature-*`；`nature-shared` 是供其他技能读取的共享支持包。
 
-### 使用 npx skills 安装和更新
+### npx skills 安装方式
 
 需要先安装 [Node.js 18 或更高版本](https://nodejs.org/)。无需全局安装 CLI；先查看仓库中可安装的技能名：
 
@@ -204,7 +204,58 @@ git pull
 
 只要 wrapper 仍然指向这个稳定 clone 路径，就不需要重复复制技能文件。
 
-### Codex 推荐安装方式
+### Claude Code 自动更新（可选）
+
+如果你希望 Claude Code 每次开启会话时自动拉取上游更新，可以用 `scripts/autoupdate-skills.sh` 配合一个 `SessionStart` 钩子。
+
+这套方式把技能**直接复制**进 `~/.claude/skills/`（Claude Code 会自动发现该目录，技能以目录名直接加载），而不是使用上面的 wrapper。两种方式二选一即可。
+
+先保留一个**专用**的稳定 clone（只用于同步技能，请不要在里面做开发提交）：
+
+```bash
+mkdir -p ~/ai-skills
+git clone https://github.com/Yuan1z0825/nature-skills.git ~/ai-skills/nature-skills
+```
+
+首次安装，把技能复制进 Claude Code 的技能目录：
+
+```bash
+~/ai-skills/nature-skills/scripts/autoupdate-skills.sh --force
+```
+
+然后在 `~/.claude/settings.json` 里加一个 `SessionStart` 钩子（若已有 `hooks`，把这一项合并进去，不要整体覆盖）：
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/ai-skills/nature-skills/scripts/autoupdate-skills.sh",
+            "async": true,
+            "timeout": 120
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+`async: true` 让它在后台运行、不阻塞启动。脚本自带保护：默认 6 小时内不重复联网检查、断网或拉取失败自动跳过（`exit 0`，绝不卡住会话）、只有上游 HEAD 真正变化时才重新同步、并且拒绝在有未提交改动的 clone 上强行前进。拉到的新版会在**下一次**开启会话时生效（当前会话的技能已经加载完毕）。运行日志在 `~/.local/state/nature-skills/autoupdate.log`。
+
+目标目录与检查频率都可配置，因此 Codex 用户也可以把它加进 shell profile 或 cron：
+
+```bash
+# 默认同步到 ~/.claude/skills；用 --dest 指到别处，例如 Codex：
+~/ai-skills/nature-skills/scripts/autoupdate-skills.sh --dest ~/.codex/skills
+# 只在最多每小时检查一次：
+~/ai-skills/nature-skills/scripts/autoupdate-skills.sh --throttle 3600
+```
+
+### Codex 安装方式
 
 推荐使用仓库自带脚本安装或更新 Codex skills。脚本会同步 `skills/` 下所有顶层技能目录，并在复制后做 `diff` 验证；它不会覆盖其他无关 Codex skills。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -125,7 +125,7 @@ know the skill name, explicitly say "use `nature-reader`" or "use
 such as `nature-*`; `nature-shared` is an installable support package read by
 other skills.
 
-### Install and update with npx skills
+### npx skills Installation
 
 Install [Node.js 18 or later](https://nodejs.org/) first. The CLI does not need
 to be installed globally. List the skill names available in this repository:
@@ -257,7 +257,70 @@ git pull
 As long as the wrapper still points to this stable clone path, no repeated file
 copy is needed.
 
-### Recommended Codex Installation
+### Claude Code Auto-Update (Optional)
+
+If you want Claude Code to pull upstream updates automatically on every session
+start, use `scripts/autoupdate-skills.sh` together with a `SessionStart` hook.
+
+This approach **copies** the skills straight into `~/.claude/skills/` (Claude Code
+auto-discovers that directory and loads each skill by its directory name) instead
+of using the wrappers above. Pick whichever one you prefer.
+
+Keep a **dedicated** stable clone (used only to sync skills — don't make dev
+commits inside it):
+
+```bash
+mkdir -p ~/ai-skills
+git clone https://github.com/Yuan1z0825/nature-skills.git ~/ai-skills/nature-skills
+```
+
+Install once, copying the skills into Claude Code's skills directory:
+
+```bash
+~/ai-skills/nature-skills/scripts/autoupdate-skills.sh --force
+```
+
+Then add a `SessionStart` hook to `~/.claude/settings.json` (merge this entry into
+an existing `hooks` block rather than replacing it):
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/ai-skills/nature-skills/scripts/autoupdate-skills.sh",
+            "async": true,
+            "timeout": 120
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+`async: true` runs it in the background so it never blocks startup. The script is
+safe to run constantly: it skips the network if it already checked within the last
+6 hours, silently skips when offline or the pull fails (`exit 0`, never stalling a
+session), re-syncs only when the upstream HEAD actually changed, and refuses to
+fast-forward a clone that has uncommitted changes. New skills take effect on the
+**next** session (the current one already loaded its skills). Logs go to
+`~/.local/state/nature-skills/autoupdate.log`.
+
+The destination and check interval are both configurable, so Codex users can add
+it to a shell profile or cron as well:
+
+```bash
+# Defaults to ~/.claude/skills; use --dest for another location, e.g. Codex:
+~/ai-skills/nature-skills/scripts/autoupdate-skills.sh --dest ~/.codex/skills
+# Check at most once per hour:
+~/ai-skills/nature-skills/scripts/autoupdate-skills.sh --throttle 3600
+```
+
+### Codex Installation
 
 Use the repository script to install or update Codex skills. It syncs every
 top-level skill directory under `skills/` and verifies the copied contents with

--- a/scripts/autoupdate-skills.sh
+++ b/scripts/autoupdate-skills.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# autoupdate-skills.sh — keep an installed copy of the skills in sync with
+# upstream, cheaply enough to run on every agent/editor session start.
+#
+# This script lives inside a dedicated clone of this repository. On each run it
+# fast-forwards the clone to its upstream and, ONLY when upstream actually moved,
+# re-syncs the skills into your agent's skills directory via update-codex-skills.sh.
+#
+# Typical use is a Claude Code SessionStart hook (see the README), but it works
+# anywhere you can run a command at startup (a shell profile, cron, etc.).
+#
+# It is safe to run constantly:
+#   - Throttled: skips the network entirely if it checked within THROTTLE seconds.
+#   - Offline-tolerant: a stalled/failed fetch is ignored and the run exits 0, so
+#     it never blocks or errors a session start (handy on flaky or blocked links).
+#   - Non-destructive: it only ever fast-forwards this clone. It refuses to run if
+#     the clone has local commits or a dirty tree, so a working dev checkout is
+#     never rewritten — keep this on a dedicated skills-only clone.
+#   - Cheap: it re-syncs skills only when the upstream HEAD changed.
+#
+# Usage:
+#   scripts/autoupdate-skills.sh                      # sync into ~/.claude/skills
+#   scripts/autoupdate-skills.sh --dest ~/.codex/skills
+#   scripts/autoupdate-skills.sh --throttle 3600      # check at most hourly
+#   scripts/autoupdate-skills.sh --force              # ignore throttle, always sync
+#
+# Environment (flags take precedence):
+#   SKILLS_DEST=/path      Destination skills dir  (default ~/.claude/skills)
+#   SKILLS_THROTTLE=SECS   Min seconds between upstream checks (default 21600 = 6h; 0 = always)
+#
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+DEST="${SKILLS_DEST:-$HOME/.claude/skills}"
+THROTTLE="${SKILLS_THROTTLE:-21600}"
+FORCE=0
+
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/nature-skills"
+STAMP="$STATE_DIR/last-check"
+LOG="$STATE_DIR/autoupdate.log"
+
+usage() { sed -n '2,32p' "$0"; }
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dest) DEST="${2:?--dest needs a path}"; shift 2 ;;
+    --dest=*) DEST="${1#*=}"; shift ;;
+    --throttle) THROTTLE="${2:?--throttle needs seconds}"; shift 2 ;;
+    --throttle=*) THROTTLE="${1#*=}"; shift ;;
+    --force) FORCE=1; THROTTLE=0; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "autoupdate-skills.sh: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+mkdir -p "$STATE_DIR" 2>/dev/null || true
+log() { printf '%s %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$*" >>"$LOG" 2>/dev/null; }
+
+# --- throttle: skip the network if we checked recently --------------------
+now=$(date +%s)
+if [ "$THROTTLE" -gt 0 ] && [ -f "$STAMP" ]; then
+  last=$(cat "$STAMP" 2>/dev/null || echo 0)
+  case "$last" in ''|*[!0-9]*) last=0 ;; esac
+  if [ $(( now - last )) -lt "$THROTTLE" ]; then
+    exit 0
+  fi
+fi
+
+command -v git >/dev/null 2>&1 || { log "git not found — skip"; exit 0; }
+
+# Refuse to touch a dev checkout: don't fast-forward over uncommitted work.
+# Only TRACKED changes block us — untracked files (e.g. macOS .DS_Store) are
+# ignored so a normal clone doesn't silently stop updating. Local commits ahead
+# of upstream are handled safely by the --ff-only pull below (it just fails).
+if ! git -C "$REPO_ROOT" diff --quiet 2>/dev/null \
+   || ! git -C "$REPO_ROOT" diff --cached --quiet 2>/dev/null; then
+  log "clone has uncommitted changes to tracked files — skip"
+  exit 0
+fi
+
+# Portable timeout (macOS ships no `timeout`); git also self-aborts stalled fetches.
+run_guarded() {
+  local secs="$1"; shift
+  "$@" &
+  local pid=$!
+  ( sleep "$secs"; kill -TERM "$pid" 2>/dev/null; sleep 3; kill -KILL "$pid" 2>/dev/null ) &
+  local watch=$!
+  wait "$pid" 2>/dev/null; local rc=$?
+  kill "$watch" 2>/dev/null; wait "$watch" 2>/dev/null
+  return "$rc"
+}
+git_slow="git -c http.lowSpeedLimit=1024 -c http.lowSpeedTime=20 -C $REPO_ROOT"
+
+before=$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo none)
+
+# Fast-forward the clone. A failure here (offline, blocked, diverged) is non-fatal.
+if ! run_guarded 60 $git_slow pull --ff-only >>"$LOG" 2>&1; then
+  log "pull failed — skip (offline, blocked, or diverged clone)"
+  exit 0
+fi
+echo "$now" >"$STAMP"
+
+after=$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo none)
+if [ "$before" = "$after" ] && [ "$FORCE" != "1" ]; then
+  log "up to date ($after)"
+  exit 0
+fi
+
+log "upstream ${before} -> ${after}; syncing skills into $DEST"
+installer="$REPO_ROOT/scripts/update-codex-skills.sh"
+if [ -x "$installer" ]; then
+  if "$installer" --dest "$DEST" --prune >>"$LOG" 2>&1; then
+    log "sync OK -> $after"
+  else
+    log "sync FAILED"
+  fi
+else
+  log "update-codex-skills.sh missing or not executable — skip sync"
+fi
+exit 0


### PR DESCRIPTION
## 这个 PR 做了什么

1. 新增 `scripts/autoupdate-skills.sh` —— 让 Claude Code 每次开启会话时自动把技能同步到上游最新。
2. 在 `README.md` / `README_EN.md` 补上对应文档（新小节「Claude Code 自动更新（可选）」/「Claude Code Auto-Update (Optional)」）。
3. 顺手统一了三个安装小节的标题命名。之前 `使用 npx skills 安装和更新` / `Claude Code 安装方式` / `Codex 推荐安装方式` 风格不一致，现统一为「X 安装方式」（英文同理统一为「X Installation」）。

## `autoupdate-skills.sh` 设计

脚本放在一个**专用**的稳定 clone 里，配合一个 `SessionStart` 钩子运行。每次触发时：

- **限流**：默认 6 小时内不重复联网检查（`--throttle` / `SKILLS_THROTTLE` 可调，`0` = 每次都查）。
- **只在有更新时同步**：`git pull --ff-only` 后比较 HEAD，只有上游 HEAD 真正变化，才调用 `update-codex-skills.sh --dest … --prune` 重新同步。
- **断网安全**：git 低速自动中断 + 一个可移植的看门狗（macOS 没有 `timeout`）；拉取失败直接跳过，始终 `exit 0`，绝不阻塞或报错会话启动。
- **不碰开发仓库**：只在「没有未提交的已跟踪改动」的 clone 上前进；**未跟踪**文件（比如 macOS 的 `.DS_Store`）会被忽略，不会让自更新永久停摆。
- **可配置**：目标目录 `--dest`、频率 `--throttle`，因此 Codex 用户也能用（shell profile / cron）。

配套 hook（README 中同样给出）：

```json
{ "hooks": { "SessionStart": [ { "hooks": [
  { "type": "command",
    "command": "$HOME/ai-skills/nature-skills/scripts/autoupdate-skills.sh",
    "async": true, "timeout": 120 }
] } ] } }
```

新版技能会在**下一次**开启会话时生效（当前会话的技能已加载完毕）。

## 测试

- **up-to-date**（无 `--force`）：不同步，目标目录保持不变。
- **`--force`**：18 个技能（含 `nature-shared`）全部同步到目标目录。
- **限流**：6h 内重复运行直接跳过，无副作用。
- **`.DS_Store` 场景**：clone 里存在未跟踪的 `.DS_Store` 时不再被误判为「脏」，正常更新。
- **`--help`**：正常输出用法。

未改动任何既有技能内容，只新增一个脚本 + 文档 + 标题统一。

Xinrui Ma
