### PR TITLE
fix: accept equals form for --dest

### DIFF
--- a/scripts/update-codex-skills.sh
+++ b/scripts/update-codex-skills.sh
@@ -77,6 +77,9 @@ while [ "$#" -gt 0 ]; do
       [ "$#" -gt 0 ] || die "--dest requires a directory"
       DST="$1"
       ;;
+    --dest=*)
+      DST="${1#*=}"
+      ;;
     --help|-h)
       usage
       exit 0


### PR DESCRIPTION
## Summary\n- Allow scripts/update-codex-skills.sh to accept --dest=/path in addition to --dest /path.\n- Keeps the documented destination override working with shell-friendly equals syntax.\n\n## Validation\n- bash -n scripts/update-codex-skills.sh\n- ./scripts/update-codex-skills.sh --help\n- End-to-end check against a prepared temp install tree: 18/18 skills matched\n\n## Notes\n- Small, reviewable shell-only fix.\n