### PR TITLE
Add MiniMax image_generation route to nature-figure schematic workflow

### DIFF
--- a/skills/nature-figure/SKILL.md
+++ b/skills/nature-figure/SKILL.md
@@ -19,7 +19,7 @@ Follow these steps every time the skill is invoked.
 
 ### 0. Check for the OpenRouter AI-schematic route
 
-If the user explicitly asks to generate a manuscript schematic, graphical abstract, mechanism diagram, concept illustration, or paper schematic with OpenRouter, GPT Image 2, an image-generation API, or similar wording, do **not** ask "Python or R?". This is a non-plotting AI-schematic route.
+If the user explicitly asks to generate a manuscript schematic, graphical abstract, mechanism diagram, concept illustration, or paper schematic with OpenRouter, GPT Image 2, the MiniMax image_generation API (image-01 / image-01-live), an image-generation API, or similar wording, do **not** ask "Python or R?". This is a non-plotting AI-schematic route.
 
 For this route:
 
@@ -28,7 +28,9 @@ For this route:
 3. Use [scripts/generate_openrouter_schematic.py](scripts/generate_openrouter_schematic.py) when the user wants a real API call or a reproducible payload.
 4. Treat output as a draft schematic / graphical abstract, not as a quantitative data panel. Do not invent experimental values, author logos, institutional marks, or unsupported mechanisms.
 
-Only continue to the Python/R backend gate for plotting, charting, data visualization, or manuscript figure assembly tasks that are not explicit OpenRouter AI image-generation requests.
+If the user instead asks for the MiniMax image_generation API (image-01 / image-01-live, global `api.minimax.io` or China `api.minimaxi.com` endpoint), follow the same non-plotting route but read [references/minimax-image-generation.md](references/minimax-image-generation.md) and use [scripts/generate_minimax_schematic.py](scripts/generate_minimax_schematic.py).
+
+Only continue to the Python/R backend gate for plotting, charting, data visualization, or manuscript figure assembly tasks that are not explicit AI image-generation requests.
 
 ### 1. Load the manifest and the core layer
 

--- a/skills/nature-figure/manifest.yaml
+++ b/skills/nature-figure/manifest.yaml
@@ -23,6 +23,17 @@ routes:
       image draft through an external image API rather than plotting data.
     reference: references/openrouter-image-generation.md
     script: scripts/generate_openrouter_schematic.py
+  minimax_image_generation:
+    detect: |
+      Use this route only when the user explicitly asks for the MiniMax
+      image_generation API, image-01 / image-01-live, AI-generated paper
+      schematics, graphical abstracts, concept illustrations, or mechanism
+      diagrams through that route. It skips the Python/R backend gate because it
+      generates a raster image draft through an external image API rather than
+      plotting data. Choose the global (api.minimax.io) or China
+      (api.minimaxi.com) endpoint to match the account.
+    reference: references/minimax-image-generation.md
+    script: scripts/generate_minimax_schematic.py
 
 preference:
   backend_script: scripts/nature_figure_backend.py
@@ -75,6 +86,8 @@ references:
       path: references/nature-2026-observations.md
     - condition: "OpenRouter/GPT Image 2 route: AI-generated graphical abstracts, mechanism diagrams, paper schematics, or concept illustrations"
       path: references/openrouter-image-generation.md
+    - condition: "MiniMax image_generation route (image-01 / image-01-live, global or China endpoint): AI-generated graphical abstracts, mechanism diagrams, paper schematics, or concept illustrations"
+      path: references/minimax-image-generation.md
     - condition: writing or auditing figure/table legend text — Fig. N | title, panel style, stats in legend, Source Data boilerplate, attribution
       path: references/figure-legend-conventions.md
     - condition: "end-to-end walkthroughs: bars, trends, heatmaps"

