### PR TITLE
feat: add initial submission package workflow

### DIFF
--- a/skills/nature-writing/README.md
+++ b/skills/nature-writing/README.md
@@ -2,7 +2,7 @@
 
 [English](README_EN.md)
 
-`nature-writing` 用于根据作者提供的 claims、图表、结果、笔记或中文草稿，起草或重建 Nature 风格手稿章节。
+`nature-writing` 用于根据作者提供的 claims、图表、结果、笔记或中文草稿，起草或重建 Nature 风格手稿章节，并准备首次投稿材料包。
 
 ## 适合用它做什么
 
@@ -11,12 +11,15 @@
 - 将中文研究笔记转成英文手稿段落。
 - 为 Introduction 建立背景、缺口、问题和贡献链。
 - 对 Results 或 Discussion 做章节级重排，而不是只做句子润色。
+- 准备首次投稿 cover letter、title page、highlights、作者贡献、数据/代码可用性和其他声明。
+- 整理推荐审稿人、投稿材料矩阵和提交前完整性检查。
 
 ## 典型请求
 
 - “根据这些图和结果写一个 Nature 风格 abstract。”
 - “帮我重建 introduction 的逻辑，不要只润色句子。”
 - “把这些中文结果整理成英文 Results 叙事。”
+- “根据这篇稿件准备首次投稿 cover letter 和完整 submission package。”
 
 ## 你需要提供
 
@@ -29,15 +32,19 @@
 - 章节大纲、claim-evidence map 或可粘贴正文。
 - 对 novelty、significance、证据链和读者路径的修改建议。
 - 需要作者确认的事实、引用或图表说明。
+- 首次投稿材料包、缺失信息清单和 `ready / ready_with_author_checks / blocked` 状态。
 
 ## 边界
 
 - 不会替作者虚构实验结果、统计意义、机制解释或参考文献。
 - 如果已有英文草稿只需要句子级润色，优先使用 `nature-polishing`。
 - 如果需要先找文献支撑 claim，优先使用 `nature-citation` 或 `nature-academic-search`。
+- 首次投稿材料由本技能处理；返修 cover letter、rebuttal 和逐点回复由 `nature-response` 处理。
 
 ## 相关技能
 
 - `nature-polishing`：英文润色、翻译和风格收束。
 - `nature-citation`：为 claim 匹配支撑文献。
 - `nature-figure`：把图件结论和面板设计对齐到正文叙事。
+- `nature-response`：返修 cover letter、response to reviewers 和返修通信材料。
+- `nature-reviewer`：投稿前模拟审稿。

--- a/skills/nature-writing/README_EN.md
+++ b/skills/nature-writing/README_EN.md
@@ -2,7 +2,7 @@
 
 [中文说明](README.md)
 
-`nature-writing` drafts or rebuilds Nature-style manuscript sections from author-provided claims, figures, results, notes, or Chinese drafts.
+`nature-writing` drafts or rebuilds Nature-style manuscript sections and prepares initial-submission packages from author-provided claims, figures, results, notes, or Chinese drafts.
 
 ## What To Use It For
 
@@ -11,12 +11,15 @@
 - Turn Chinese research notes into English manuscript paragraphs.
 - Build the background, gap, question, and contribution chain for an Introduction.
 - Reorder Results or Discussion at the section level rather than only polishing sentences.
+- Prepare an initial cover letter, title page, highlights, author contributions, availability statements, and other declarations.
+- Organize reviewer suggestions, a deliverable matrix, and a pre-submission completeness audit.
 
 ## Typical Requests
 
 - "Write a Nature-style abstract from these figures and results."
 - "Rebuild the logic of this introduction; do not only polish the sentences."
 - "Turn these Chinese results into an English Results narrative."
+- "Prepare an initial cover letter and complete submission package from this manuscript."
 
 ## What You Need To Provide
 
