### PR TITLE
ci: validate README mirror consistency

### DIFF
--- a/.github/workflows/validate-readme-mirror.yml
+++ b/.github/workflows/validate-readme-mirror.yml
@@ -1,0 +1,36 @@
+name: Validate README mirrors
+
+on:
+  pull_request:
+    paths:
+      - 'skills/**/README.md'
+      - 'skills/**/README_EN.md'
+      - 'scripts/validate-readme-mirror.py'
+      - '.github/workflows/validate-readme-mirror.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'skills/**/README.md'
+      - 'skills/**/README_EN.md'
+      - 'scripts/validate-readme-mirror.py'
+      - '.github/workflows/validate-readme-mirror.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-readme-mirrors:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run README mirror validator
+        run: python scripts/validate-readme-mirror.py


### PR DESCRIPTION
## Summary\n- Add a dedicated workflow that runs the existing README mirror validator when README pairs change\n- Keep README mirror checks separately observable from the broader repository validation job\n\n## Validation\n- python -m py_compile scripts/validate-readme-mirror.py\n- python scripts/validate-repository.py\n- python scripts/validate-skill-index.py\n- python scripts/validate-readme-mirror.py\n\n## Notes\n- Small, reviewable CI-only change