--- a/skills/nature-figure/references/minimax-image-generation.md
+++ b/skills/nature-figure/references/minimax-image-generation.md
@@ -1,0 +1,127 @@
+# MiniMax Image Generation for Manuscript Schematics
+
+Use this reference only when the user explicitly asks to generate a paper schematic, graphical abstract, mechanism diagram, or concept illustration through the MiniMax image_generation API.
+
+Do not use this route for quantitative plots, data panels, heatmaps, microscopy plates, blots, or figure assembly unless the user explicitly wants an AI-generated draft illustration. Keep data-driven figures in the Python or R route.
+
+## Source
+
+MiniMax exposes text-to-image generation at:
+
+- generation: `POST /v1/image_generation`
+- global endpoint: `https://api.minimax.io/v1/image_generation`
+- China endpoint: `https://api.minimaxi.com/v1/image_generation`
+- models: `image-01` (default) and `image-01-live`
+
+Authentication uses a bearer token read from `MINIMAX_API_KEY`. Pick the endpoint that matches your account with `--region global` (api.minimax.io) or `--region cn` (api.minimaxi.com).
+
+## Request fields
+
+`model` and `prompt` are required. The prompt supports up to 1500 characters. Supported optional fields:
+
+- `aspect_ratio`: one of `1:1`, `16:9`, `4:3`, `3:2`, `2:3`, `3:4`, `9:16`, `21:9` (default `1:1`).
+- `width` / `height`: pixels in `[512, 2048]`, each divisible by 8, and set together. Effective for `image-01`. When both `width`/`height` and `aspect_ratio` are supplied, `aspect_ratio` takes priority.
+- `response_format`: `url` (default) or `base64`.
+- `seed`: fixed integer seed for reproducible images.
+- `n`: number of images per request, range `[1, 9]`.
+- `prompt_optimizer`: boolean; let the service rewrite the prompt automatically.
+
+## Response fields
+
+- `data.image_urls`: array of image links when `response_format=url`. Links expire 24 hours after generation.
+- `data.image_base64`: array of base64-encoded images when `response_format=base64`.
+- `metadata.success_count` / `metadata.failed_count`: images generated versus blocked for content safety.
+- `base_resp.status_code`: `0` on success; non-zero values (for example `1026` sensitive content, `1002` rate limited, `1004`/`2049` authentication) carry `base_resp.status_msg`.
+
+## Safety and scientific integrity
+
+- Treat generated images as draft visual concepts, not evidence.
+- Do not invent quantitative values, p-values, spectra, microscopy findings, institution logos, author photos, journal marks, or unsupported mechanisms.
+- Prefer short labels and simple shapes. AI image models can misspell text; final publication labels should usually be redrawn in Illustrator, Inkscape, PowerPoint, or a Python/R vector workflow.
+- If the schematic could be interpreted as a data panel, explicitly mark it as conceptual.
+- Do not send confidential manuscript content to the API without user permission.
+
+## Prompt contract
+
+Before calling the API, collect or infer:
+
+1. article title or central claim
+2. key biological/material/computational entities
+3. cause-effect mechanism or workflow stages
+4. desired layout, such as left-to-right pipeline, circular mechanism, split before/after, or graphical abstract
+5. target aspect ratio and response format
+6. any labels that must appear, keeping them short
+7. things that must be excluded
+
+Write a compact prompt with:
+
+- visual role: "Nature-style graphical abstract" or "clean scientific mechanism schematic"
+- composition: panel flow, hierarchy, and focal element
+- style: flat vector-like, restrained palette, high contrast, white or transparent background
+- scientific constraints: no fabricated numbers, no extra organs/cells/materials, no logos
+- output constraints: minimal text, editable downstream, journal-safe
+
+## Script usage
+
+Use the bundled script for reproducible calls:
+
+```bash
+export MINIMAX_API_KEY="..."
+python skills/nature-figure/scripts/generate_minimax_schematic.py \
+  --title "Paper title" \
+  --abstract-file abstract.txt \
+  --panel-map "left: problem; center: proposed mechanism; right: validated outcome" \
+  --outdir outputs/schematic \
+  --basename graphical_abstract \
+  --aspect-ratio 16:9 \
+  --model image-01
+```
+
+Dry-run without network or API key:
+
+```bash
+python skills/nature-figure/scripts/generate_minimax_schematic.py \
+  --title "Self-healing cementitious sensor" \
+  --abstract "A composite sensor couples chloride ingress with recoverable piezoresistive response." \
+  --panel-map "left: marine exposure; center: ion transport and microcrack healing; right: signal recovery curve" \
+  --dry-run
+```
+
+Use a fully custom prompt and the China endpoint:
+
+```bash
+python skills/nature-figure/scripts/generate_minimax_schematic.py \
+  --prompt-file schematic_prompt.md \
+  --raw \
+  --region cn \
+  --outdir outputs/schematic
+```
+
+Request explicit pixel dimensions and base64 output:
+
+```bash
+python skills/nature-figure/scripts/generate_minimax_schematic.py \
+  --prompt-file schematic_prompt.md \
+  --raw \
+  --width 1280 --height 720 \
+  --response-format base64
+```
+
+The script saves generated files plus `request_metadata.json` in the output directory. The metadata records the endpoint, region, request payload, trace id, and the `success_count` / `failed_count` reported by the API.
+
+## Recommended defaults
+
+- `model`: `image-01`
+- `aspect_ratio`: `16:9` for graphical abstracts, `4:3` for mechanism figures, `1:1` for cover-like concepts
+- `response_format`: `url` for review drafts; use `base64` when you need the bytes inline
+- `n`: `1`, raise only when comparing drafts
+
+## Follow-up QA
+
+After generation:
+
+1. inspect the image visually
+2. check whether labels are legible and spelled correctly
+3. list any scientific hallucinations or unsupported visual claims
+4. recommend which labels or arrows should be redrawn as vector objects
+5. keep the generated image and metadata together for provenance

