### PR TITLE
feat: add initial submission LaTeX templates

### DIFF
--- a/skills/nature-writing/README.md
+++ b/skills/nature-writing/README.md
@@ -32,7 +32,7 @@
 - 章节大纲、claim-evidence map 或可粘贴正文。
 - 对 novelty、significance、证据链和读者路径的修改建议。
 - 需要作者确认的事实、引用或图表说明。
-- 首次投稿材料包、缺失信息清单和 `ready / ready_with_author_checks / blocked` 状态。
+- 首次投稿材料包、可编辑 LaTeX 模板、缺失信息清单和 `ready / ready_with_author_checks / blocked` 状态。
 
 ## 边界
 

--- a/skills/nature-writing/README_EN.md
+++ b/skills/nature-writing/README_EN.md
@@ -32,7 +32,7 @@
 - Section outline, claim-evidence map, or ready-to-paste prose.
 - Revision suggestions for novelty, significance, evidence chain, and reader path.
 - Facts, references, or figure notes requiring author confirmation.
-- Initial-submission materials, a missing-input checklist, and a `ready / ready_with_author_checks / blocked` status.
+- Initial-submission materials, editable LaTeX templates, a missing-input checklist, and a `ready / ready_with_author_checks / blocked` status.
 
 ## Boundaries
 

--- a/skills/nature-writing/references/submission-package.md
+++ b/skills/nature-writing/references/submission-package.md
@@ -12,7 +12,8 @@ Use this reference for first-submission materials before peer review. Journal in
 6. Declarations
 7. Reviewer suggestions
 8. Completeness audit
-9. Output format
+9. LaTeX templates
+10. Output format
 
 ## 1. Intake and routing
 
@@ -162,7 +163,27 @@ Readiness:
 - `ready_with_author_checks`: drafts are complete but administrative facts need confirmation.
 - `blocked`: required ethics, authorship, permissions, integrity, or journal-rule information is missing.
 
-## 9. Output format
+## 9. LaTeX templates
+
+Use these only for initial submission:
+
+| Template | Purpose |
+|---|---|
+| `templates/submission/initial-cover-letter.tex` | Initial editor-facing cover letter |
+| `templates/submission/title-page.tex` | Identified title page and declarations |
+| `templates/submission/highlights-and-summary.tex` | Highlights and editorial/significance summary |
+| `templates/submission/declarations-and-reviewers.tex` | Submission declarations and reviewer suggestions |
+
+When producing LaTeX:
+
+- Copy only the requested templates into the user's delivery folder.
+- Replace placeholders only with author-confirmed facts.
+- Keep unresolved facts visibly marked as `AUTHOR_INPUT_NEEDED`.
+- Check journal instructions before deciding which declarations belong on the title page or in separate files.
+- Compile when a LaTeX engine is available and report any missing package or compilation error.
+- Never reuse `nature-response/templates/cover-letter.tex`; that template is explicitly for a revised manuscript.
+
+## 10. Output format
 
 Return:
 

