### PR TITLE
ci: scope repository validation triggers

### DIFF
--- a/.github/workflows/validate-repository.yml
+++ b/.github/workflows/validate-repository.yml
@@ -2,9 +2,29 @@ name: Validate repository metadata
 
 on:
   pull_request:
+    paths:
+      - 'README.md'
+      - 'README_EN.md'
+      - 'skills/**'
+      - 'scripts/validate-repository.py'
+      - 'scripts/validate-readmes.py'
+      - 'scripts/validate-readme-mirror.py'
+      - 'scripts/validate-skill-index.py'
+      - 'scripts/validate-skill-metadata.py'
+      - '.github/workflows/validate-repository.yml'
   push:
     branches:
       - main
+    paths:
+      - 'README.md'
+      - 'README_EN.md'
+      - 'skills/**'
+      - 'scripts/validate-repository.py'
+      - 'scripts/validate-readmes.py'
+      - 'scripts/validate-readme-mirror.py'
+      - 'scripts/validate-skill-index.py'
+      - 'scripts/validate-skill-metadata.py'
+      - '.github/workflows/validate-repository.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Scope repository validation workflow triggers to the files the job actually checks
- Keep README, skill, validator, and workflow edits covered on PRs and main pushes

## Validation
- python - <<'PY' ... workflow YAML parsed with BaseLoader
- python scripts/validate-repository.py
- python scripts/validate-readmes.py
- python scripts/validate-readme-mirror.py
- python scripts/validate-skill-index.py
