### PR TITLE
docs: add README table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,21 @@
 * 知识星球名称：Nature Skills以及背后的哲学！
  <img width="300" height="400" alt="1591" src="https://github.com/user-attachments/assets/64e37909-0a48-4bfb-8471-c2aff971a0f6" />
 
+## 目录
+
+- [快速开始](#快速开始)
+- [主要贡献者](#主要贡献者)
+- [自己的一些浅薄观点](#自己的一些浅薄观点)
+- [安装](#安装)
+  - [npx skills 安装方式](#npx-skills-安装方式)
+  - [Claude Code 安装方式](#claude-code-安装方式)
+  - [Codex 安装方式](#codex-安装方式)
+  - [其他 agent 场景](#其他-agent-场景)
+- [目录结构](#目录结构)
+- [技能索引](#技能索引)
+- [共享设计原则](#共享设计原则)
+- [新增技能](#新增技能)
+- [Star 历史](#star-历史)
 
 ## 快速开始
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -35,6 +35,21 @@
 - Knowledge Planet: `Nature Skills` and the philosophy behind it.
 <img width="300" height="400" alt="1591" src="https://github.com/user-attachments/assets/64e37909-0a48-4bfb-8471-c2aff971a0f6" />
 
+## Table of Contents
+
+- [Quick Start](#quick-start)
+- [Main Contributors](#main-contributors)
+- [Some Personal Views](#some-personal-views)
+- [Installation](#installation)
+  - [npx skills Installation](#npx-skills-installation)
+  - [Claude Code Installation](#claude-code-installation)
+  - [Codex Installation](#codex-installation)
+  - [Other Agent Scenarios](#other-agent-scenarios)
+- [Directory Layout](#directory-layout)
+- [Skill Index](#skill-index)
+- [Shared Design Principles](#shared-design-principles)
+- [Adding a Skill](#adding-a-skill)
+- [Star History](#star-history)
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary
- add a compact table of contents near the top of the Chinese README
- add the matching English table of contents
- include main sections and installation methods without overloading the list with every contribution step

## Validation
- git diff --check
- verified all 13 links in each table of contents resolve to an existing heading anchor