@@ -29,15 +32,19 @@
 - Section outline, claim-evidence map, or ready-to-paste prose.
 - Revision suggestions for novelty, significance, evidence chain, and reader path.
 - Facts, references, or figure notes requiring author confirmation.
+- Initial-submission materials, a missing-input checklist, and a `ready / ready_with_author_checks / blocked` status.
 
 ## Boundaries
 
 - The skill does not invent experimental results, statistical significance, mechanism explanations, or references.
 - If an English draft only needs sentence-level polishing, use `nature-polishing`.
 - If claim support requires literature search first, use `nature-citation` or `nature-academic-search`.
+- This skill handles first submission; use `nature-response` for revision cover letters, rebuttals, and point-by-point responses.
 
 ## Related Skills
 
 - `nature-polishing`: English polishing, translation, and style tightening.
 - `nature-citation`: match supporting references for claims.
 - `nature-figure`: align figure conclusions and panel design with manuscript narrative.
+- `nature-response`: revision cover letters, responses to reviewers, and revision correspondence.
+- `nature-reviewer`: simulated review before submission.

--- a/skills/nature-writing/SKILL.md
+++ b/skills/nature-writing/SKILL.md
@@ -1,15 +1,13 @@
 ---
 name: nature-writing
-description: Draft, restructure, or plan Nature-style manuscript sections from author-provided claims, results, figures, notes, or Chinese drafts. Use when the user wants to write or rebuild an abstract, introduction, related-work, method, experiments, discussion, conclusion, title, or full manuscript argument rather than only polish finished prose. Also trigger on general academic-writing requests even without the word "Nature", such as writing a paper from scratch, drafting a manuscript/section, structuring a paper, and Chinese phrasings like 学术写作、科研写作、论文写作、写论文、写paper、SCI写作、帮我写论文、搭论文框架、起草论文、写引言/摘要/讨论.
-version: 1.0.0
-author: Community contribution, refactored into static/dynamic layers
+description: Draft, restructure, or plan Nature-style manuscript sections and initial-submission materials from author-provided claims, results, figures, notes, or Chinese drafts. Use when the user wants to write or rebuild an abstract, introduction, related-work, method, experiments, discussion, conclusion, title, full manuscript argument, pre-submission cover letter, title page, highlights, author-contribution statement, availability/declaration text, reviewer suggestions, or a complete initial submission package rather than only polish finished prose. Also trigger on general academic-writing and first-submission requests such as writing a paper from scratch, drafting a manuscript/section, structuring a paper, submission package, 投稿材料、首次投稿、投稿前 cover letter、投稿信、标题页、亮点、作者贡献、数据可用性声明、推荐审稿人.
 ---
 
 # Nature-Style Scientific Writing — Router
 
 This skill is split into two layers:
 
-- A **static layer** under `static/` that holds versioned, reusable content fragments (core stance + workflow, paper-type playbooks, per-section drafting guidance, language-specific rules, per-journal style).
+- A **static layer** under `static/` that holds versioned, reusable content fragments (core stance + workflow, paper-type playbooks, per-section drafting guidance, initial-submission guidance, language-specific rules, per-journal style).
 - A **dynamic layer** (this file plus `manifest.yaml`) that detects the request's axes and loads only the fragments needed for the current job.
 
 Do not try to apply the drafting logic from memory or from this router. Always load fragments from disk as described below.
@@ -20,7 +18,7 @@ Follow these five steps every time the skill is invoked.
 
 ### 1. Load the manifest and the core layer
 
-Read [manifest.yaml](manifest.yaml). It declares the axes (`paper_type`, `section`, `language`, `journal`), the allowed values, and the file paths each value maps to.
+Read [manifest.yaml](manifest.yaml). It declares the axes (`task`, `paper_type`, `section`, `language`, `journal`), the allowed values, and the file paths each value maps to.
 
 Also read every file listed under `always_load`. These hold the default stance, writing workflow, and output format that apply to every drafting job.
 
