### PR TITLE
ci: validate workflow path filters

### DIFF
--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -1,0 +1,33 @@
+name: Validate workflow path filters
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - 'scripts/validate-workflows.py'
+  push:
+    paths:
+      - '.github/workflows/**'
+      - 'scripts/validate-workflows.py'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-workflows:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install PyYAML
+        run: python -m pip install pyyaml
+
+      - name: Run workflow validator
+        run: python scripts/validate-workflows.py

--- a/scripts/validate-workflows.py
+++ b/scripts/validate-workflows.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Validate GitHub Actions workflow triggers for repository health checks.
+
+The repository has several focused validators with `paths` filters so routine
+skill edits only run the relevant CI jobs. This check keeps those filters honest:
+if a workflow runs a local validation script, changes to that script must be in
+both pull_request and push path filters. Otherwise a broken validator can be
+edited without triggering its own CI job.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError as exc:  # pragma: no cover - developer environment guard
+    raise SystemExit("Missing dependency: PyYAML. Install with `python -m pip install pyyaml`.") from exc
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS_DIR = ROOT / ".github" / "workflows"
+LOCAL_SCRIPT_RE = re.compile(r"\b(?:python3?|bash|sh)\s+(scripts/[\w./-]+)")
+
+
+def read_workflow(path: Path) -> dict[str, Any]:
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+def workflow_events(workflow: dict[str, Any]) -> dict[str, Any]:
+    # PyYAML 1.1 treats the key `on` as a boolean unless a custom loader is used.
+    # Accept both forms so the validator remains portable across environments.
+    events = workflow.get("on", workflow.get(True, {}))
+    return events if isinstance(events, dict) else {}
+
+
+def normalized_paths(event_config: Any) -> set[str] | None:
+    if not isinstance(event_config, dict):
+        return None
+    paths = event_config.get("paths")
+    if paths is None:
+        return None
+    if not isinstance(paths, list):
+        return set()
+    return {str(item) for item in paths}
+
+
+def local_scripts_from_run_steps(workflow: dict[str, Any]) -> set[str]:
+    scripts: set[str] = set()
+    jobs = workflow.get("jobs", {})
+    if not isinstance(jobs, dict):
+        return scripts
+    for job in jobs.values():
+        if not isinstance(job, dict):
+            continue
+        steps = job.get("steps", [])
+        if not isinstance(steps, list):
+            continue
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            run = step.get("run")
+            if not isinstance(run, str):
+                continue
+            scripts.update(LOCAL_SCRIPT_RE.findall(run))
+    return scripts
+
+
+def validate_workflow(path: Path) -> list[str]:
+    workflow = read_workflow(path)
+    scripts = local_scripts_from_run_steps(workflow)
+    if not scripts:
+        return []
+
+    errors: list[str] = []
+    events = workflow_events(workflow)
+    for event_name in ("pull_request", "push"):
+        paths = normalized_paths(events.get(event_name))
+        if paths is None:
+            continue
+        missing = sorted(script for script in scripts if script not in paths)
+        if missing:
+            errors.append(
+                f"{path.relative_to(ROOT)}: {event_name}.paths missing "
+                + ", ".join(missing)
+            )
+    return errors
+
+
+def main() -> int:
+    if not WORKFLOWS_DIR.is_dir():
+        print(f"ERROR: workflow directory not found: {WORKFLOWS_DIR}", file=sys.stderr)
+        return 1
+
+    errors: list[str] = []
+    workflows = sorted(WORKFLOWS_DIR.glob("*.yml")) + sorted(WORKFLOWS_DIR.glob("*.yaml"))
+    for path in workflows:
+        errors.extend(validate_workflow(path))
+
+    if errors:
+        print("Workflow validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print(f"Workflow validation passed: {len(workflows)} workflow files checked.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a workflow validator that checks GitHub Actions path filters include local validation scripts they execute.
- Add CI coverage for workflow files and the validator itself so workflow-trigger drift is caught in PRs.
- Handle PyYAML's legacy parsing of the `on` key for portable local/CI execution.

## Test Plan
- `python scripts/validate-workflows.py`
- `python -m py_compile scripts/validate-workflows.py`
- `python scripts/validate-repository.py`
- `python scripts/validate-skill-index.py`
- `python scripts/validate-readme-mirror.py`
- `python scripts/validate-readmes.py`
- `python scripts/validate-skill-metadata.py`
