### PR TITLE
fix: exclude internal package from skill badge count

### DIFF
--- a/scripts/validate-repository.py
+++ b/scripts/validate-repository.py
@@ -72,15 +72,16 @@ def validate_readme(readme: pathlib.Path, skills: list[pathlib.Path]) -> list[Va
     errors: list[ValidationError] = []
     text = readme.read_text(encoding="utf-8")
     expected = {path.name for path in skills if path.name not in EXCLUDED_INDEX_DIRS}
+    expected_badge_count = len(expected)
 
     badges = BADGE_RE.findall(text)
     if not badges:
         errors.append(ValidationError(readme, "missing skills count badge"))
-    elif int(badges[0]) != len(skills):
+    elif int(badges[0]) != expected_badge_count:
         errors.append(
             ValidationError(
                 readme,
-                f"skills badge says {badges[0]}, but skills/ contains {len(skills)} directories",
+                f"skills badge says {badges[0]}, but {expected_badge_count} public skills are indexed",
             )
         )
 


### PR DESCRIPTION
## 问题

Validate repository metadata 将 skills 目录下全部 18 个目录用于校验 README 徽章，但 nature-shared 是内部共享支持包，已被技能索引逻辑排除。公开技能数量应保持为 17，因此 main 出现红叉。

## 修复

- 使用已经排除内部包的公开技能集合计算徽章数量
- 保持 README 和 README_EN 的公开技能数量为 17
- 改进错误信息，明确校验的是公开索引技能

## 验证

- validate-repository.py：通过（18 个目录，17 个公开技能）
- validate-skill-index.py：通过
- validate-readmes.py：通过
- validate-readme-mirror.py：通过
- 仅修改 scripts/validate-repository.py