### PR TITLE
 更新完善了nature-reader的相关功能

### DIFF
--- a/skills/nature-reader/SKILL.md
+++ b/skills/nature-reader/SKILL.md
@@ -2,7 +2,7 @@
 name: nature-reader
 description: Build full-paper Chinese-English side-by-side, figure/table/equation-aware, source-grounded Markdown readers for journal or conference papers from PDF, DOI, arXiv, publisher HTML, or pasted text. Use whenever the user asks to translate or read a paper, make 中英文对照/原文对照/全文翻译解读, render equations instead of exposing raw LaTeX, extract figures or tables into the right positions, preserve figure/table placement near relevant prose, or keep exact source anchors for every block. This skill must not degrade into a summary-only output unless the user explicitly asks for a summary. Also trigger on general paper-reading and translation requests even without the word "Nature", such as reading/translating an academic paper, literature reading, understanding a paper, and Chinese phrasings like 读论文、精读论文、论文翻译、文献翻译、文献阅读、学术阅读、帮我读这篇文章、翻译这篇paper.
 metadata:
-  version: "2.1.0"
+  version: "2.1.1"
   author: Community contribution, refactored into static/dynamic layers
 ---
 

--- a/skills/nature-reader/evals/evals.json
+++ b/skills/nature-reader/evals/evals.json
@@ -30,6 +30,12 @@
       "prompt": "这篇扫描论文的公式无法可靠 OCR。不要根据上下文猜公式：请把每个原始公式裁剪出来放进 assets/equations，在正文中显示原图；如果给 LaTeX 转写，必须标成低置信度并提示以原图为准。",
       "expected_output": "An image-first equation workflow with E IDs, existing equation crop paths, explicit low-confidence transcription labels, no guessed symbols, and source-map linkage for every displayed equation.",
       "files": []
+    },
+    {
+      "id": 6,
+      "prompt": "生成中英对照全文时，数学公式本体不要翻译或在中文段落里重写。显示公式只放一份；中文只解释含义。I_0、E_0、w_0、tau 等行内符号必须继续使用与英文相同的 LaTeX 和数学定界符，不能变成 (I_0)、(tau) 或普通文本。",
+      "expected_output": "A bilingual reader with one shared copy of each display equation, unchanged mathematical notation in Chinese prose, valid $...$/$$...$$ delimiters, no parenthesized pseudo-math, and a strict validator pass.",
+      "files": []
     }
   ]
 }

--- a/skills/nature-reader/references/equation-handling.md
+++ b/skills/nature-reader/references/equation-handling.md
@@ -30,6 +30,27 @@ Do not put formulas in ordinary backticks or generic code fences. Do not leave c
 
 Keep the publisher's printed equation number outside the math delimiters so the renderer cannot swallow or reposition it.
 
+## Bilingual formula preservation
+
+Do not translate mathematical content. Preserve formulas, symbols, indices, operators, Greek letters, and units exactly as they appear in the verified source. Translate only prose that introduces, defines, or interprets them.
+
+For a display equation, emit one shared `E...` block. Do not repeat or rewrite the equation under `**中文:**`:
+
+```markdown
+**Original:** The peak intensity is
+
+<a id="E001"></a>
+**Source:** p.6 E001
+
+$$
+I_0=\frac{4E_0}{\pi w_0^2\tau}\sqrt{\frac{\ln(2)}{\pi}}
+$$
+
+**中文:** 峰值强度由上方原式给出。其中 $I_0$ 为峰值强度，$E_0$ 为脉冲能量，$w_0$ 为焦斑半径，$\tau$ 为脉宽。
+```
+
+Forbidden forms include `(I_0)`, `(E_0=...)`, `(tau)`, `(Delta T)`, translated variable names, Unicode approximations that change the source notation, and bare LaTeX outside math delimiters. Ordinary parentheses remain valid for prose labels such as `Fig. 2(a)`; they must not be used as a substitute for `$...$`.
+
 ## Display-equation block
 
 Assign every display equation a stable `E...` ID in reading order:

--- a/skills/nature-reader/scripts/validate_reader_math.py
+++ b/skills/nature-reader/scripts/validate_reader_math.py
@@ -24,6 +24,14 @@ LATEX_COMMAND_RE = re.compile(
     r"mathcal|mathrm|mathbf|operatorname|overline|underline|widetilde|hat)\b"
 )
 MARKDOWN_IMAGE_RE = re.compile(r"!\[[^\]]*]\(([^)]+)\)")
