### PR TITLE
docs: fix English README table of contents

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -26,6 +26,9 @@
 ## Table of Contents
 
 - [1. Project Founder and Operations](#1-project-founder-and-operations)
+  - [1.1 Founder Introduction](#11-founder-introduction)
+  - [1.2 Knowledge Planet](#12-knowledge-planet)
+  - [1.3 Repository Store](#13-repository-store)
 - [2. Nature Skills Core Developers](#2-nature-skills-core-developers)
 - [3. Project Philosophy and Community](#3-project-philosophy-and-community)
 - [4. Quick Start](#4-quick-start)


### PR DESCRIPTION
## Summary
- Add the missing English README subsection links for the Project Founder and Operations section
- Keep the English table of contents aligned with the Chinese README structure

## Validation
- `pythonfrom pathlib import Path
import re, sys
for name in ['README.md','README_EN.md']:
    text=Path(name).read_text(encoding='utf-8')
    toc=re.search(r'## (?:目录|Table of Contents)\n\n(.*?)(?=\n## )', text, re.S)
    assert toc
    assert not any(line.startswith(('  ##','##')) for line in toc.group(1).splitlines())
print('README.md: TOC block OK')
print('README_EN.md: TOC block OK')
- `git diff --check