@@ -28,6 +26,7 @@ Also read every file listed under `always_load`. These hold the default stance, 
 
 For each axis in the manifest, decide the value using the manifest's `detect:` hint and the user's input:
 
+- `task` — manuscript / submission-package. Use `submission-package` for first-submission materials, never for revision correspondence.
 - `paper_type` — research / methods / hypothesis / algorithmic / review. Default: research.
 - `section` — abstract / intro / related-work / method / experiments / discussion / conclusion / title. May be multiple. Ask the user if it is ambiguous and matters for the draft.
 - `language` — en or zh-to-en. Detect from the user's notes themselves.
@@ -37,7 +36,7 @@ State the detected axis values in one short line to the user before drafting, so
 
 ### 3. Load the matching fragments
 
-For each axis value, Read the file mapped in the manifest. Skip the `section` axis only when the user has explicitly asked for a free-floating argument paragraph with no section context.
+For each axis value, Read the file mapped in the manifest. Skip the `section` axis when the task is `submission-package` or when the user explicitly asks for a free-floating argument paragraph with no section context.
 
 Do **not** read every fragment in `static/`. Load only what step 2 selected.
 
@@ -48,10 +47,13 @@ Apply the loaded fragments in this priority order:
 1. Core stance + intake (`core/stance.md`) — surface missing claim / evidence / boundary before drafting.
 2. Paper-type playbook — argument chain, drafting order.
 3. Section-specific drafting rules and structure.
-4. Journal-specific framing and constraints.
-5. Language-specific sentence and paragraph rules (apply last).
+4. Task-specific submission rules when `task=submission-package`.
+5. Journal-specific framing and constraints.
+6. Language-specific sentence and paragraph rules (apply last).
 
-Run the 8-step workflow in `core/workflow.md` end-to-end. Do not skip steps 1-3 (planning) just because the user asked for prose immediately — write the one-sentence argument first.
+For `task=manuscript`, run the workflow in `core/workflow.md` end-to-end. Do not skip planning just because the user asked for prose immediately.
+
+For `task=submission-package`, follow `static/fragments/task/submission-package.md` and `references/submission-package.md` instead. Build the deliverable matrix and readiness audit; do not force manuscript paragraph architecture onto administrative submission materials.
 
 If essential evidence or boundary is missing, write a placeholder and list it under `Assumptions or missing inputs:` instead of inventing content.
 
@@ -64,6 +66,13 @@ The files under `references/` are deep references and the example library, not d
 - The user needs a broad-audience `Nature` abstract opening or asks about a `summary paragraph` → `references/nature-summary-paragraph.md`.
 - The user asks "does this paragraph flow?" → `references/paragraph-flow.md`.
 - The user asks for a self-review or rejection-risk audit → `references/paper-review.md`.
+- The user requests a complete first-submission package, templates, or a submission-readiness audit → `references/submission-package.md`.
+
+## Submission boundary
+
+- `nature-writing` owns **initial submission** materials prepared before peer review.
+- `nature-response` owns revision cover letters, rebuttals, point-by-point responses, marked manuscripts, appeals, and other post-decision correspondence.
+- Route graphical abstracts and TOC graphics to `nature-figure`; route simulated pre-submission peer review to `nature-reviewer`.
 
 ## Why this split
 

--- a/skills/nature-writing/agents/openai.yaml
+++ b/skills/nature-writing/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Nature Writing"
-  short_description: "Draft Nature-style manuscript sections"
-  default_prompt: "Help me turn my claims, results, figures, or Chinese notes into a Nature-style manuscript section with a clear argument and claim-evidence map."
+  short_description: "Draft manuscripts and first-submission packages"
+  default_prompt: "Help me turn my claims, results, figures, or Chinese notes into a Nature-style manuscript section or a complete initial-submission package with fact-checked placeholders."

--- a/skills/nature-writing/manifest.yaml
+++ b/skills/nature-writing/manifest.yaml
@@ -2,7 +2,8 @@ name: nature-writing
 version: 1.0.0
 description: >
   Declarative manifest for the static/dynamic split. SKILL.md uses this to