+CHINESE_LINE_RE = re.compile(
+    r"^\s*\*\*中文(?:说明|图注)?[:：]\*\*.*$", re.MULTILINE
+)
+PAREN_PSEUDO_MATH_RE = re.compile(
+    r"\((?:[^()\n]*\\[A-Za-z]+[^()\n]*|"
+    r"[A-Za-z][A-Za-z0-9]*_(?:\{[^}]+\}|[A-Za-z0-9]+)|"
+    r"[^()\n]*=[^()\n]*)\)"
+)
 
 
 @dataclass(frozen=True)
@@ -144,6 +152,24 @@ def validate_markdown(text: str) -> tuple[list[Finding], list[str], list[str]]:
 
     display_ranges, display_findings = display_math_ranges(without_fences)
     findings.extend(display_findings)
+
+    normalized_displays: dict[str, list[int]] = {}
+    for start, end in display_ranges:
+        body = without_fences[start + 2 : end - 2].strip()
+        normalized = re.sub(r"\s+", "", body).rstrip(",.;")
+        if normalized:
+            normalized_displays.setdefault(normalized, []).append(start)
+    for offsets in normalized_displays.values():
+        if len(offsets) > 1:
+            findings.append(
+                Finding(
+                    "WARN",
+                    "DUPLICATE_DISPLAY_EQUATION",
+                    "The same display equation appears more than once; use one shared E... block for the bilingual pair.",
+                    line_number(text, offsets[1]),
+                )
+            )
+
     prose = mask_ranges(without_fences, display_ranges)
 
     inline_problem = find_inline_dollar_problem(prose)
@@ -166,6 +192,27 @@ def validate_markdown(text: str) -> tuple[list[Finding], list[str], list[str]]:
                 line_number(text, match.start()),
             )
         )
+
+    for line_match in CHINESE_LINE_RE.finditer(plain_prose):
+        line_text = line_match.group(0)
+        if "\t" in line_text:
+            findings.append(
+                Finding(
+                    "FAIL",
+                    "TAB_IN_CHINESE_MATH_PROSE",
+                    "A tab appears in a Chinese line; this can indicate a corrupted command such as \\tau.",
+                    line_number(text, line_match.start()),
+                )
+            )
+        for pseudo_match in PAREN_PSEUDO_MATH_RE.finditer(line_text):
+            findings.append(
+                Finding(
+                    "FAIL",
+                    "PARENTHESIZED_PSEUDO_MATH",
+                    f"Use math delimiters instead of ordinary parentheses: {pseudo_match.group(0)!r}.",
+                    line_number(text, line_match.start() + pseudo_match.start()),
+                )
+            )
 
     anchors = EQUATION_ANCHOR_RE.findall(text)
     duplicates = sorted({item for item in anchors if anchors.count(item) > 1})
@@ -323,6 +370,8 @@ $$
 \\frac{a}{b} = c
 $$
 
+**中文:** 其中 $a$、$b$ 和 $c$ 保持原始数学符号。
+
 <a id="E002"></a>
 **Source:** p.2 E002 · low confidence
 
@@ -348,13 +397,14 @@ $$
         bad_markdown = """# Broken
 <a id="E001"></a>
 Raw formula: \\frac{a}{b}
+**中文:** 其中 (I_0) 为峰值强度。
 $$
 x+y
 """
         paper.write_text(bad_markdown, encoding="utf-8")
         bad_findings = run_validation(paper, None)
         bad_codes = {item.code for item in bad_findings if item.severity == "FAIL"}
-        required = {"BARE_LATEX", "UNBALANCED_DISPLAY_MATH"}
+        required = {"BARE_LATEX", "UNBALANCED_DISPLAY_MATH", "PARENTHESIZED_PSEUDO_MATH"}
         if not required.issubset(bad_codes):
             print(f"Self-test failed: missing expected failures {sorted(required - bad_codes)}.", file=sys.stderr)
             return 1

--- a/skills/nature-reader/static/core/output-contract.md
+++ b/skills/nature-reader/static/core/output-contract.md
@@ -18,6 +18,7 @@ Before final response, verify:
 - every image/table link used in `paper.md` exists under `assets/`
 - every figure/table in `assets/` has a corresponding Markdown block and source pointer
 - display equations render inside `$$...$$` (or a fenced `math` block), and inline equations render inside `$...$`
+- mathematical content is unchanged across the bilingual explanation: only prose is translated, each display equation is shown once, and Chinese text never uses `(I_0)`-style pseudo-math
 - no bare LaTeX commands such as `\\frac`, `\\sum`, or `\\begin{...}` appear as ordinary prose
 - every display equation has an `E...` anchor and a matching equation entry in `source_map.json`
 - every low-confidence or image-only equation points to an existing file under `assets/equations/`


### PR DESCRIPTION
先前的nature-reader在将英文文献转化为中英文对照md时，会出现翻译数学公式导致中文翻译部分公式乱码的问题，因此对nature-reader这一skill做更新，使其不再翻译数学公式的部分，更便于阅读文献