--- a/skills/nature-writing/static/fragments/task/submission-package.md
+++ b/skills/nature-writing/static/fragments/task/submission-package.md
@@ -23,5 +23,6 @@ Use this task only before the first editorial decision. Read `references/submiss
 - Suggested/opposed reviewer table when requested.
 - Related-manuscript, preprint, originality, permissions, and reporting-checklist prompts.
 - Submission completeness matrix.
+- Filled LaTeX deliverables from `templates/submission/` when the user requests `.tex` files.
 
 Graphical abstracts and TOC graphics belong to `nature-figure`. Revision cover letters and rebuttals belong to `nature-response`.

--- a/skills/nature-writing/templates/submission/declarations-and-reviewers.tex
+++ b/skills/nature-writing/templates/submission/declarations-and-reviewers.tex
@@ -1,0 +1,75 @@
+\documentclass[10pt]{article}
+
+\usepackage[margin=0.8in]{geometry}
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{lmodern}
+\usepackage{longtable}
+\usepackage{array}
+\usepackage{hyperref}
+
+\title{Submission Declarations and Reviewer Suggestions\\
+\large AUTHOR\_INPUT\_NEEDED: Manuscript title}
+\author{}
+\date{}
+
+\begin{document}
+\maketitle
+
+\section*{Submission declarations}
+
+\subsection*{Originality and author approval}
+AUTHOR\_INPUT\_NEEDED: Confirm originality, absence of prohibited concurrent
+submission, and approval by all authors using the journal's required wording.
+
+\subsection*{Author contributions}
+AUTHOR\_INPUT\_NEEDED: CRediT roles confirmed by all authors.
+
+\subsection*{Competing interests}
+AUTHOR\_INPUT\_NEEDED: Declaration.
+
+\subsection*{Funding}
+AUTHOR\_INPUT\_NEEDED: Funder names and grant identifiers, or no specific funding.
+
+\subsection*{Data availability}
+AUTHOR\_INPUT\_NEEDED: Real repository, accession number, embargo, and access conditions.
+
+\subsection*{Code availability}
+AUTHOR\_INPUT\_NEEDED: Real repository, version, license, and access conditions, or not applicable.
+
+\subsection*{Ethics and consent}
+AUTHOR\_INPUT\_NEEDED: Ethics approval, consent, and publication-consent statements, or not applicable.
+
+\subsection*{Preprint and related manuscripts}
+AUTHOR\_INPUT\_NEEDED: DOI or URL and relationship to this submission, or none.
+
+\subsection*{Third-party permissions}
+AUTHOR\_INPUT\_NEEDED: Permission status for reused figures, tables, instruments, or other material.
+
+\section*{Suggested reviewers}
+
+\begin{longtable}{>{\raggedright\arraybackslash}p{0.14\textwidth}
+                  >{\raggedright\arraybackslash}p{0.18\textwidth}
+                  >{\raggedright\arraybackslash}p{0.18\textwidth}
+                  >{\raggedright\arraybackslash}p{0.17\textwidth}
+                  >{\raggedright\arraybackslash}p{0.13\textwidth}
+                  >{\raggedright\arraybackslash}p{0.13\textwidth}}
+\textbf{Name} & \textbf{Institution} & \textbf{Email} &
+\textbf{Expertise fit} & \textbf{Conflict check} & \textbf{Rationale}\\
+\hline
+AUTHOR\_INPUT\_NEEDED & AUTHOR\_INPUT\_NEEDED & AUTHOR\_INPUT\_NEEDED &
+AUTHOR\_INPUT\_NEEDED & Author must confirm & AUTHOR\_INPUT\_NEEDED\\
+\end{longtable}
+
+\section*{Opposed reviewers, if permitted}
+
+\begin{longtable}{>{\raggedright\arraybackslash}p{0.2\textwidth}
+                  >{\raggedright\arraybackslash}p{0.25\textwidth}
+                  >{\raggedright\arraybackslash}p{0.45\textwidth}}
+\textbf{Name} & \textbf{Institution} & \textbf{Factual reason}\\
+\hline
+AUTHOR\_INPUT\_NEEDED & AUTHOR\_INPUT\_NEEDED &
+AUTHOR\_INPUT\_NEEDED: concise, non-personal reason\\
+\end{longtable}
+
+\end{document}

--- a/skills/nature-writing/templates/submission/highlights-and-summary.tex
+++ b/skills/nature-writing/templates/submission/highlights-and-summary.tex
@@ -1,0 +1,38 @@
+\documentclass[11pt]{article}
+
+\usepackage[margin=1in]{geometry}
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{lmodern}
+\usepackage{enumitem}
+
+% Check the target journal's bullet count and character limits before submission.
+
+\title{Highlights and Editorial Summary\\
+\large AUTHOR\_INPUT\_NEEDED: Manuscript title}
+\author{}
+\date{}
+
+\begin{document}
+\maketitle
+
+\section*{Highlights}
+
+\begin{itemize}[leftmargin=*]
+  \item AUTHOR\_INPUT\_NEEDED: Concrete principal finding.
+  \item AUTHOR\_INPUT\_NEEDED: Specific methodological or conceptual advance.
+  \item AUTHOR\_INPUT\_NEEDED: Strongest evidence or comparison.
+  \item AUTHOR\_INPUT\_NEEDED: Bounded implication for the field or practice.
+  \item AUTHOR\_INPUT\_NEEDED: Optional fifth highlight or remove this item.
+\end{itemize}
+
+\section*{Editorial summary or significance statement}
+
+AUTHOR\_INPUT\_NEEDED: State the problem and intended audience.
+
+AUTHOR\_INPUT\_NEEDED: State the principal advance and evidence.
+
+AUTHOR\_INPUT\_NEEDED: Explain why the result changes understanding or practice,
+while preserving the manuscript's scope and limitations.
+
+\end{document}

--- a/skills/nature-writing/templates/submission/initial-cover-letter.tex
+++ b/skills/nature-writing/templates/submission/initial-cover-letter.tex
@@ -1,0 +1,50 @@
+\documentclass[11pt]{letter}
+
+\usepackage[margin=1in]{geometry}
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{lmodern}
+\usepackage{hyperref}
+\usepackage{setspace}
+
+% Replace every AUTHOR_INPUT_NEEDED placeholder with author-confirmed facts.
+% This template is for an initial submission, not a revision or rebuttal.
+
+\signature{AUTHOR\_INPUT\_NEEDED: corresponding author name\\
+on behalf of all authors}
+\address{AUTHOR\_INPUT\_NEEDED: affiliation\\
+AUTHOR\_INPUT\_NEEDED: email and postal address}
+\date{\today}
+
+\begin{document}
+
+\begin{letter}{AUTHOR\_INPUT\_NEEDED: editor name or Editors\\
+AUTHOR\_INPUT\_NEEDED: journal name}
+
+\opening{Dear AUTHOR\_INPUT\_NEEDED: Editor name or Editors,}
+
+Please consider our manuscript entitled
+\emph{AUTHOR\_INPUT\_NEEDED: manuscript title}
+for publication as a
+AUTHOR\_INPUT\_NEEDED: article type
+in \emph{AUTHOR\_INPUT\_NEEDED: journal name}.
+
+AUTHOR\_INPUT\_NEEDED: In one or two sentences, state the problem addressed and
+the principal finding, using only results supported by the manuscript.
+
+AUTHOR\_INPUT\_NEEDED: In one or two sentences, explain the specific advance and
+the strongest evidence supporting it. Avoid unsupported priority claims.
+
+AUTHOR\_INPUT\_NEEDED: In one sentence, explain why the finding matters to the
+journal's readership and scope.
+
+AUTHOR\_INPUT\_NEEDED: Add only journal-required declarations, such as
+originality, approval by all authors, preprint or related-manuscript disclosure,
+and competing interests.
+
+Thank you for your consideration.
+
+\closing{Sincerely,}
+
+\end{letter}
+\end{document}

--- a/skills/nature-writing/templates/submission/title-page.tex
+++ b/skills/nature-writing/templates/submission/title-page.tex
@@ -1,0 +1,70 @@
+\documentclass[11pt]{article}
+
+\usepackage[margin=1in]{geometry}
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{lmodern}
+\usepackage{authblk}
+\usepackage{hyperref}
+\usepackage{enumitem}
+
+% Confirm journal placement rules before keeping declarations on this page.
+% For double-anonymous review, upload this separately from the anonymous manuscript.
+
+\title{AUTHOR\_INPUT\_NEEDED: Full manuscript title}
+
+\author[1]{AUTHOR\_INPUT\_NEEDED: Author One}
+\author[2]{AUTHOR\_INPUT\_NEEDED: Author Two}
+\affil[1]{AUTHOR\_INPUT\_NEEDED: Affiliation one}
+\affil[2]{AUTHOR\_INPUT\_NEEDED: Affiliation two}
+
+\date{}
+
+\begin{document}
+\maketitle
+
+\noindent\textbf{Running title:}
+AUTHOR\_INPUT\_NEEDED: Short title
+
+\medskip
+\noindent\textbf{Corresponding author:}
+AUTHOR\_INPUT\_NEEDED: Name, affiliation, postal address, email, and ORCID
+
+\medskip
+\noindent\textbf{Equal or senior contribution notes:}
+AUTHOR\_INPUT\_NEEDED: Statement or not applicable
+
+\medskip
+\noindent\textbf{Keywords:}
+AUTHOR\_INPUT\_NEEDED: Keywords
+
+\medskip
+\noindent\textbf{Article type:}
+AUTHOR\_INPUT\_NEEDED: Article type
+
+\medskip
+\noindent\textbf{Counts:}
+AUTHOR\_INPUT\_NEEDED: Word count; number of figures, tables, and supplementary files
+
+\section*{Author contributions}
+AUTHOR\_INPUT\_NEEDED: CRediT roles confirmed by all authors.
+
+\section*{Competing interests}
+AUTHOR\_INPUT\_NEEDED: Declaration.
+
+\section*{Funding}
+AUTHOR\_INPUT\_NEEDED: Funder names and grant numbers, or no specific funding.
+
+\section*{Acknowledgements}
+AUTHOR\_INPUT\_NEEDED: Acknowledgements, or none.
+
+\section*{Data availability}
+AUTHOR\_INPUT\_NEEDED: Real repository, accession, access conditions, or justified statement.
+
+\section*{Code availability}
+AUTHOR\_INPUT\_NEEDED: Real repository, version, license, access conditions, or not applicable.
+
+\section*{Ethics and consent}
+AUTHOR\_INPUT\_NEEDED: Approval body and identifier, consent statement, or not applicable.
+
+\end{document}


### PR DESCRIPTION
## Summary
- add initial-submission LaTeX templates for cover letter, title page, highlights/editorial summary, and declarations/reviewer suggestions
- keep unresolved administrative facts visibly marked as AUTHOR_INPUT_NEEDED
- document template routing and prevent accidental reuse of the revision-cover-letter template from nature-response
- expose editable LaTeX output in the Chinese and English nature-writing READMEs

## Validation
- skill-creator quick_validate.py: Skill is valid
- git diff --check
- compiled all four templates with latexmk/pdflatex successfully