### PR TITLE
ci: serialize star history updates

### DIFF
--- a/.github/workflows/update-star-history.yml
+++ b/.github/workflows/update-star-history.yml
@@ -9,9 +9,14 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: update-star-history-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update-star-history:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add a workflow-level concurrency group for the scheduled star-history updater.
- Cancel older in-progress runs on the same ref so manual dispatches and scheduled runs cannot race to push generated README/SVG updates.

## Validation
- git diff --check
- Parsed .github/workflows/update-star-history.yml with PyYAML and verified the concurrency block plus ubuntu-latest job runner.

## Duplicate check
- Checked open PRs by zpf2234 before creating this PR; no existing star-history concurrency PR was open.