### PR TITLE
ci: validate skill index on skill changes

### DIFF
--- a/.github/workflows/validate-skill-index.yml
+++ b/.github/workflows/validate-skill-index.yml
@@ -3,11 +3,15 @@ name: Validate skill index
 on:
   pull_request:
     paths:
+      - 'skills/**'
       - 'README.md'
       - 'README_EN.md'
       - 'scripts/validate-skill-index.py'
   push:
+    branches:
+      - main
     paths:
+      - 'skills/**'
       - 'README.md'
       - 'README_EN.md'
       - 'scripts/validate-skill-index.py'


### PR DESCRIPTION
## Summary

Keeps the skill-index CI check in sync with skill directory changes, not only README/script edits.

## What changed

- Runs `validate-skill-index.yml` when files under `skills/**` change.
- Restricts push-triggered runs to the `main` branch, matching the repository validation workflow and avoiding unnecessary branch pushes.

## Validation

- `python scripts/validate-repository.py`
- `python scripts/validate-readmes.py`
- `python scripts/validate-readme-mirror.py`
- `python scripts/validate-skill-index.py`
- `python scripts/validate-skill-metadata.py`
- Parsed `.github/workflows/validate-skill-index.yml` with PyYAML and asserted the new `skills/**` paths and `main` push branch filter.