### PR TITLE
docs: add manifests for remaining Nature skills

### DIFF
--- a/skills/nature-experiment-log/manifest.yaml
+++ b/skills/nature-experiment-log/manifest.yaml
@@ -1,0 +1,32 @@
+name: nature-experiment-log
+version: 1.0.0
+description: >
+  Declarative manifest for the experiment-log workflow. SKILL.md uses this to
+  route raw images, voice transcripts, and text notes into standardized
+  Obsidian-compatible experiment records while loading examples and templates
+  only when they are needed.
+
+# Design note: the core workflow is short and operational. The heavier example
+# logs and vault templates are supporting resources and should stay on demand so
+# routine logging does not preload every sample document.
+
+always_load:
+  - SKILL.md
+
+templates:
+  on_demand:
+    - condition: creating or refreshing the experiment index dashboard
+      path: templates/experiment-index.md
+    - condition: logging an anomaly, failed run, contamination, unexpected device behavior, or deviation from protocol
+      path: templates/anomaly-log.md
+    - condition: setting up shared equipment, reagent, or consumable tracking in the vault
+      path: templates/equipment-tracking.md
+
+references:
+  on_demand:
+    - condition: user needs a complete corrosion, soaking, or general materials experiment log example
+      path: references/example-log.md
+    - condition: electrochemical characterization, CV, SWV, EIS, electrode setup, or electrochemical window logging
+      path: references/example-electrochemical.md
+    - condition: thermal stability, heating, furnace, muffle furnace, tube furnace, or temperature-program experiment logging
+      path: references/example-thermal-stability.md

--- a/skills/nature-literature-pipeline/manifest.yaml
+++ b/skills/nature-literature-pipeline/manifest.yaml
@@ -1,0 +1,34 @@
+name: nature-literature-pipeline
+version: 1.0.0
+description: >
+  Declarative manifest for the automated literature-discovery pipeline. SKILL.md
+  uses this to keep the default cron/search/deliver/archive workflow concise
+  while loading scoring, gap-analysis, digest, and archival details only when
+  the task reaches that stage.
+
+# Design note: the pipeline has stable stages (search -> coarse filter -> fine
+# read -> deliver -> archive). Configuration and examples are large enough to be
+# loaded on demand instead of for every invocation.
+
+always_load:
+  - SKILL.md
+
+templates:
+  on_demand:
+    - condition: configuring keywords, scoring weights, delivery target, archive path, or a reusable daily push profile
+      path: templates/literature-push-template.md
+
+references:
+  on_demand:
+    - condition: ranking candidates, checking score arithmetic, changing dimension weights, or explaining the six-dimension scoring system
+      path: references/scoring-system.md
+    - condition: identifying research gaps, building a review map, or turning discoveries into a research direction
+      path: references/gap-analysis.md
+    - condition: writing or validating archived literature notes with YAML frontmatter
+      path: references/note-template.md
+    - condition: formatting daily digest messages for Feishu, Telegram, email, or chat delivery
+      path: references/push-format.md
+    - condition: creating, updating, debugging, or documenting the recurring cron job
+      path: references/cron-setup.md
+    - condition: compiling multiple daily notes into a literature review, related-work section, or concentrated reading report
+      path: references/review-compilation-workflow.md

--- a/skills/nature-proposal-writer/manifest.yaml
+++ b/skills/nature-proposal-writer/manifest.yaml
@@ -1,0 +1,49 @@
+name: researchwrite
+version: 1.0.0
+description: >
+  Declarative manifest for the proposal-first scientific writing pipeline. The
+  public skill uses a compact state-machine description and loads foundation
+  templates, rubrics, and validation references only for the selected compose,
+  revise, hybrid, or QA workflow.
+
+# Design note: the installed skill name is researchwrite although the directory
+# is nature-proposal-writer. Keep this manifest aligned with the SKILL.md
+# frontmatter so `npx skills add --list` exposes the same user-facing name.
+
+always_load:
+  - SKILL.md
+
+templates:
+  on_demand:
+    - condition: initializing a new proposal project or rebuilding the foundation file set
+      path: templates/00_scope.md
+    - condition: creating or auditing the research canon of hard facts and constraints
+      path: templates/01_research_canon.md
+    - condition: mapping claims to evidence before prose drafting
+      path: templates/02_evidence_table.md
+    - condition: building the argument map before section drafting
+      path: templates/03_argument_map.md
+    - condition: defining section purposes, inputs, allowed claims, and forbidden claims
+      path: templates/04_section_contracts.md
+    - condition: setting terminology, voice, banned phrases, or anti-slop style rules
+      path: templates/05_style_guide.md
+    - condition: producing a QA report after the four-gate review pipeline
+      path: templates/qa_report.md
+    - condition: writing a targeted revision brief after a failed gate or expert review
+      path: templates/revision_brief.md
+
+references:
+  on_demand:
+    - condition: scoring a draft or proposal with the 8-dimension rubric
+      path: references/evaluation-rubric.md
+    - condition: deciding whether to continue, stop, split scope, or request more evidence
+      path: references/stopping-rules.md
+    - condition: creating or repairing the five foundation files before drafting
+      path: references/foundation-files.md
+    - condition: validating claims, citations, numbering, method reproducibility, or project completeness
+      path: references/validation-checklist.md
+
+scripts:
+  on_demand:
+    - condition: exporting a proposal package to DOCX from the generated Markdown files
+      path: scripts/build_proposal_docx.py