-  decide which fragments to load for a given drafting or restructuring request.
+  decide which fragments to load for a drafting, restructuring, or
+  initial-submission request.
 
 always_load:
   # Shared layer — common to nature-polishing and nature-writing
@@ -16,6 +17,20 @@ always_load:
   - static/core/output-format.md
 
 axes:
+  task:
+    detect: |
+      Use submission-package when the user requests first-submission or
+      pre-submission materials such as an initial cover letter, title page,
+      highlights, author contributions, availability/declaration statements,
+      reviewer suggestions, or a complete submission checklist. Use manuscript
+      for manuscript sections and argument development. Revision correspondence
+      after an editor decision belongs to nature-response, not this skill.
+    values:
+      manuscript:          static/fragments/task/manuscript.md
+      submission-package: static/fragments/task/submission-package.md
+    default: manuscript
+    multi: false
+
   paper_type:
     detect: |
       Decide what kind of paper or section is being drafted. Default to research.
@@ -95,6 +110,8 @@ references:
       path: references/paragraph-flow.md
     - condition: final manuscript self-review, rejection-risk audit, claim-evidence alignment
       path: references/paper-review.md
+    - condition: initial cover letter, title page, highlights, declarations, suggested reviewers, complete first-submission package, or submission-readiness audit
+      path: references/submission-package.md
     - condition: deeper Chinese-author repair patterns beyond the language fragment
       path: references/chinese-author-workflow.md
     - condition: user wants concrete abstract/introduction/method examples

