### PR TITLE
docs: sync skill count to 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <p>
     <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-2ea44f"></a>
     <a href="#5-安装"><img alt="Install" src="https://img.shields.io/badge/install-Claude%20Code%20%7C%20Codex%20%7C%20OpenClaw%20%7C%20OpenCode%20%7C%20Hermes-111827"></a>
-    <a href="#6-技能索引"><img alt="Skills" src="https://img.shields.io/badge/skills-17-0ea5e9"></a>
+    <a href="#6-技能索引"><img alt="Skills" src="https://img.shields.io/badge/skills-18-0ea5e9"></a>
     <a href="README_EN.md"><img alt="Language" src="https://img.shields.io/badge/language-中文%20%7C%20English-1f6feb"></a>
   </p>
   <p>

--- a/README_EN.md
+++ b/README_EN.md
@@ -5,7 +5,7 @@
   <p>
     <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-2ea44f"></a>
     <a href="#5-installation"><img alt="Install" src="https://img.shields.io/badge/install-Claude%20Code%20%7C%20Codex%20%7C%20OpenClaw%20%7C%20OpenCode%20%7C%20Hermes-111827"></a>
-    <a href="#6-skill-index"><img alt="Skills" src="https://img.shields.io/badge/skills-17-0ea5e9"></a>
+    <a href="#6-skill-index"><img alt="Skills" src="https://img.shields.io/badge/skills-18-0ea5e9"></a>
     <a href="README.md"><img alt="Language" src="https://img.shields.io/badge/language-English%20%7C%20中文-1f6feb"></a>
   </p>
   <p>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title data-i18n="pageTitle">Nature Skills — 面向全球学者的 AI 科研技能库</title>
-<meta name="description" data-i18n="pageDesc" data-i18n-attrs="content" content="Nature Skills 收录 17 个可复用 AI 科研技能，覆盖论文阅读、学术写作、审稿模拟、科研绘图、专利生成、文献检索等全流程。">
+<meta name="description" data-i18n="pageDesc" data-i18n-attrs="content" content="Nature Skills 收录 18 个可复用 AI 科研技能，覆盖论文阅读、学术写作、审稿模拟、科研绘图、专利生成、文献检索等全流程。">
 <meta name="color-scheme" content="light dark">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -1514,7 +1514,7 @@ h3 { font-size: var(--fs-h3); }
   <div class="hero__content">
     <div class="hero__badge">
       <span class="hero__badge-dot"></span>
-      <span data-i18n="heroBadge">17 个可复用技能 · 5 大平台支持</span>
+      <span data-i18n="heroBadge">18 个可复用技能 · 5 大平台支持</span>
     </div>
     <h1 class="hero__title" data-i18n-html="heroTitle">
       让 AI 成为<br>你的<em>科研伙伴</em>
@@ -1528,7 +1528,7 @@ h3 { font-size: var(--fs-h3); }
     </div>
     <div class="hero__stats">
       <div>
-        <div class="hero__stat-value">17</div>
+        <div class="hero__stat-value">18</div>
         <div class="hero__stat-label" data-i18n="heroStat1Label">科研技能</div>
       </div>
       <div>
@@ -1587,7 +1587,7 @@ h3 { font-size: var(--fs-h3); }
   <div class="container">
     <div class="skills__header">
       <span class="section-label" data-i18n="skillsLabel">技能索引</span>
-      <h2 data-i18n="skillsTitle">覆盖科研全流程的 17 个技能</h2>
+      <h2 data-i18n="skillsTitle">覆盖科研全流程的 18 个技能</h2>
       <p data-i18n="skillsDesc">从文献阅读到论文发表，每个环节都有对应的 AI 技能包。点击分类筛选，找到你需要的技能。</p>
     </div>
 
@@ -1775,7 +1775,7 @@ h3 { font-size: var(--fs-h3); }
 <section class="cta-banner">
   <div class="container">
     <h2 data-i18n="ctaTitle">准备好改变你的科研方式了吗？</h2>
-    <p data-i18n="ctaDesc">从 17 个技能中选择，或把整个技能库装进你的 AI Agent。</p>
+    <p data-i18n="ctaDesc">从 18 个技能中选择，或把整个技能库装进你的 AI Agent。</p>
     <div class="cta-banner__actions">
       <a href="#install" class="hero__btn hero__btn--primary" data-i18n="ctaBtnPrimary">开始安装</a>
       <a href="https://github.com/Yuan1z0825/nature-skills" class="hero__btn hero__btn--secondary" target="_blank" rel="noopener" data-i18n="ctaBtnSecondary">GitHub →</a>
