### PR TITLE
fix: keep active skill category text visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -599,9 +599,11 @@ h3 { font-size: var(--fs-h3); }
   color: var(--verdigris);
 }
 
-.skills__cat-btn--active {
+.skills__cat-btn--active,
+.skills__cat-btn--active:hover,
+.skills__cat-btn--active:focus-visible {
   background: var(--verdigris);
-  color: white;
+  color: #FFFFFF;
   border-color: var(--verdigris);
 }
 


### PR DESCRIPTION
## 修复内容

- 修复移动端点击技能分类后，选中项文字因悬停样式覆盖而不可见的问题
- 为选中状态的 hover 和 focus-visible 明确保持白色文字

## 验证

- 已检查全部 7 个分类按钮的选中状态
- 选中项背景为主题绿色，文字保持白色
- 页面控制台无报错