### PR TITLE
chore: validate skill manifest presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <p>
     <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-2ea44f"></a>
     <a href="#5-安装"><img alt="Install" src="https://img.shields.io/badge/install-Claude%20Code%20%7C%20Codex%20%7C%20OpenClaw%20%7C%20OpenCode%20%7C%20Hermes-111827"></a>
-    <a href="#6-技能索引"><img alt="Skills" src="https://img.shields.io/badge/skills-18-0ea5e9"></a>
+    <a href="#6-技能索引"><img alt="Skills" src="https://img.shields.io/badge/skills-17-0ea5e9"></a>
     <a href="README_EN.md"><img alt="Language" src="https://img.shields.io/badge/language-中文%20%7C%20English-1f6feb"></a>
   </p>
   <p>

--- a/README_EN.md
+++ b/README_EN.md
@@ -5,7 +5,7 @@
   <p>
     <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-2ea44f"></a>
     <a href="#5-installation"><img alt="Install" src="https://img.shields.io/badge/install-Claude%20Code%20%7C%20Codex%20%7C%20OpenClaw%20%7C%20OpenCode%20%7C%20Hermes-111827"></a>
-    <a href="#6-skill-index"><img alt="Skills" src="https://img.shields.io/badge/skills-18-0ea5e9"></a>
+    <a href="#6-skill-index"><img alt="Skills" src="https://img.shields.io/badge/skills-17-0ea5e9"></a>
     <a href="README.md"><img alt="Language" src="https://img.shields.io/badge/language-English%20%7C%20中文-1f6feb"></a>
   </p>
   <p>

--- a/scripts/validate-readmes.py
+++ b/scripts/validate-readmes.py
@@ -56,13 +56,16 @@ def validate_top_readmes(triggerable_skill_count: int) -> None:
 def validate_skill_readmes(skill_dirs: list[Path]) -> None:
     for skill_dir in skill_dirs:
         name = skill_dir.name
+        manifest = skill_dir / "manifest.yaml"
         readme = skill_dir / "README.md"
         readme_en = skill_dir / "README_EN.md"
+        if not manifest.is_file():
+            fail(f"{name} is missing manifest.yaml")
         if not readme.is_file():
             fail(f"{name} is missing README.md")
         if not readme_en.is_file():
             fail(f"{name} is missing README_EN.md")
-        print(f"ok: {name} includes README.md and README_EN.md")
+        print(f"ok: {name} includes manifest.yaml, README.md, and README_EN.md")
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary
- Require every installed skill directory to include manifest.yaml in the README validation script
- Keep the root README skill-count badges aligned with the current 17 triggerable skills

## Validation
- ok: README.md badge and index count = 17
ok: README_EN.md badge and index count = 17
ok: nature-academic-search includes manifest.yaml, README.md, and README_EN.md
ok: nature-citation includes manifest.yaml, README.md, and README_EN.md
ok: nature-data includes manifest.yaml, README.md, and README_EN.md
ok: nature-downloader includes manifest.yaml, README.md, and README_EN.md
ok: nature-experiment-log includes manifest.yaml, README.md, and README_EN.md
ok: nature-figure includes manifest.yaml, README.md, and README_EN.md
ok: nature-literature-pipeline includes manifest.yaml, README.md, and README_EN.md
ok: nature-paper-to-patent includes manifest.yaml, README.md, and README_EN.md
ok: nature-paper2ppt includes manifest.yaml, README.md, and README_EN.md
ok: nature-polishing includes manifest.yaml, README.md, and README_EN.md
ok: nature-proposal-writer includes manifest.yaml, README.md, and README_EN.md
ok: nature-reader includes manifest.yaml, README.md, and README_EN.md
ok: nature-ref-verifier includes manifest.yaml, README.md, and README_EN.md
ok: nature-response includes manifest.yaml, README.md, and README_EN.md
ok: nature-reviewer includes manifest.yaml, README.md, and README_EN.md
ok: nature-shared includes manifest.yaml, README.md, and README_EN.md
ok: nature-statistics includes manifest.yaml, README.md, and README_EN.md
ok: nature-writing includes manifest.yaml, README.md, and README_EN.md
README validation passed.

## Notes
- Scope is small and reviewable: documentation/validation only