### PR TITLE
docs: clarify nature-shared index behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@
 
 ## 5. 安装
 
-`nature-skills` 是一组围绕 `SKILL.md` 组织的可复用技能包。`skills/` 下的每个顶层技能目录都是一个可安装单元，例如 `nature-*`；`nature-shared` 是供其他技能读取的共享支持包。
+`nature-skills` 是一组围绕 `SKILL.md` 组织的可复用技能包。`skills/` 下的每个顶层技能目录都是一个可安装单元，例如 `nature-*`；`nature-shared` 是供其他技能读取的共享支持包，默认不作为独立触发技能计入技能索引。
 
 ### 5.1 `npx skills` 安装方式
 


### PR DESCRIPTION
Clarifies that nature-shared is support-only and not counted as a standalone triggerable skill in the index. Verified the README badge/index wording stays aligned.