--- a/skills/nature-writing/references/submission-package.md
+++ b/skills/nature-writing/references/submission-package.md
@@ -1,0 +1,174 @@
+# Initial submission package
+
+Use this reference for first-submission materials before peer review. Journal instructions override these defaults.
+
+## Contents
+
+1. Intake and routing
+2. Deliverable matrix
+3. Initial cover letter
+4. Title page
+5. Highlights and editorial summary
+6. Declarations
+7. Reviewer suggestions
+8. Completeness audit
+9. Output format
+
+## 1. Intake and routing
+
+Collect or mark as missing:
+
+- Target journal, article type, manuscript title, short title, abstract, and keywords.
+- Author names, order, affiliations, corresponding-author details, email, and ORCID.
+- One-sentence claim, strongest evidence, novelty boundary, significance, and journal fit.
+- Funding identifiers, acknowledgements, conflicts, ethics approvals, consent, and permissions.
+- Data/code repository links, accession numbers, license, embargo, and access conditions.
+- Preprint, conference version, related manuscripts, prior submission, or concurrent-submission facts.
+- Suggested/opposed reviewers with affiliation, email, expertise, relationship/conflict check, and rationale.
+- Journal-specific items such as highlights, graphical abstract, reporting summary, checklist, or author declaration.
+
+Do not infer unknown administrative facts. Use `[AUTHOR_INPUT_NEEDED: ...]`.
+
+## 2. Deliverable matrix
+
+Return a compact table:
+
+| Item | Status | Source or missing input | Draft/output |
+|---|---|---|---|
+| Main manuscript | required / optional / N/A | path or note | filename/status |
+| Anonymous manuscript | required / optional / N/A | journal rule | filename/status |
+| Title page | required / optional / N/A | author metadata | draft/status |
+| Cover letter | required / optional / N/A | claim + fit | draft/status |
+| Highlights | required / optional / N/A | key findings | draft/status |
+| Graphical abstract | required / optional / N/A | route to nature-figure | status |
+| Supplementary information | required / optional / N/A | supplied files | status |
+| Reporting checklist | required / optional / N/A | study design | status |
+| Declarations | required / optional / N/A | author facts | draft/status |
+| Reviewer suggestions | required / optional / N/A | author candidates | draft/status |
+
+## 3. Initial cover letter
+
+This is not a revision cover letter.
+
+Recommended anatomy:
+
+```text
+Dear [Editor name / Editors],
+
+Please consider our manuscript, "[Title]," for publication as a [Article type] in [Journal].
+
+[What the study addresses and the principal finding, in 1-2 sentences.]
+[What is specifically new and which evidence supports it, in 1-2 sentences.]
+[Why the result matters to this journal's readership, in 1 sentence.]
+
+[Required declarations: originality, author approval, related manuscripts/preprint, conflicts, or other journal-specific statements.]
+
+Thank you for your consideration.
+
+Sincerely,
+[Corresponding author]
+[Affiliation and contact details]
+```
+
+Rules:
+
+- Usually 250-400 words unless the journal specifies otherwise.
+- Do not repeat the abstract.
+- Do not use unsupported priority claims such as "the first" or "unprecedented".
+- Do not name-drop editors, reviewers, or famous researchers as persuasion.
+- Do not claim journal fit without connecting the finding to the journal's scope and readers.
+
+## 4. Title page
+
+Draft or audit:
+
+- Full title and short/running title.
+- Author names in final order.
+- Affiliation mapping and present addresses.
+- Corresponding author(s), email, postal address when required, and ORCID.
+- Equal-contribution and senior-author notes.
+- Word count, figure/table count, keywords, and article type when required.
+- Funding, acknowledgements, conflicts, data/code availability, ethics, consent, and author contributions when the journal places them on the title page.
+
+For double-anonymous review, keep identifying details out of the anonymous manuscript.
+
+## 5. Highlights and editorial summary
+
+Highlights:
+
+- Three to five bullets.
+- One finding per bullet.
+- Prefer concrete results over generic importance claims.
+- Respect the journal's character limit.
+
+Editorial summary or significance statement:
+
+- Problem and audience.
+- Main advance.
+- Why the evidence changes understanding or practice.
+- Scope and limitation.
+
+## 6. Declarations
+
+Prepare separate, fact-grounded blocks as applicable:
+
+- CRediT author contributions.
+- Competing interests.
+- Funding.
+- Acknowledgements.
+- Data availability.
+- Code availability.
+- Ethics approval and consent to participate.
+- Consent for publication.
+- Materials availability.
+- Preprint and related-manuscript disclosure.
+- Originality and all-author approval.
+- Third-party permissions.
+
+Never convert "available on request" into a public repository claim. Never invent contribution roles, grant numbers, approval IDs, accession numbers, or licenses.
+
+## 7. Reviewer suggestions
+
+When requested, return:
+
+| Name | Institution | Email | Expertise fit | Conflict check | Rationale |
+|---|---|---|---|---|---|
+
+Require the author to confirm:
+
+- No recent coauthorship, same institution, close collaboration, supervisory relationship, personal conflict, or other journal-defined conflict.
+- Institutional email and current affiliation are accurate.
+- The candidate has topic/method expertise relevant to the manuscript.
+
+For opposed reviewers, give a short factual reason without attacking competence or character.
+
+## 8. Completeness audit
+
+Check:
+
+- Journal instructions and article type are confirmed.
+- All author names, order, affiliations, and corresponding-author details match every file.
+- Title, abstract, keywords, declarations, repository links, and manuscript metadata are consistent.
+- Anonymous and identified files are separated correctly.
+- Figures, tables, supplements, permissions, and checklists are present and cited.
+- Data/code statements point to real destinations and access conditions.
+- Cover letter matches the manuscript's actual claims and does not overstate novelty.
+- Suggested reviewers pass conflict checks.
+- Required placeholders are resolved.
+
+Readiness:
+
+- `ready`: all required facts and files are present and cross-checked.
+- `ready_with_author_checks`: drafts are complete but administrative facts need confirmation.
+- `blocked`: required ethics, authorship, permissions, integrity, or journal-rule information is missing.
+
+## 9. Output format
+
+Return:
+
+1. `Submission readiness:`
+2. `Deliverable matrix:`
+3. `Draft materials:` with clear headings for each requested item.
+4. `AUTHOR_INPUT_NEEDED:` as a consolidated checklist.
+5. `Cross-file consistency checks:`
+6. `Next actions:` ordered by blocking priority.

