### PR TITLE
docs: clarify nature-figure skill relationships

### DIFF
--- a/skills/nature-figure/README.md
+++ b/skills/nature-figure/README.md
@@ -75,3 +75,10 @@
 - `nature-statistics`：检查统计标注、n 定义和 p 值表述。
 - `nature-writing`：把图件结论放回手稿叙事。
 - `nature-paper2ppt`：把论文图件整理成汇报幻灯片。
+
+## 与其他技能的关系
+
+- 如果任务核心是统计解释、样本量定义或显著性表述，优先让 `nature-statistics` 先把文字审清，再回到 `nature-figure` 画图。
+- 如果图件已经定稿，但需要把结论组织成摘要、引言或结果段落，交给 `nature-writing` 继续承接。
+- 如果图件要直接转成组会材料或答辩汇报，再交给 `nature-paper2ppt` 组织成页面。
+- `nature-figure` 负责图件本身；它不替代统计审查，也不替代手稿叙事。

--- a/skills/nature-figure/README_EN.md
+++ b/skills/nature-figure/README_EN.md
@@ -75,3 +75,10 @@ Start with a figure contract rather than a template:
 - `nature-statistics`: check statistical annotations, n definitions, and p-value wording.
 - `nature-writing`: align figure conclusions with manuscript narrative.
 - `nature-paper2ppt`: turn manuscript figures into presentation slides.
+
+## Relationship With Other Skills
+
+- If the core task is statistical interpretation, sample-size definition, or significance wording, let `nature-statistics` audit the text before returning to `nature-figure`.
+- If the figure is finished but the user needs the claim written into an abstract, introduction, or results section, hand off to `nature-writing`.
+- If the figure should become a lab meeting deck or presentation slide, hand off to `nature-paper2ppt`.
+- `nature-figure` is responsible for the figure itself; it does not replace statistical review or manuscript narration.


### PR DESCRIPTION
## Summary

Adds a short "Relationship With Other Skills" section to `nature-figure` in both Chinese and English.

## Why

The figure skill is often used together with `nature-statistics`, `nature-writing`, and `nature-paper2ppt`. This update makes the handoff boundaries explicit so users can route tasks more cleanly.

## Validation

- Verified the Chinese and English READMEs keep the same heading count.
- Confirmed both pages still remain mirrored after the new section.
