### PR TITLE
fix: prevent reviewer table text overlap

### DIFF
--- a/skills/nature-writing/templates/submission/declarations-and-reviewers.tex
+++ b/skills/nature-writing/templates/submission/declarations-and-reviewers.tex
@@ -48,17 +48,17 @@ AUTHOR\_INPUT\_NEEDED: Permission status for reused figures, tables, instruments
 
 \section*{Suggested reviewers}
 
-\begin{longtable}{>{\raggedright\arraybackslash}p{0.14\textwidth}
-                  >{\raggedright\arraybackslash}p{0.18\textwidth}
-                  >{\raggedright\arraybackslash}p{0.18\textwidth}
+\begin{longtable}{>{\raggedright\arraybackslash}p{0.11\textwidth}
+                  >{\raggedright\arraybackslash}p{0.15\textwidth}
                   >{\raggedright\arraybackslash}p{0.17\textwidth}
-                  >{\raggedright\arraybackslash}p{0.13\textwidth}
-                  >{\raggedright\arraybackslash}p{0.13\textwidth}}
+                  >{\raggedright\arraybackslash}p{0.14\textwidth}
+                  >{\raggedright\arraybackslash}p{0.12\textwidth}
+                  >{\raggedright\arraybackslash}p{0.12\textwidth}}
 \textbf{Name} & \textbf{Institution} & \textbf{Email} &
 \textbf{Expertise fit} & \textbf{Conflict check} & \textbf{Rationale}\\
 \hline
-AUTHOR\_INPUT\_NEEDED & AUTHOR\_INPUT\_NEEDED & AUTHOR\_INPUT\_NEEDED &
-AUTHOR\_INPUT\_NEEDED & Author must confirm & AUTHOR\_INPUT\_NEEDED\\
+Input needed & Input needed & Input needed &
+Input needed & Author confirmation needed & Input needed\\
 \end{longtable}
 
 \section*{Opposed reviewers, if permitted}
@@ -68,7 +68,7 @@ AUTHOR\_INPUT\_NEEDED & Author must confirm & AUTHOR\_INPUT\_NEEDED\\
                   >{\raggedright\arraybackslash}p{0.45\textwidth}}
 \textbf{Name} & \textbf{Institution} & \textbf{Factual reason}\\
 \hline
-AUTHOR\_INPUT\_NEEDED & AUTHOR\_INPUT\_NEEDED &
+Input needed & Input needed &
 AUTHOR\_INPUT\_NEEDED: concise, non-personal reason\\
 \end{longtable}
 


### PR DESCRIPTION
## Summary
- shorten placeholder content in narrow reviewer-table cells
- rebalance column widths so the rendered table stays within the page

## Validation
- compiled with latexmk/pdflatex
- rendered to PNG and visually checked
- no Overfull box warnings
- git diff --check