### PR TITLE
ci: add repository metadata validation

### DIFF
--- a/.github/workflows/validate-repository.yml
+++ b/.github/workflows/validate-repository.yml
@@ -1,0 +1,25 @@
+name: Validate repository metadata
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  validate-repository:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run repository validation
+        run: python3 scripts/validate-repository.py

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <p>
     <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-2ea44f"></a>
     <a href="#5-安装"><img alt="Install" src="https://img.shields.io/badge/install-Claude%20Code%20%7C%20Codex%20%7C%20OpenClaw%20%7C%20OpenCode%20%7C%20Hermes-111827"></a>
-    <a href="#6-技能索引"><img alt="Skills" src="https://img.shields.io/badge/skills-17-0ea5e9"></a>
+    <a href="#6-技能索引"><img alt="Skills" src="https://img.shields.io/badge/skills-18-0ea5e9"></a>
     <a href="README_EN.md"><img alt="Language" src="https://img.shields.io/badge/language-中文%20%7C%20English-1f6feb"></a>
   </p>
   <p>

--- a/README_EN.md
+++ b/README_EN.md
@@ -5,7 +5,7 @@
   <p>
     <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-2ea44f"></a>
     <a href="#5-installation"><img alt="Install" src="https://img.shields.io/badge/install-Claude%20Code%20%7C%20Codex%20%7C%20OpenClaw%20%7C%20OpenCode%20%7C%20Hermes-111827"></a>
-    <a href="#6-skill-index"><img alt="Skills" src="https://img.shields.io/badge/skills-17-0ea5e9"></a>
+    <a href="#6-skill-index"><img alt="Skills" src="https://img.shields.io/badge/skills-18-0ea5e9"></a>
     <a href="README.md"><img alt="Language" src="https://img.shields.io/badge/language-English%20%7C%20中文-1f6feb"></a>
   </p>
   <p>

--- a/scripts/validate-repository.py
+++ b/scripts/validate-repository.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Validate repository-level Nature Skills metadata and README consistency.
+
+This lightweight check intentionally avoids optional runtime dependencies. It is
+safe to run locally and in CI to catch stale skill counts, broken README index
+links, and missing per-skill metadata before a documentation or skill change is
+merged.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+from dataclasses import dataclass
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SKILLS_DIR = ROOT / "skills"
+README_FILES = (ROOT / "README.md", ROOT / "README_EN.md")
+SKILL_LINK_RE = re.compile(r"\[`(nature-[^`]+)`\]\(skills/([^/)]+)/README(?:_EN)?\.md\)")
+BADGE_RE = re.compile(r"badge/skills-(\d+)-")
+EXCLUDED_INDEX_DIRS = {"nature-shared"}
+EXCLUDED_LINK_DIRS = {"nature-shared", "nature-<topic>"}
+
+
+@dataclass
+class ValidationError:
+    path: pathlib.Path
+    message: str
+
+    def __str__(self) -> str:
+        rel = self.path.relative_to(ROOT) if self.path.is_absolute() else self.path
+        return f"{rel}: {self.message}"
+
+
+def skill_dirs() -> list[pathlib.Path]:
+    return sorted(path for path in SKILLS_DIR.iterdir() if path.is_dir())
+
+
+def validate_skill_layout(skills: list[pathlib.Path]) -> list[ValidationError]:
+    errors: list[ValidationError] = []
+    required_files = ("SKILL.md", "README.md", "README_EN.md", "manifest.yaml")
+    for skill in skills:
+        for filename in required_files:
+            if not (skill / filename).is_file():
+                errors.append(ValidationError(skill, f"missing required file {filename}"))
+    return errors
+
+
+def validate_readme(readme: pathlib.Path, skills: list[pathlib.Path]) -> list[ValidationError]:
+    errors: list[ValidationError] = []
+    text = readme.read_text(encoding="utf-8")
+    expected = {path.name for path in skills if path.name not in EXCLUDED_INDEX_DIRS}
+
+    badges = BADGE_RE.findall(text)
+    if not badges:
+        errors.append(ValidationError(readme, "missing skills count badge"))
+    elif int(badges[0]) != len(skills):
+        errors.append(
+            ValidationError(
+                readme,
+                f"skills badge says {badges[0]}, but skills/ contains {len(skills)} directories",
+            )
+        )
+
+    linked = {
+        match.group(2)
+        for match in SKILL_LINK_RE.finditer(text)
+        if match.group(2) not in EXCLUDED_LINK_DIRS
+    }
+    missing = sorted(expected - linked)
+    extra = sorted(linked - expected)
+    if missing:
+        errors.append(ValidationError(readme, "skill index missing: " + ", ".join(missing)))
+    if extra:
+        errors.append(ValidationError(readme, "skill index references unknown dirs: " + ", ".join(extra)))
+
+    broken = []
+    for _label, dirname in SKILL_LINK_RE.findall(text):
+        if dirname in EXCLUDED_LINK_DIRS:
+            continue
+        if not (ROOT / "skills" / dirname / "README.md").is_file():
+            broken.append(dirname)
+    if broken:
+        errors.append(ValidationError(readme, "broken skill README links: " + ", ".join(sorted(set(broken)))))
+
+    return errors
+
+
+def main() -> int:
+    if not SKILLS_DIR.is_dir():
+        print(f"ERROR: skills directory not found: {SKILLS_DIR}", file=sys.stderr)
+        return 1
+
+    skills = skill_dirs()
+    errors = validate_skill_layout(skills)
+    for readme in README_FILES:
+        if readme.is_file():
+            errors.extend(validate_readme(readme, skills))
+        else:
+            errors.append(ValidationError(readme, "README file is missing"))
+
+    if errors:
+        print("Repository validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print(f"Repository validation passed: {len(skills)} skill directories checked.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a small repository validation script for skill counts and README index consistency
- add a CI workflow to run the validation on pushes and pull requests
- sync both README skill badges to 18

## Validation
- python scripts/validate-repository.py
- python -m py_compile scripts/validate-repository.py

## Notes
- keeps Nature Skills metadata healthier and catches README/index drift early