--- a/skills/nature-writing/static/core/output-format.md
+++ b/skills/nature-writing/static/core/output-format.md
@@ -13,3 +13,12 @@ Default output:
 For Chinese-author notes, provide polished English first, then brief Chinese notes explaining major structural choices.
 
 If essential evidence or boundary is missing, do not invent. Write a placeholder such as `[Evidence needed: comparator group accuracy on test set X]` and list it under `Assumptions or missing inputs:`.
+
+For `task=submission-package`, replace the default manuscript format with:
+
+1. `Submission readiness:`
+2. `Deliverable matrix:`
+3. `Draft materials:`
+4. `AUTHOR_INPUT_NEEDED:`
+5. `Cross-file consistency checks:`
+6. `Next actions:`

--- a/skills/nature-writing/static/fragments/task/manuscript.md
+++ b/skills/nature-writing/static/fragments/task/manuscript.md
@@ -1,0 +1,5 @@
+# Manuscript task
+
+Use the normal section-writing workflow. Build the paper argument, load the requested section fragment, draft from evidence outward, and return the prose with claim-evidence notes.
+
+Do not add submission forms or editorial correspondence unless the user asks for them.

--- a/skills/nature-writing/static/fragments/task/submission-package.md
+++ b/skills/nature-writing/static/fragments/task/submission-package.md
@@ -1,0 +1,27 @@
+# Initial submission package
+
+Use this task only before the first editorial decision. Read `references/submission-package.md` for the full intake contract, templates, and readiness checklist.
+
+## Core workflow
+
+1. Identify the target journal, article type, manuscript title, corresponding author, and requested deliverables.
+2. Check the journal's current author instructions when exact requirements matter. Treat journal-specific instructions as authoritative.
+3. Build a deliverable matrix: required, optional, not applicable, or author input needed.
+4. Draft only from author-supplied facts. Never invent author identities, affiliations, ORCIDs, funding numbers, ethics approvals, repository links, accession numbers, conflicts, reviewer identities, or permissions.
+5. Keep the initial cover letter concise and editor-facing: what the study shows, what is new, why it fits the journal/readership, and any required declarations.
+6. Keep each declaration internally consistent with the manuscript and title page.
+7. Return a readiness state: `ready`, `ready_with_author_checks`, or `blocked`.
+
+## Default deliverables
+
+- Initial-submission cover letter.
+- Title-page metadata checklist or draft.
+- Three to five highlights when the journal accepts them.
+- CRediT-style author-contribution statement.
+- Data and code availability statements.
+- Competing-interests, funding, acknowledgements, and ethics statements.
+- Suggested/opposed reviewer table when requested.
+- Related-manuscript, preprint, originality, permissions, and reporting-checklist prompts.
+- Submission completeness matrix.
+
+Graphical abstracts and TOC graphics belong to `nature-figure`. Revision cover letters and rebuttals belong to `nature-response`.


### PR DESCRIPTION
## Summary
- extend nature-writing with a dedicated initial-submission task axis
- add first-submission cover letters, title pages, highlights, CRediT contributions, availability/declaration statements, reviewer suggestions, and completeness audits
- return an explicit ready / ready_with_author_checks / blocked state with AUTHOR_INPUT_NEEDED placeholders
- keep first submission in nature-writing while routing revision correspondence to nature-response, graphical abstracts to nature-figure, and simulated review to nature-reviewer
- update Chinese/English skill documentation and OpenAI interface metadata

## Validation
- skill-creator quick_validate.py: Skill is valid
- manifest route/path validation: all routes exist
- Chinese/English README H2 counts match
- git diff --check