--- a/skills/nature-figure/scripts/generate_minimax_schematic.py
+++ b/skills/nature-figure/scripts/generate_minimax_schematic.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Generate manuscript schematic drafts with the MiniMax image_generation API."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+# Regional hosts. The global endpoint serves platform.minimax.io accounts; the
+# CN endpoint serves platform.minimaxi.com accounts. Both expose the same path.
+REGION_BASE_URLS = {
+    "global": "https://api.minimax.io",
+    "cn": "https://api.minimaxi.com",
+}
+IMAGE_PATH = "/v1/image_generation"
+DEFAULT_MODEL = "image-01"
+SUPPORTED_MODELS = ("image-01", "image-01-live")
+
+
+def read_optional_text(text: str | None, path: str | None) -> str:
+    parts: list[str] = []
+    if text:
+        parts.append(text.strip())
+    if path:
+        parts.append(Path(path).read_text(encoding="utf-8").strip())
+    return "\n\n".join(part for part in parts if part)
+
+
+def build_prompt(args: argparse.Namespace) -> str:
+    custom_prompt = read_optional_text(args.prompt, args.prompt_file)
+    if custom_prompt and args.raw:
+        return custom_prompt
+
+    title = args.title.strip() if args.title else ""
+    abstract = read_optional_text(args.abstract, args.abstract_file)
+    panel_map = args.panel_map.strip() if args.panel_map else ""
+
+    content_blocks = []
+    if title:
+        content_blocks.append(f"Title: {title}")
+    if abstract:
+        content_blocks.append(f"Article summary:\n{abstract}")
+    if panel_map:
+        content_blocks.append(f"Desired panel flow:\n{panel_map}")
+    if custom_prompt:
+        content_blocks.append(f"Additional instructions:\n{custom_prompt}")
+
+    if not content_blocks:
+        raise SystemExit(
+            "Provide --prompt/--prompt-file or at least one of --title, "
+            "--abstract/--abstract-file, or --panel-map."
+        )
+
+    style = args.style or (
+        "Create a clean Nature-style scientific graphical abstract / mechanism "
+        "schematic for a research paper. Use a flat vector-like visual language, "
+        "restrained journal palette, clear hierarchy, simple arrows, and minimal "
+        "short labels. Keep the background uncluttered."
+    )
+
+    constraints = (
+        "Scientific constraints: show only the mechanisms and entities described "
+        "below; do not invent quantitative values, p-values, microscopy results, "
+        "institutional logos, journal marks, or unsupported experimental claims. "
+        "Use conceptual visual elements rather than fake data panels. Text labels "
+        "must be short and easy to redraw later."
+    )
+
+    return "\n\n".join([style, constraints, *content_blocks])
+
+
+def build_payload(args: argparse.Namespace) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "model": args.model,
+        "prompt": build_prompt(args),
+        "response_format": args.response_format,
+    }
+
+    if args.width is not None or args.height is not None:
+        if args.width is None or args.height is None:
+            raise SystemExit("--width and --height must be provided together.")
+        payload["width"] = args.width
+        payload["height"] = args.height
+    elif args.aspect_ratio is not None:
+        payload["aspect_ratio"] = args.aspect_ratio
+
+    optional_fields = {
+        "seed": args.seed,
+        "n": args.n,
+        "prompt_optimizer": args.prompt_optimizer,
+    }
+    for key, value in optional_fields.items():
+        if value is not None:
+            payload[key] = value
+
+    return payload
+
+
+def sniff_extension(data: bytes) -> str:
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        return ".png"
+    if data[:3] == b"\xff\xd8\xff":
+        return ".jpg"
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return ".webp"
+    if data[:6] in (b"GIF87a", b"GIF89a"):
+        return ".gif"
+    return ".png"
+
+
+def decode_b64_image(value: str) -> bytes:
+    if value.startswith("data:"):
+        value = value.split(",", 1)[1]
+    return base64.b64decode(value)
+
+
+def request_images(payload: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
+    api_key = os.environ.get(args.api_key_env)
+    if not api_key:
+        raise SystemExit(f"Missing API key: set {args.api_key_env}.")
+
+    endpoint = REGION_BASE_URLS[args.region] + IMAGE_PATH
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    request = urllib.request.Request(
+        endpoint,
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=args.timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise SystemExit(f"Image generation request failed ({exc.code}): {body}") from exc
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"Image generation request failed: {exc}") from exc
+
+
+def check_base_resp(response: dict[str, Any]) -> None:
+    base_resp = response.get("base_resp") or {}
+    status_code = base_resp.get("status_code")
+    if status_code not in (0, None):
+        status_msg = base_resp.get("status_msg", "unknown error")
+        raise SystemExit(f"Image generation returned status {status_code}: {status_msg}")
+
+
+def collect_images(response: dict[str, Any], args: argparse.Namespace) -> list[bytes]:
+    data = response.get("data") or {}
+    images: list[bytes] = []
+    if args.response_format == "base64":
+        for value in data.get("image_base64", []) or []:
+            images.append(decode_b64_image(value))
+    else:
+        for url in data.get("image_urls", []) or []:
+            with urllib.request.urlopen(url, timeout=args.timeout) as image_response:
+                images.append(image_response.read())
+    if not images:
+        raise SystemExit(f"No images returned in response: {json.dumps(response)[:500]}")
+    return images
+
+
+def save_outputs(response: dict[str, Any], payload: dict[str, Any], args: argparse.Namespace) -> None:
+    check_base_resp(response)
+    images = collect_images(response, args)
+
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+    basename = args.basename or time.strftime("minimax_schematic_%Y%m%d_%H%M%S")
+
+    saved: list[str] = []
+    for index, data in enumerate(images, start=1):
+        ext = sniff_extension(data)
+        suffix = "" if len(images) == 1 else f"_{index:02d}"
+        outpath = outdir / f"{basename}{suffix}{ext}"
+        outpath.write_bytes(data)
+        saved.append(str(outpath))
+
+    metadata = {
+        "endpoint": REGION_BASE_URLS[args.region] + IMAGE_PATH,
+        "region": args.region,
+        "request": payload,
+        "trace_id": response.get("id"),
+        "success_count": (response.get("metadata") or {}).get("success_count"),
+        "failed_count": (response.get("metadata") or {}).get("failed_count"),
+        "base_resp": response.get("base_resp"),
+        "saved_files": saved,
+    }
+    metadata_path = outdir / f"{basename}_request_metadata.json"
+    metadata_path.write_text(json.dumps(metadata, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    print("Saved:")
+    for path in saved:
+        print(f"  {path}")
+    print(f"  {metadata_path}")
+    if args.response_format == "url":
+        print("Note: source image URLs expire 24 hours after generation.")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate manuscript schematic drafts with the MiniMax image_generation API."
+    )
+    parser.add_argument(
+        "--model",
+        default=os.environ.get("MINIMAX_IMAGE_MODEL", DEFAULT_MODEL),
+        choices=SUPPORTED_MODELS,
+    )
+    parser.add_argument(
+        "--region",
+        default=os.environ.get("MINIMAX_REGION", "global"),
+        choices=sorted(REGION_BASE_URLS),
+        help="global -> api.minimax.io, cn -> api.minimaxi.com.",
+    )
+    parser.add_argument("--title")
+    parser.add_argument("--abstract")
+    parser.add_argument("--abstract-file")
+    parser.add_argument("--panel-map")
+    parser.add_argument("--prompt")
+    parser.add_argument("--prompt-file")
+    parser.add_argument("--style")
+    parser.add_argument("--raw", action="store_true", help="Use prompt text without the schematic scaffold.")
+    parser.add_argument("--outdir", default="minimax_schematic")
+    parser.add_argument("--basename")
+    parser.add_argument(
+        "--aspect-ratio",
+        default="16:9",
+        choices=["1:1", "16:9", "4:3", "3:2", "2:3", "3:4", "9:16", "21:9"],
+    )
+    parser.add_argument("--width", type=int, help="Image width in px [512, 2048], divisible by 8; requires --height.")
+    parser.add_argument("--height", type=int, help="Image height in px [512, 2048], divisible by 8; requires --width.")
+    parser.add_argument("--response-format", default="url", choices=["url", "base64"])
+    parser.add_argument("--seed", type=int, help="Fixed seed for reproducible images.")
+    parser.add_argument("--n", type=int, default=1, help="Number of images to generate, range [1, 9].")
+    parser.add_argument(
+        "--prompt-optimizer",
+        action="store_true",
+        help="Let the service automatically optimize the prompt.",
+    )
+    parser.add_argument("--api-key-env", default="MINIMAX_API_KEY")
+    parser.add_argument("--timeout", type=int, default=180)
+    parser.add_argument("--dry-run", action="store_true", help="Print request payload without calling the API.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if not args.prompt_optimizer:
+        args.prompt_optimizer = None
+    payload = build_payload(args)
+
+    if args.dry_run:
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+        return 0
+
+    response = request_images(payload, args)
+    save_outputs(response, payload, args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Reason: The manuscript schematic workflow only had a single hardcoded external image route, with no MiniMax image_generation route for image-01 and image-01-live.

## What this changes

Adds a MiniMax `image_generation` text-to-image route to the `nature-figure` schematic workflow, in parallel with the existing AI-schematic route.

- **`skills/nature-figure/scripts/generate_minimax_schematic.py`** — a reproducible CLI that builds the `POST /v1/image_generation` request. It supports `model` (`image-01` default, `image-01-live`), `prompt`, `aspect_ratio` or explicit `width`/`height`, `response_format` (`url`/`base64`), `seed`, `n`, and `prompt_optimizer`, and selects the global (`api.minimax.io`) or China (`api.minimaxi.com`) endpoint via `--region`. It parses `data.image_urls` and `data.image_base64`, records `metadata.success_count` / `metadata.failed_count` and the trace id in the saved request metadata, and raises on a non-zero `base_resp.status_code` using `base_resp.status_msg`. Image bytes are sniffed to pick the file extension, and URL expiry (24h) is noted on save. A `--dry-run` prints the payload without a network call.
- **`skills/nature-figure/references/minimax-image-generation.md`** — route reference documenting the endpoints, models, request fields, response fields (`data.image_urls`, `data.image_base64`, `metadata` counts, `base_resp.status_code`), scientific-integrity guidance, and usage examples.
- **`skills/nature-figure/manifest.yaml`** — registers the `minimax_image_generation` route (detect / reference / script) and adds the reference to the on-demand table.
- **`skills/nature-figure/SKILL.md`** — routing step 0 now recognizes and directs MiniMax image_generation requests to the new reference and script.

## Checks

- `python3 scripts/validate-skill-metadata.py` — passed (manifest route/reference/script paths resolve).
- `python3 scripts/validate-skill-index.py` — passed.
- `python3 -m py_compile skills/nature-figure/scripts/generate_minimax_schematic.py` — passed.
- `python3 skills/nature-figure/scripts/generate_minimax_schematic.py ... --dry-run` — verified payloads for aspect-ratio, width/height, base64, region, and both models; and the required-argument and paired-dimension errors.
- Parsing verified against mock responses: `base_resp` non-zero raises with the status message, `image_base64` decoding and file saving, and `metadata` success/failed counts recorded.