--- a/skills/nature-ref-verifier/manifest.yaml
+++ b/skills/nature-ref-verifier/manifest.yaml
@@ -1,0 +1,19 @@
+name: nature-ref-verifier
+version: 1.0.0
+description: >
+  Declarative manifest for the multi-source reference verification workflow.
+  SKILL.md carries the core DOI/title/source-check procedure; pattern libraries
+  are loaded only when the user needs batch diagnosis, severity examples, or
+  field-specific correction guidance.
+
+# Design note: reference verification can run on a single citation or a full
+# bibliography. Keep the default path lightweight and open pattern references
+# only for ambiguous or batch cases.
+
+always_load:
+  - SKILL.md
+
+references:
+  on_demand:
+    - condition: diagnosing recurring bibliography errors, field-level mismatch patterns, DOI/title conflicts, author-order anomalies, page-range drift, or batch report wording
+      path: references/common-patterns.md

--- a/skills/nature-reviewer/manifest.yaml
+++ b/skills/nature-reviewer/manifest.yaml
@@ -1,0 +1,30 @@
+name: nature-reviewer
+version: 1.0.0
+description: >
+  Declarative manifest for the Nature-style reviewer assessment workflow. It
+  keeps the referee-facing SKILL.md compact while loading source basis, axes,
+  domain gates, report structure, role boundaries, and QA checks only when the
+  review stage requires them.
+
+# Design note: reviewer simulation should remain grounded and non-inventive.
+# The official/local criteria and QA checks are always relevant to final reports,
+# but domain-specific gates should only load for manuscripts in covered domains.
+
+always_load:
+  - references/editorial criteria and processes.md
+  - references/source-basis.md
+
+references:
+  on_demand:
+    - condition: executing the full fact-base extraction workflow or resolving assessment order
+      path: references/reviewer-workflow.md
+    - condition: weighting originality, scientific importance, interdisciplinary readership, technical soundness, or readability
+      path: references/review-axes.md
+    - condition: manuscript is clearly in chemistry, engineering, materials, atmospheric science, climate-ecology, hydrology, or remote sensing
+      path: references/domain-specific-review-gates.md
+    - condition: composing or auditing the exact three-reviewer plus synthesis output structure
+      path: references/report-structure.md
+    - condition: preventing invented reviewer identities, editor decisions, or inappropriate reviewer-role claims
+      path: references/role-boundaries.md
+    - condition: final groundedness, non-invention, coverage, and reviewer-risk QA before delivery
+      path: references/qa-checklist.md

--- a/skills/nature-shared/manifest.yaml
+++ b/skills/nature-shared/manifest.yaml
@@ -1,0 +1,28 @@
+name: nature-shared
+version: 1.0.0
+description: >
+  Declarative manifest for shared Nature reference modules. This package is not
+  a standalone workflow; installed Nature skills use it to load exact shared
+  core or journal-format files on demand.
+
+# Design note: never preload the whole shared package. Requesting skills should
+# load only the specific file listed below and then return to their own workflow,
+# output format, and QA rules.
+
+always_load: []
+
+core:
+  on_demand:
+    - condition: shared ethics, safety, authorship, disclosure, or non-invention guardrails are needed
+      path: core/ethics.md
+    - condition: classifying paper type, article genre, or manuscript family before applying a writing/reader workflow
+      path: core/paper-type-taxonomy.md
+    - condition: shared reader workflow is explicitly requested by another Nature skill
+      path: core/reader-workflow.md
+    - condition: maintaining terminology consistency across paper reading, polishing, writing, or slide generation
+      path: core/terminology-ledger.md
+
+journal_formats:
+  on_demand:
+    - condition: formatting or checking output for Nature Communications conventions
+      path: journal-formats/nat-comms.md


### PR DESCRIPTION
## Summary

Adds `manifest.yaml` files for six Nature skills that currently have SKILL/README/reference assets but no declarative manifest:

- `nature-experiment-log`
- `nature-literature-pipeline`
- `nature-proposal-writer` (`researchwrite`)
- `nature-ref-verifier`
- `nature-reviewer`
- `nature-shared`

## Why

Several skills already use manifests to describe always-loaded files and on-demand references. These six directories were missing the same metadata layer, which makes skill indexing, installation previews, and lazy-loading behavior less consistent across the repository.

## What changed

Each new manifest documents:

- the skill name/version/description
- the intended design split
- always-loaded files, where appropriate
- on-demand references/templates/scripts with trigger conditions

For `nature-shared`, the manifest explicitly marks it as a support package rather than a standalone workflow.

## Validation

Locally validated that all manifests parse as YAML and that every referenced file exists:

```text
manifest_count 18
missing_refs 0
```

Commit author was also checked before push:

```text
lv2234 <2543679596@qq.com>
```
