### PR TITLE
fix: validate autoupdate throttle value

### DIFF
--- a/scripts/autoupdate-skills.sh
+++ b/scripts/autoupdate-skills.sh
@@ -56,6 +56,13 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
+case "$THROTTLE" in
+  ''|*[!0-9]*)
+    echo "autoupdate-skills.sh: --throttle must be a non-negative integer" >&2
+    exit 2
+    ;;
+esac
+
 mkdir -p "$STATE_DIR" 2>/dev/null || true
 log() { printf '%s %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$*" >>"$LOG" 2>/dev/null; }
 


### PR DESCRIPTION
## Summary
- Validate SKILLS_THROTTLE / --throttle before numeric comparisons in autoupdate-skills.sh
- Return a clear usage error instead of letting shell integer comparison errors leak through hooks

## Test Plan
- bash -n scripts/autoupdate-skills.sh
- scripts/autoupdate-skills.sh --help >/tmp/autoupdate-help.txt
- SKILLS_THROTTLE=abc scripts/autoupdate-skills.sh exits with code 2 and prints the validation message