@@ -1803,7 +1803,7 @@ h3 { font-size: var(--fs-h3); }
 const i18n = {
   zh: {
     pageTitle: 'Nature Skills — 面向全球学者的 AI 科研技能库',
-    pageDesc: 'Nature Skills 收录 17 个可复用 AI 科研技能，覆盖论文阅读、学术写作、审稿模拟、科研绘图、专利生成、文献检索等全流程。',
+    pageDesc: 'Nature Skills 收录 18 个可复用 AI 科研技能，覆盖论文阅读、学术写作、审稿模拟、科研绘图、专利生成、文献检索等全流程。',
 
     langLabel: 'EN',
 
@@ -1813,7 +1813,7 @@ const i18n = {
     navPhilosophy: '设计哲学',
     navGitHub: 'GitHub',
 
-    heroBadge: '17 个可复用技能 · 5 大平台支持',
+    heroBadge: '18 个可复用技能 · 5 大平台支持',
     heroTitle: '让 AI 成为<br>你的<em>科研伙伴</em>',
     heroSubtitle: 'Nature Skills 是为全球学者构建的 AI 科研技能库。从论文阅读、学术写作到审稿模拟、专利生成——每一步都有可复用的智能技能包。',
     heroBtnPrimary: '开始安装',
@@ -1834,7 +1834,7 @@ const i18n = {
     philosophyCard3Desc: '一手来源驱动、显式胜过隐式、输出优先——每个技能都返回能直接使用的产物，而非泛泛建议。',
 
     skillsLabel: '技能索引',
-    skillsTitle: '覆盖科研全流程的 17 个技能',
+    skillsTitle: '覆盖科研全流程的 18 个技能',
     skillsDesc: '从文献阅读到论文发表，每个环节都有对应的 AI 技能包。点击分类筛选，找到你需要的技能。',
     catAll: '全部',
     catReading: '📖 阅读与翻译',
@@ -1894,7 +1894,7 @@ const i18n = {
     community3Btn: 'Star on GitHub',
 
     ctaTitle: '准备好改变你的科研方式了吗？',
-    ctaDesc: '从 17 个技能中选择，或把整个技能库装进你的 AI Agent。',
+    ctaDesc: '从 18 个技能中选择，或把整个技能库装进你的 AI Agent。',
     ctaBtnPrimary: '开始安装',
     ctaBtnSecondary: 'GitHub →',
 
@@ -1961,7 +1961,7 @@ const i18n = {
 
   en: {
     pageTitle: 'Nature Skills — AI Research Skills for Global Scholars',
-    pageDesc: 'Nature Skills: 17 reusable AI research skills covering paper reading, academic writing, reviewer simulation, scientific plotting, patent drafting, and literature search.',
+    pageDesc: 'Nature Skills: 18 reusable AI research skills covering paper reading, academic writing, reviewer simulation, scientific plotting, patent drafting, and literature search.',
 
     langLabel: '中文',
 
@@ -1971,7 +1971,7 @@ const i18n = {
     navPhilosophy: 'Philosophy',
     navGitHub: 'GitHub',
 
-    heroBadge: '17 Reusable Skills · 5 Platform Support',
+    heroBadge: '18 Reusable Skills · 5 Platform Support',
     heroTitle: 'Make AI Your<br><em>Research Partner</em>',
     heroSubtitle: 'Nature Skills is an AI research skill library built for global scholars. From paper reading and academic writing to reviewer simulation and patent drafting — every step has a reusable intelligent skill pack.',
     heroBtnPrimary: 'Get Started',
@@ -1992,7 +1992,7 @@ const i18n = {
     philosophyCard3Desc: 'Primary-source driven, explicit over implicit, output-first — every skill returns immediately usable artifacts, not vague suggestions.',
 
     skillsLabel: 'Skill Index',
-    skillsTitle: '17 Skills Covering the Full Research Pipeline',
+    skillsTitle: '18 Skills Covering the Full Research Pipeline',
     skillsDesc: 'From literature reading to paper publication, every stage has a corresponding AI skill pack. Click to filter by category.',
     catAll: 'All',
     catReading: '📖 Reading & Translation',
@@ -2052,7 +2052,7 @@ const i18n = {
     community3Btn: 'Star on GitHub',
 
     ctaTitle: 'Ready to Transform Your Research?',
-    ctaDesc: 'Choose from 17 skills, or load the entire skill library into your AI agent.',
+    ctaDesc: 'Choose from 18 skills, or load the entire skill library into your AI agent.',
     ctaBtnPrimary: 'Get Started',
     ctaBtnSecondary: 'GitHub →',
 


### PR DESCRIPTION
## Summary
- Updates README and README_EN skill-count badges from 17 to 18.
- Updates the landing page visible copy, meta description, and Chinese/English i18n strings to match the 18 skill directories currently present.

## Validation
- Counted `skills/*/SKILL.md` directories and verified the total is 18.
- Verified `README.md`, `README_EN.md`, and `index.html` no longer contain stale `skills-17` / 17-skill marketing text.
- Ran `git diff --check`.