### PR TITLE
docs: add website link to README navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
     <a href="README_EN.md"><img alt="Language" src="https://img.shields.io/badge/language-中文%20%7C%20English-1f6feb"></a>
   </p>
   <p>
-    <a href="#5-安装">立即安装</a>
+    <a href="https://yuan1z0825.github.io/nature-skills/">在线网站</a>
+    · <a href="#5-安装">立即安装</a>
     · <a href="#4-快速开始">快速开始</a>
     · <a href="#6-技能索引">技能索引</a>
     · <a href="docs/open-source-agent-frameworks.md">其他安装</a>

--- a/README_EN.md
+++ b/README_EN.md
@@ -9,7 +9,8 @@
     <a href="README.md"><img alt="Language" src="https://img.shields.io/badge/language-English%20%7C%20中文-1f6feb"></a>
   </p>
   <p>
-    <a href="#5-installation">Install</a>
+    <a href="https://yuan1z0825.github.io/nature-skills/">Website</a>
+    · <a href="#5-installation">Install</a>
     · <a href="#4-quick-start">Quick Start</a>
     · <a href="#6-skill-index">Skill Index</a>
     · <a href="docs/open-source-agent-frameworks_EN.md">Other Install</a>


### PR DESCRIPTION
## Summary
- add the Nature Skills website as the first quick-navigation link in the Chinese README
- add the matching Website link in the English README
- preserve the latest upstream README edits

## Validation
- git diff --check
- confirmed the PR changes only the two top navigation blocks