### PR TITLE
Add Nature Machine Intelligence submission requirements

### DIFF
--- a/scripts/tests/test_nmi_submission_requirements.py
+++ b/scripts/tests/test_nmi_submission_requirements.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACT = "skills/nature-shared/journal-formats/nature-machine-intelligence.md"
+
+
+def read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+def squash(text: str) -> str:
+    return " ".join(text.split())
+
+
+class NatureMachineIntelligenceSubmissionRequirementsTests(unittest.TestCase):
+    def test_shared_contract_is_stage_aware_and_source_dated(self) -> None:
+        rules = read(CONTRACT)
+
+        for stage in (
+            "initial_submission",
+            "revision",
+            "accepted_in_principle",
+            "proof",
+        ):
+            self.assertIn(stage, rules)
+        self.assertIn("Verified **2026-08-12**", rules)
+
+        for url in (
+            "https://www.nature.com/natmachintell/submission-guidelines",
+            "https://www.nature.com/natmachintell/content",
+            "https://www.nature.com/natmachintell/editorial-policies/reporting-standards",
+            "https://www.nature.com/natmachintell/editorial-policies/preprints-conference-proceedings",
+        ):
+            self.assertIn(url, rules)
+
+    def test_article_and_analysis_limits_are_exact(self) -> None:
+        rules = read(CONTRACT)
+
+        for requirement in (
+            "up to **3,500 words**",
+            "up to **150 words**, unreferenced",
+            "**100–150 words**, unreferenced",
+            "up to **6** figures and tables combined",
+            "typically up to **50**",
+        ):
+            self.assertIn(requirement, rules)
+
+        self.assertIn("Introduction, without an `Introduction` heading", rules)
+        self.assertIn("Discussion should not", rules)
+
+    def test_initial_package_and_content_type_contract_are_present(self) -> None:
+        rules = read(CONTRACT)
+
+        for requirement in (
+            "PDF",
+            "Microsoft Word",
+            "TeX/LaTeX",
+            "a **cover letter**",
+            "**3,000–4,000 words**",
+            "**500–1,000 words**",
+            "**1,500–2,000 words**",
+            "Reusability Report",
+            "does **not** consider presubmission enquiries",
+        ):
+            self.assertIn(requirement, rules)
+
+    def test_display_data_code_and_overlap_gates_are_present(self) -> None:
+        rules = read(CONTRACT)
+        normalized = squash(rules)
+
+        for requirement in (
+            "no more than **10** Extended Data",
+            "after Data Availability and before the references",
+            "Software Submission Checklist",
+            "available to editors and reviewers",
+            "**substantially extends**",
+            "300 dpi",
+            "180 mm",
+            "5–7 pt sans-serif",
+        ):
+            self.assertIn(requirement, normalized)
+
+    def test_unpublished_numeric_limits_are_not_invented(self) -> None:
+        rules = read(CONTRACT)
+
+        self.assertIn("do not publish", rules)
+        self.assertIn("a fixed title character or word limit", rules)
+        self.assertIn("a separate numeric Methods word limit", rules)
+        self.assertIn("a separate numeric per-figure-legend word limit", rules)
+        self.assertIn("do not import", rules)
+
+    def test_writing_and_polishing_have_distinct_nmi_routes(self) -> None:
+        writing = read("skills/nature-writing/manifest.yaml")
+        polishing = read("skills/nature-polishing/manifest.yaml")
+
+        for manifest in (writing, polishing):
+            self.assertIn("nat-mach-intell:", manifest)
+            self.assertIn("nature-machine-intelligence.md", manifest)
+
+        self.assertIn("Nature Machine Intelligence or NMI", squash(writing))
+        self.assertIn("Nature Machine Intelligence or NMI", squash(polishing))
+
+    def test_cross_skill_routes_and_bilingual_docs_are_complete(self) -> None:
+        skill_roots = (
+            "nature-writing",
+            "nature-polishing",
+            "nature-figure",
+            "nature-data",
+            "nature-statistics",
+        )
+
+        for skill in skill_roots:
+            manifest = read(f"skills/{skill}/manifest.yaml")
+            skill_router = read(f"skills/{skill}/SKILL.md")
+            readme_zh = read(f"skills/{skill}/README.md")
+            readme_en = read(f"skills/{skill}/README_EN.md")
+
+            self.assertIn("nature-machine-intelligence.md", manifest)
+            self.assertIn("nature-machine-intelligence.md", skill_router)
+            self.assertIn("Nature Machine Intelligence", readme_zh)
+            self.assertIn("Nature Machine Intelligence", readme_en)
+
+        shared = read("skills/nature-shared/manifest.yaml")
+        self.assertIn("journal-formats/nature-machine-intelligence.md", shared)
+
+    def test_fragment_relative_paths_resolve(self) -> None:
+        routes = (
+            (
+                "skills/nature-writing/static/fragments/journal/nat-mach-intell.md",
+                "../../../../nature-shared/journal-formats/nature-machine-intelligence.md",
+            ),
+            (
+                "skills/nature-writing/static/fragments/task/submission-package.md",
+                "../../../../nature-shared/journal-formats/nature-machine-intelligence.md",
+            ),
+            (
+                "skills/nature-polishing/static/fragments/journal/nat-mach-intell.md",
+                "../../../../nature-shared/journal-formats/nature-machine-intelligence.md",
+            ),
+        )
+
+        for source, target in routes:
+            resolved = ((ROOT / source).parent / target).resolve()
+            self.assertTrue(resolved.is_file(), f"missing routed reference: {resolved}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/nature-data/README.md
+++ b/skills/nature-data/README.md
@@ -12,6 +12,7 @@
 - 区分公开数据、受控访问数据、第三方数据、补充材料数据和不适用场景。
 - 将中文作者笔记转成投稿可用英文，并列出需要作者确认的信息。
 - 对旗舰 `Nature Article` 检查声明位置、强制仓储、审稿访问、中心代码、材料和结构数据文件。
+- 对 `Nature Machine Intelligence`（NMI）检查 Data Availability、其后独立的 Code availability、审稿期数据/中心代码访问、限制条件和 Software Submission Checklist。
 
 ## 典型请求
 

--- a/skills/nature-data/README_EN.md
+++ b/skills/nature-data/README_EN.md
@@ -12,6 +12,7 @@
 - Distinguish public data, controlled-access data, third-party data, supplementary-data cases, and not-applicable cases.
 - Turn Chinese author notes into submission-ready English and list facts that still need confirmation.
 - Check flagship `Nature Article` statement placement, mandatory repositories, reviewer access, central code, materials, and structure-data files.
+- Check `Nature Machine Intelligence` (NMI) Data Availability, the following separate Code availability section, review-stage data/central-code access, restrictions, and the Software Submission Checklist.
 
 ## Typical Requests
 

--- a/skills/nature-data/SKILL.md
+++ b/skills/nature-data/SKILL.md
@@ -59,6 +59,13 @@ When the target is the flagship journal Nature, also open
 mandatory-deposition routing, central-code review access, materials and
 structure-file checks.
 
+When the target is Nature Machine Intelligence, open
+`../nature-shared/journal-formats/nature-machine-intelligence.md`. Enforce a
+Data Availability statement and a separate `Code availability` section after
+it and before references; check reviewer access, precise restrictions,
+repository/identifier quality and the Software Submission Checklist for newly
+developed central code.
+
 ## Why this split
 
 - The static layer is versioned and reviewable; the core stays small for a normal statement.

--- a/skills/nature-data/manifest.yaml
+++ b/skills/nature-data/manifest.yaml
@@ -1,5 +1,5 @@
 name: nature-data
-version: 2.1.0
+version: 2.2.0
 description: >
   Declarative manifest for the static/dynamic split. SKILL.md uses this to
   decide which fragments to load for a data-availability request.
@@ -24,6 +24,8 @@ references:
       path: references/policy-principles.md
     - condition: target is the flagship journal Nature, or exact Nature Article data, code, materials, mandatory-deposition, reviewer-access, or statement-placement rules are needed
       path: references/nature-article-requirements.md
+    - condition: target is Nature Machine Intelligence, or exact NMI Data Availability, Code availability, repository, reviewer-access, central-code, software-checklist, or statement-placement rules are needed
+      path: ../nature-shared/journal-formats/nature-machine-intelligence.md
     - condition: the user writes in Chinese, needs bilingual wording, or provides Chinese availability notes
       path: references/chinese-author-alignment.md
     - condition: ready-to-adapt Data Availability statement patterns

--- a/skills/nature-figure/README.md
+++ b/skills/nature-figure/README.md
@@ -11,6 +11,7 @@
 - 规划 Figure 1、机制图、workflow、graphical abstract 或补充图。
 - 检查面板标签、配色与视觉层级、逐面板误差线、最终 PDF 实际字号、统计标注、source data 和导出格式。
 - 区分旗舰 `Nature` 初投稿、主图终稿和 Extended Data 的文件契约，并执行 `<250` 词图注上限。
+- 对 `Nature Machine Intelligence` 单独执行 6 个主 display、最多 10 个 Extended Data、初投稿/终稿边界、300 dpi/180 mm 和 source data 要求；不虚构 NMI 图注字数上限。
 - 在用户明确要求时，通过 OpenRouter Images API 调用 `openai/gpt-image-2` 生成 AI 概念示意图草稿。
 
 ## 工作方式

--- a/skills/nature-figure/README_EN.md
+++ b/skills/nature-figure/README_EN.md
@@ -11,6 +11,7 @@
 - Plan Figure 1, mechanism diagrams, workflows, graphical abstracts, or supplementary figures.
 - Check panel labels, color hierarchy, panel-by-panel uncertainty, actual PDF glyph sizes, statistical annotations, source data, and export formats.
 - Separate flagship `Nature` initial, final main-figure, and Extended Data file contracts, including the under-250-word legend limit.
+- Apply `Nature Machine Intelligence` (NMI)'s separate six-main-display, up-to-ten Extended Data, initial/final, 300-dpi/180-mm, and source-data requirements without inventing an NMI legend word limit.
 - When explicitly requested, call `openai/gpt-image-2` through the OpenRouter Images API to draft AI concept schematics.
 
 ## Workflow

--- a/skills/nature-figure/SKILL.md
+++ b/skills/nature-figure/SKILL.md
@@ -69,13 +69,21 @@ When the target is the flagship journal Nature, also load
 from accepted-in-principle main and Extended Data production contracts and owns
 the flagship legend limit.
 
+When the target is Nature Machine Intelligence, instead load
+`../nature-shared/journal-formats/nature-machine-intelligence.md`. Apply its
+combined six-item main display budget, ten-item Extended Data maximum,
+initial-versus-production boundary, 300-dpi/180-mm production checks and source-
+data contract. NMI's current public pages do not state a numeric per-legend
+word limit; do not import flagship Nature's limit.
+
 The chart serves the scientific logic; aesthetic polish is subordinate to making the core conclusion clear, defensible, and reviewable.
 
 ### 5. Reach for references only when needed
 
-The files under `references/` are deep references, not defaults. Open them on demand per the `references.on_demand` table in the manifest — for example `references/figure-contract.md` to build the contract, `references/asset-adaptation.md` to reuse a plotting template safely, `references/template-catalog.md` for validated Python CSV templates, `references/api.md` for the Python palette and numerical/layout safety helpers, `references/r-workflow.md` for R, `references/design-theory.md` for color/typography/export rationale, `references/common-patterns.md` and `references/chart-types.md` for layout/chart recipes, `references/nature-2026-observations.md` for real Nature page archetypes, `references/qa-contract.md` before final delivery, `references/nature-article-requirements.md` for exact flagship Nature stage and upload rules, and `references/tutorials.md` / `references/demos.md` for worked examples.
+The files under `references/` are deep references, not defaults. Open them on demand per the `references.on_demand` table in the manifest — for example `references/figure-contract.md` to build the contract, `references/asset-adaptation.md` to reuse a plotting template safely, `references/template-catalog.md` for validated Python CSV templates, `references/api.md` for the Python palette and numerical/layout safety helpers, `references/r-workflow.md` for R, `references/design-theory.md` for color/typography/export rationale, `references/common-patterns.md` and `references/chart-types.md` for layout/chart recipes, `references/nature-2026-observations.md` for real Nature page archetypes, `references/qa-contract.md` before final delivery, `references/nature-article-requirements.md` for exact flagship Nature stage and upload rules, `../nature-shared/journal-formats/nature-machine-intelligence.md` for exact NMI figure rules, and `references/tutorials.md` / `references/demos.md` for worked examples.
 
-Do not infer flagship Nature requirements from a Nature Communications corpus.
+Do not infer flagship Nature or NMI requirements from a Nature Communications
+corpus or from the visual-style examples in this skill.
 
 ## Why this split
 

--- a/skills/nature-figure/manifest.yaml
+++ b/skills/nature-figure/manifest.yaml
@@ -1,5 +1,5 @@
 name: nature-figure
-version: 2.3.0
+version: 2.4.0
 description: >
   Declarative manifest for the static/dynamic split. SKILL.md uses this to
   decide which fragments to load for a given figure request. The main axis is
@@ -67,6 +67,8 @@ references:
       path: references/qa-contract.md
     - condition: target is the flagship journal Nature, or exact initial-versus-production main/Extended Data figure and legend requirements are needed
       path: references/nature-article-requirements.md
+    - condition: target is Nature Machine Intelligence, or exact NMI main-display, Extended Data, legend, source-data, initial-review, or production-figure requirements are needed
+      path: ../nature-shared/journal-formats/nature-machine-intelligence.md
     - condition: typography, color theory, layout rationale, export policy
       path: references/design-theory.md
     - condition: Python PALETTE, helper function signatures, validation rules

--- a/skills/nature-polishing/README.md
+++ b/skills/nature-polishing/README.md
@@ -8,7 +8,8 @@
 
 - 将中文学术段落翻译为投稿可用英文。
 - 精简冗长句子，增强论证顺序和段落推进。
-- 按 Nature / Nature Communications 论文范式调整摘要、引言、结果、讨论或标题。
+- 按 Nature / Nature Communications / Nature Machine Intelligence 论文范式调整摘要、引言、结果、讨论或标题。
+- 对 NMI 识别独立路由，检查 3,500 词正文、150 词摘要、6 个 display、代码审查与会议论文实质扩展，不再误用旗舰 Nature 数字。
 - 区分 research paper 与 methods paper 的写作重点。
 - 检查 AI 味、夸张声称、过度因果表达和不自然搭配。
 - 对全文或多轮修改稿执行一致性扫描，定位术语、单位、数值精度和内部声称漂移。

--- a/skills/nature-polishing/README_EN.md
+++ b/skills/nature-polishing/README_EN.md
@@ -8,7 +8,8 @@
 
 - Translate Chinese academic paragraphs into submission-ready English.
 - Shorten long sentences and improve argument order and paragraph movement.
-- Adjust abstracts, introductions, results, discussions, or titles using Nature / Nature Communications article patterns.
+- Adjust abstracts, introductions, results, discussions, or titles using Nature / Nature Communications / Nature Machine Intelligence article patterns.
+- Route NMI separately to check its 3,500-word main text, 150-word abstract, six-display budget, code-review duties, and substantial conference-paper extension without importing flagship Nature numbers.
 - Distinguish research-paper and methods-paper writing priorities.
 - Check AI-like phrasing, exaggerated claims, excessive causal language, and unnatural collocations.
 - Sweep full or repeatedly revised manuscripts for terminology, unit, numeric-precision, and internal-claim drift.

--- a/skills/nature-polishing/SKILL.md
+++ b/skills/nature-polishing/SKILL.md
@@ -29,7 +29,10 @@ For each axis in the manifest, decide the value using the manifest's `detect:` h
 - `paper_type` — research / methods / hypothesis / algorithmic / review. Default: research.
 - `section` — abstract / intro / results / discussion / conclusion / title / methods. May be multiple. Ask the user if it is ambiguous and matters for the polish.
 - `language` — en or zh-to-en. Detect from the draft itself.
-- `journal` — nature / nat-comms / generic. Default: generic. If the user names a Nature subjournal, treat it as `nature`.
+- `journal` — nature / nat-comms / nat-mach-intell / generic. Default:
+  generic. Use `nature` only for flagship Nature, `nat-comms` for Nature
+  Communications and `nat-mach-intell` for Nature Machine Intelligence (NMI).
+  Do not route another Nature Portfolio title through flagship Nature rules.
 
 State the detected axis values in one short line to the user before proceeding, so they can correct you cheaply.
 
@@ -54,6 +57,11 @@ If a paragraph's structural problem cannot be fixed without inventing content, f
 ### 5. Reach for references only when needed
 
 The files under `references/` are deep references, not defaults. Open them on demand per the `references.on_demand` table in the manifest, for example when the user explicitly asks for phrasebank-style alternatives or a stricter style audit.
+
+When the target is Nature Machine Intelligence and exact limits, availability
+sections, conference-extension disclosure or production checks affect the
+revision, load
+`../nature-shared/journal-formats/nature-machine-intelligence.md`.
 
 When the job is a whole manuscript rather than a passage, or the text has already been through more than one round of editing, also load `../nature-shared/core/consistency-sweep.md`. Polishing passage by passage cannot see accumulated drift: one experimental factor under several names, the same quantity in two units, a metric at two precisions, or a superlative the paper's own table contradicts. Sweep for those before working on sentences, and repeat the sweep until a pass finds nothing new.
 

--- a/skills/nature-polishing/manifest.yaml
+++ b/skills/nature-polishing/manifest.yaml
@@ -1,5 +1,5 @@
 name: nature-polishing
-version: 6.2.0
+version: 6.3.0
 description: >
   Declarative manifest for the static/dynamic split. SKILL.md uses this to
   decide which fragments to load for a given polishing request.
@@ -57,12 +57,14 @@ axes:
 
   journal:
     detect: |
-      Use the journal value the user names. If the user says "Nature-family"
-      generically or names a Nature subjournal, use nature. If they name
-      Nature Communications, use nat-comms. Otherwise generic.
+      Use nature only for the flagship journal Nature. Use nat-comms for Nature
+      Communications and nat-mach-intell for Nature Machine Intelligence or
+      NMI. If the user says "Nature-family" generically or names another Nature
+      Portfolio subjournal, use generic and check that title's current guide.
     values:
       nature:         static/fragments/journal/nature.md
       nat-comms:      static/fragments/journal/nat-comms.md
+      nat-mach-intell: static/fragments/journal/nat-mach-intell.md
       generic:        static/fragments/journal/generic.md
     default: generic
     multi: false
@@ -85,3 +87,5 @@ references:
       path: references/writing-strategy.md
     - condition: needs LaTeX layout/typesetting help (排版) — loose or sparse pages, stranded section headings, figures that don't fill the page or split across pages, "Float too large", multi-panel figure arrangement, or Supplementary Information that looks empty
       path: references/latex-layout.md
+    - condition: target is Nature Machine Intelligence and exact content-type, word/display, data/code, initial-submission, or production requirements affect the polish
+      path: ../nature-shared/journal-formats/nature-machine-intelligence.md

--- a/skills/nature-polishing/static/fragments/journal/nat-mach-intell.md
+++ b/skills/nature-polishing/static/fragments/journal/nat-mach-intell.md
@@ -1,0 +1,53 @@
+# Journal: Nature Machine Intelligence — polishing
+
+## Read the shared contract first
+
+Open
+`../../../../nature-shared/journal-formats/nature-machine-intelligence.md` for
+the exact, stage-aware NMI facts. This fragment controls polishing decisions,
+not the submission numbers themselves.
+
+## Audience and stance
+
+Polish for readers across AI, robotics, machine learning and the scientific or
+societal application domain. Preserve technical precision while making the
+question, evidence and consequence understandable outside one specialist
+benchmark community.
+
+## Structure before sentence polish
+
+For an Article, check these before line editing:
+
+1. Count Introduction + Results + Discussion against the 3,500-word main-text
+   limit; exclude abstract, Methods, references and legends.
+2. Keep the unreferenced abstract at or below 150 words.
+3. Check that figures and tables total no more than six.
+4. Keep the introduction unheaded; allow topical subheadings in Results and
+   Methods but not in Discussion.
+5. Preserve enough Methods detail for replication; NMI does not publish a
+   fixed Methods word limit on the current pages.
+
+Report an over-limit or wrong-structure manuscript under `Revision notes:`.
+Do not silently delete evidence, uncertainty or reproducibility detail to make
+the prose fit.
+
+## Claim calibration
+
+- Replace benchmark-only claims of general intelligence or deployment
+  readiness with the evaluated scope.
+- Separate gains due to architecture from data, supervision, compute or tuning
+  differences.
+- Name robustness and transfer boundaries when the prose currently hides them.
+- Do not convert association, retrospective performance or simulation results
+  into causal, clinical or societal effectiveness.
+- Define specialist abbreviations and remove jargon that is not needed for
+  technical accuracy.
+
+## Submission-sensitive checks
+
+- Preserve explicit disclosure of a substantially extended conference paper.
+- Preserve Data Availability and the separate Code availability section.
+- Flag missing reviewer access or a missing Software Submission Checklist when
+  new code is central to the conclusions.
+- Do not apply a flagship Nature title, Methods or legend limit: NMI's current
+  public pages state no fixed number for those three items.

--- a/skills/nature-shared/README.md
+++ b/skills/nature-shared/README.md
@@ -21,6 +21,7 @@ always_load:
 | `core/consistency-sweep.md` | `nature-polishing`, `nature-reviewer`, `nature-response`, `nature-statistics` |
 | `journal-formats/nat-comms.md` | `nature-polishing`, `nature-writing` |
 | `journal-formats/nature.md` | `nature-writing` 及需要旗舰 `Nature Article` 精确投稿规则的技能 |
+| `journal-formats/nature-machine-intelligence.md` | NMI 投稿的写作、润色、图表、数据与统计工作流 |
 
 `scripts/check_consistency.py` 为一致性扫描提供机械初筛，可报告术语变体、同值不同精度和等值长度单位混用。输出是待人工核对的风险提示，不会自动改稿。
 

--- a/skills/nature-shared/README_EN.md
+++ b/skills/nature-shared/README_EN.md
@@ -21,6 +21,7 @@ always_load:
 | `core/consistency-sweep.md` | `nature-polishing`, `nature-reviewer`, `nature-response`, `nature-statistics` |
 | `journal-formats/nat-comms.md` | `nature-polishing`, `nature-writing` |
 | `journal-formats/nature.md` | `nature-writing` and skills needing exact flagship `Nature Article` submission rules |
+| `journal-formats/nature-machine-intelligence.md` | Writing, polishing, figure, data, and statistics workflows for NMI submissions |
 
 `scripts/check_consistency.py` provides a mechanical first pass for terminology variants, equal values reported at different precision, and equivalent lengths expressed in different units. Its output is a set of warnings for contextual review, not automatic edits.
 

--- a/skills/nature-shared/SKILL.md
+++ b/skills/nature-shared/SKILL.md
@@ -12,4 +12,7 @@ Use this package only as a dependency of another installed Nature skill.
 - Use `journal-formats/nature.md` only for the flagship journal Nature and
   `core/research-compliance.md` only when its specialist applicability gate is
   triggered.
+- Use `journal-formats/nature-machine-intelligence.md` for exact NMI article
+  types, limits, initial-submission files, data/code duties and production
+  requirements; do not import flagship Nature or Nature Communications limits.
 - Return to the requesting skill for task logic, output format, and final QA.

--- a/skills/nature-shared/journal-formats/nature-machine-intelligence.md
+++ b/skills/nature-shared/journal-formats/nature-machine-intelligence.md
@@ -1,0 +1,405 @@
+# Nature Machine Intelligence submission requirements
+
+Canonical, stage-aware rules for manuscripts submitted to **Nature Machine
+Intelligence** (`NMI`; route key `nat-mach-intell`). This file contains the
+journal facts. A requesting skill supplies its own drafting, polishing, figure,
+data or statistics action layer.
+
+Do not substitute the flagship *Nature* or *Nature Communications* limits.
+When an editor gives manuscript-specific instructions, those instructions take
+priority over this public-page snapshot.
+
+## Contents
+
+1. Authority and stage gate
+2. Editorial scope and article types
+3. Article and Analysis contract
+4. Other content types
+5. Initial-submission package
+6. Writing, structure and accessibility
+7. Cover letter, review mode and related work
+8. Data, code and reporting standards
+9. Figures, Extended Data and Supplementary Information
+10. Accepted-in-principle production contract
+11. Requirements not stated as fixed numbers
+12. Official sources
+
+## 1. Authority and stage gate
+
+Record the active stage before applying a rule:
+
+- `initial_submission`: before the first editorial decision. A complete,
+  reviewable manuscript is required, but no special house formatting is
+  required.
+- `revision`: after peer review. Follow the handling editor's instructions in
+  addition to the public guide and preserve a point-by-point response record.
+- `accepted_in_principle`: supply editable text, production-quality figures,
+  final declarations, supporting-information inventory and requested forms.
+- `proof`: correct production errors only; do not silently introduce a new
+  scientific claim or analysis.
+
+Do not block an initial submission for missing final-production typography,
+editable source artwork, final table placement or ORCID linking. Do block or
+flag an initial package that lacks required scientific content, a cover letter,
+required availability statements, disclosed overlap or review access to data
+and central custom code.
+
+## 2. Editorial scope and article types
+
+### Scope fit
+
+The journal considers high-quality original research and reviews across
+machine learning, robotics and artificial intelligence, including the broader
+scientific, societal and industrial effects of these technologies. It aims to
+support dialogue across disciplines, so a technically strong paper still needs
+an intelligible question, consequence and audience beyond one narrow benchmark
+community.
+
+For an original-research **Article**, verify that the work presents substantial
+novel research and a complex, well-supported story. Several techniques or
+approaches may be needed, but method count is not a substitute for scientific
+importance, validation or scope fit.
+
+### Supported content types
+
+The public content-type guide includes:
+
+- Article
+- Analysis
+- Review Article
+- Perspective
+- Correspondence
+- Comment
+- Reusability Report
+
+Primary research is normally eligible for either subscription publication or
+Gold open access. Non-primary content types are not normally eligible for Gold
+open access and should not be used to smuggle in new primary findings; only
+minimal supporting data are appropriate where the content type permits them.
+
+## 3. Article and Analysis contract
+
+### Article limits
+
+| Item | Current NMI requirement |
+|---|---|
+| Main text | up to **3,500 words** |
+| Excluded from main-text count | abstract, Methods, references and figure legends |
+| Abstract | up to **150 words**, unreferenced |
+| Display items | up to **6** figures and tables combined |
+| References | typically up to **50** |
+| Supplementary Information | permitted when relevant |
+
+### Analysis limits
+
+| Item | Current NMI requirement |
+|---|---|
+| Main text | up to **3,500 words** |
+| Excluded from main-text count | abstract, online Methods, references and figure legends |
+| Abstract | **100–150 words**, unreferenced |
+| Display items | up to **6** figures and tables combined |
+| References | typically up to **50** |
+
+### Article and Analysis structure
+
+Use this sequence unless the editor authorizes a justified variant:
+
+1. Introduction, without an `Introduction` heading
+2. Results
+3. Discussion
+4. Methods
+
+Results and Methods may use short topical subheadings. Discussion should not
+use subheadings. The Methods section should be concise but contain enough
+detail for interpretation and replication; original research publishes Methods
+online.
+
+Treat the six-item display allowance as a combined figure-plus-table budget.
+Plan the evidence hierarchy before drafting rather than shrinking essential
+validation into unreadable composite panels.
+
+## 4. Other content types
+
+| Content type | Length | Displays | References | Key boundary |
+|---|---:|---:|---:|---|
+| Review Article | **3,000–4,000 words** | illustrations strongly encouraged | up to **100** | synthesize a field; annotations are encouraged for the most important references, normally no more than 10% of the list |
+| Perspective | **3,000–4,000 words** | as justified | up to **100** | present a scholarly, forward-looking viewpoint rather than a disguised original Article |
+| Correspondence | **500–1,000 words** | up to **1** | up to **10** | should not contain research data or analysis |
+| Comment | **1,500–2,000 words** | as justified | up to **15** | should not be a normal primary-research report |
+| Reusability Report | follow the Article format | follow the Article format | follow the Article format | evaluate robustness or reusability of existing code rather than merely announcing software |
+
+Do not infer an Article limit for an unlisted or commissioned format. Check the
+current content-type page or the commissioning editor's instructions.
+
+## 5. Initial-submission package
+
+### Accepted review formats
+
+At initial submission, NMI does not require special formatting if the material
+is complete and reviewable. The journal accepts:
+
+- PDF
+- Microsoft Word
+- TeX/LaTeX, submitted as a compiled PDF for review
+
+### Package inventory
+
+Prepare:
+
+- one complete manuscript file containing the Methods, figures and any
+  Extended Data used at review stage
+- a **cover letter**
+- Supplementary Information when needed for the conclusions, understanding or
+  replication
+
+The manuscript should include:
+
+- author names and affiliations, unless optional double-anonymized review is
+  selected
+- enough findings, methods and material detail for editorial and peer review
+- a complete reference list
+- optional Extended Data, within the ten-item limit
+
+Every figure, table, Extended Data item and supplementary item must be cited in
+the manuscript. Supporting information is sent to reviewers, so it must be
+reviewable and must not contain claims that the main text depends on but never
+states.
+
+## 6. Writing, structure and accessibility
+
+- Write for readers beyond the immediate machine-learning or application
+  subfield.
+- Make titles and abstracts intelligible to scientists outside the specialty.
+- Explain unavoidable jargon and define non-standard abbreviations at first
+  use; minimize abbreviations when plain language is shorter.
+- State the scientific or societal question, not only the architecture and
+  benchmark score.
+- Report quantitative evidence and important limitations without inflating
+  association, benchmark gain or simulation performance into general-world
+  effectiveness.
+- Keep Methods concise but reproducible. A numeric Methods word limit is not
+  stated on the current public NMI pages.
+
+For algorithmic papers, distinguish the contribution from parameter scaling,
+data leakage, additional supervision, compute advantages and benchmark-specific
+tuning. For deployed or societal claims, describe the population, setting,
+failure modes and transfer boundary.
+
+## 7. Cover letter, review mode and related work
+
+### Cover letter
+
+The initial package includes a cover letter. It should:
+
+- explain the work's importance and fit for NMI's diverse readership
+- disclose related manuscripts under consideration or in press
+- disclose any prior discussion of the work with an NMI editor
+- place author affiliations and contact details here when double-anonymized
+  review is selected
+- optionally recommend or oppose reviewers, giving a concise reason for an
+  exclusion request
+
+The cover letter is confidential and is not shown to reviewers. Do not repeat
+the abstract; use it to help the editor understand novelty, audience, overlap
+and any sensitive procedural context.
+
+### Double-anonymized peer review
+
+Double-anonymized review is optional. Authors who select it must:
+
+- remove identifying author and affiliation information from the manuscript
+- anonymize self-citations, acknowledgements, repository links and file
+  metadata where necessary without making the science uninterpretable
+- provide author information in the cover letter and submission system
+- select the double-anonymized option during submission
+
+The authors, not the journal, are responsible for effective anonymization.
+
+### Preprints, conference papers and overlapping work
+
+- A preprint is not treated as prior publication. Disclose it and provide its
+  DOI and licence where available; a preprint may be posted during review.
+- NMI may consider a journal manuscript extending a conference proceeding only
+  when the new submission **substantially extends** the results, methodology,
+  analysis, conclusions or implications. The editor decides whether the
+  extension is sufficient.
+- Cite and disclose the conference paper, identify the concrete extension and
+  obtain any reuse permission or attribution required for text, figures or
+  tables.
+- Disclose and supply related manuscripts with overlapping authors that are
+  under consideration or in press.
+- Do not submit work with significant overlap simultaneously to another
+  journal.
+
+NMI does **not** consider presubmission enquiries. Prepare the full initial
+submission instead.
+
+## 8. Data, code and reporting standards
+
+### Data Availability
+
+Every original-research manuscript needs a Data Availability statement that
+maps each supporting dataset to an access route. At initial submission:
+
+- give repository names, persistent identifiers or accession numbers when
+  available
+- prefer recognized repositories for large or reusable datasets instead of
+  burying them in Supplementary Information
+- make supporting data available to editors and reviewers on request
+- disclose legal, ethical, privacy, commercial, controlled-access,
+  third-party or proprietary restrictions at submission and describe the
+  access procedure precisely in the manuscript
+- avoid an unqualified `available upon request` statement
+
+### Code Availability
+
+Place a separate headed **Code availability** section after Data Availability
+and before the references. It must state how central custom code or algorithms
+can be accessed and describe any restrictions.
+
+For code central to the conclusions:
+
+- make it available to editors and reviewers during peer review
+- provide executable instructions, environment/dependency information and the
+  inputs needed to reproduce key results
+- prefer a DOI-minting repository such as Zenodo or Code Ocean and an
+  Open Source Initiative-approved licence when release is possible
+- expect the central code to be peer reviewed
+- complete the **Software Submission Checklist** when newly developed code is
+  central to the paper
+
+Never invent a repository, DOI, licence, access condition or software version.
+Route repository and statement drafting to `nature-data` and statistical
+completeness to `nature-statistics`.
+
+### Reporting and protocols
+
+- Complete the appropriate Nature Portfolio reporting summary when the study
+  type or field requires one, including relevant life, behavioural, social,
+  ecological and specified physical-science routes.
+- Apply study-type standards such as CONSORT, STROBE, PRISMA or ARRIVE when
+  applicable.
+- Sharing step-by-step protocols through a persistent protocol platform is
+  encouraged; cite the protocol in Methods.
+- Apply `../core/research-compliance.md` to human, animal, clinical, image,
+  structure, chemistry, taxonomy and provenance-sensitive work.
+
+### AI-assisted writing
+
+- A large language model cannot be an author.
+- Human authors remain responsible for the manuscript.
+- Disclose substantive LLM use in Methods or another suitable section.
+- Pure AI-assisted copy editing does not require a declaration under the
+  current Nature Portfolio policy.
+- Apply the confidentiality and non-invention rules in `../core/ethics.md`.
+
+## 9. Figures, Extended Data and Supplementary Information
+
+### Initial submission
+
+- Figures must be legible and assessable by reviewers; final production files
+  are not required at this stage.
+- Use no more than **6** main display items for an Article or Analysis, counting
+  figures and tables together.
+- Use no more than **10** Extended Data figures and tables combined.
+- Cite every Extended Data item in the main text.
+
+### Legend content
+
+Each legend should begin with a brief title and then describe the panels. It
+should define:
+
+- visual encodings and panel labels
+- centre and error-bar definitions
+- the exact `n` and unit of analysis
+- statistical tests, sidedness, corrections and exact P-value policy where
+  applicable
+- scale bars and necessary sample identifiers
+
+Avoid placing a second Methods section in the legend. The current public NMI
+pages do **not** state a separate numeric per-legend word limit; do not import
+the flagship *Nature* below-250-word limit or invent an NMI number.
+
+### Supplementary Information
+
+- Keep SI relevant to the conclusions, understanding or replication.
+- Number Supplementary figures and tables separately from main and Extended
+  Data items.
+- Make each Supplementary figure plus legend fit on one PDF page.
+- Cite every supplementary item in the manuscript.
+- Combine simple SI into one PDF; provide complex tables or datasets as Excel
+  or CSV, and software packages as ZIP or TAR where appropriate.
+
+## 10. Accepted-in-principle production contract
+
+Apply these only after the editor requests final files:
+
+### Text and tables
+
+- Submit editable Microsoft Word or TeX/LaTeX source; PDF is not accepted as
+  the final manuscript source.
+- Place tables at the end of the manuscript; complex tables may be supplied in
+  Excel.
+- Number references sequentially and include DOI-bearing data and code records
+  in the reference list where cited.
+- Do not use footnotes.
+- Use short bold Methods headings.
+- Keep acknowledgements brief, do not thank anonymous reviewers or editors,
+  and provide the funding statement separately.
+- Link the corresponding authors' ORCID records before final acceptance when
+  requested.
+
+### Figure production
+
+- Cite figures in sequential order.
+- Supply figure panels at **at least 300 dpi** and no more than **180 mm** wide.
+- Use editable **5–7 pt sans-serif** labels and Symbol for Greek characters.
+- Use scale bars instead of magnification and define them in the legend.
+- Keep labels, scale bars and error bars editable rather than flattened into a
+  raster when the production workflow permits.
+- Provide source data. Full unprocessed gels or blots are required for relevant
+  figures, and statistical source data should be organized by figure, normally
+  in an Excel workbook.
+
+### Extended Data and supporting-information inventory
+
+- Keep the combined Extended Data total at no more than **10**.
+- Fit each Extended Data figure or table on one PDF page.
+- Cite each item in the main text and include its legend in the Inventory of
+  Supporting Information.
+- Finalize the SI numbering, citations, file formats and inventory before
+  upload.
+
+## 11. Requirements not stated as fixed numbers
+
+The current official NMI pages reviewed for this contract do not publish:
+
+- a fixed title character or word limit
+- a separate numeric Methods word limit
+- a separate numeric per-figure-legend word limit
+
+Do not borrow numbers from flagship *Nature*, *Nature Communications*, a third-
+party checklist or an older template. Write concisely, then verify any new
+editor- or system-provided limit at the active submission stage.
+
+Open-access article-processing charges and currencies can change. If the author
+asks for cost planning, check the live Publishing Options page instead of
+treating a stored price as a submission rule.
+
+## 12. Official sources
+
+Verified **2026-08-12**:
+
+- Submission guidelines: <https://www.nature.com/natmachintell/submission-guidelines>
+- Content types: <https://www.nature.com/natmachintell/content>
+- Preparing your submission: <https://www.nature.com/natmachintell/submission-guidelines/preparing-your-submission>
+- Initial formatting: <https://www.nature.com/natmachintell/submission-guidelines/initial-formatting>
+- Writing and language: <https://www.nature.com/natmachintell/submission-guidelines/writing-and-language>
+- Accepted-in-principle and formatting: <https://www.nature.com/natmachintell/submission-guidelines/aip-and-formatting>
+- Double-anonymized peer review: <https://www.nature.com/natmachintell/submission-guidelines/dapr>
+- Editorial policies: <https://www.nature.com/natmachintell/editorial-policies>
+- Reporting standards, data and code: <https://www.nature.com/natmachintell/editorial-policies/reporting-standards>
+- Preprints and conference proceedings: <https://www.nature.com/natmachintell/editorial-policies/preprints-conference-proceedings>
+- Presubmission enquiries: <https://www.nature.com/natmachintell/submission-guidelines/presubmission-enquiries>
+- Aims and scope: <https://www.nature.com/natmachintell/aims>
+- Publishing options: <https://www.nature.com/natmachintell/submission-guidelines/publishing-options>

--- a/skills/nature-shared/manifest.yaml
+++ b/skills/nature-shared/manifest.yaml
@@ -1,5 +1,5 @@
 name: nature-shared
-version: 1.2.0
+version: 1.3.0
 description: >
   Declarative manifest for shared Nature reference modules. This package is not
   a standalone workflow; installed Nature skills use it to load exact shared
@@ -32,6 +32,8 @@ journal_formats:
       path: journal-formats/nature.md
     - condition: formatting or checking output for Nature Communications conventions
       path: journal-formats/nat-comms.md
+    - condition: formatting, article-type selection, initial-submission readiness, or stage-aware checking for Nature Machine Intelligence
+      path: journal-formats/nature-machine-intelligence.md
 
 quality_tools:
   consistency_script: scripts/check_consistency.py

--- a/skills/nature-statistics/README.md
+++ b/skills/nature-statistics/README.md
@@ -13,6 +13,7 @@
 - 交叉检查摘要、正文、表格和结论中同一统计量的数值精度、单位及统计术语是否一致。
 - 根据审稿人统计意见生成保守回应或修改建议。
 - 对旗舰 `Nature Article` 检查单尾/双尾、exact n、重复次数、显著与非显著 P 值、ANOVA F/df 和 t 检验 t/df。
+- 对 `Nature Machine Intelligence` 检查图注中的 n/误差/检验、source data、适用的 Reporting Summary，以及初投稿与终稿的不同要求。
 
 ## 典型请求
 

--- a/skills/nature-statistics/README_EN.md
+++ b/skills/nature-statistics/README_EN.md
@@ -13,6 +13,7 @@
 - Cross-check numeric precision, units, and statistical terminology for the same statistic across the abstract, text, tables, and conclusion.
 - Draft conservative responses or revision suggestions for reviewer statistics comments.
 - Check the flagship `Nature Article` requirements for test tails, exact n, repeat counts, significant and non-significant P values, ANOVA F/df, and t-test t/df.
+- Check `Nature Machine Intelligence` (NMI) legend-level n/error/test definitions, source data, applicable Reporting Summaries, and the separate initial versus final requirements.
 
 ## Typical Requests
 

--- a/skills/nature-statistics/SKILL.md
+++ b/skills/nature-statistics/SKILL.md
@@ -42,6 +42,9 @@ If the input is partial, run a bounded audit and state which parts cannot be ass
    If the target is the flagship journal Nature, also use
    `references/nature-article-requirements.md` for its exact tail, `n`, repeat,
    P-value, test-statistic and degrees-of-freedom requirements.
+   If the target is Nature Machine Intelligence, also use
+   `../nature-shared/journal-formats/nature-machine-intelligence.md` for its
+   legend-statistics, source-data, reporting-summary and stage-specific checks.
 7. **Align figure statistics.** Use `references/figure-statistics.md` when figure legends, panel labels, stars, error bars, box plots, violin plots, source data, or supplementary figure notes are involved.
 8. **Draft or revise.** Produce conservative, ready-to-paste text. Keep claims within the supplied design and evidence. Do not upgrade statistical association into mechanism or causality.
 9. **Run final QA.** Use `references/reviewer-checklist.md` before final delivery for severity labels, unresolved author questions, and reviewer-facing risk.
@@ -102,6 +105,7 @@ Reporting notes
 |---|---|
 | [references/source-basis.md](references/source-basis.md) | You need the source hierarchy or want to justify why the skill emphasizes transparency, reproducibility, and design reporting |
 | [references/nature-article-requirements.md](references/nature-article-requirements.md) | The target is the flagship journal Nature or the user requests its exact statistical submission checklist |
+| [../nature-shared/journal-formats/nature-machine-intelligence.md](../nature-shared/journal-formats/nature-machine-intelligence.md) | The target is Nature Machine Intelligence or NMI-specific legend, source-data, reporting or stage requirements affect the audit |
 | [references/statistical-reporting.md](references/statistical-reporting.md) | You are drafting or auditing Statistical analysis, Methods, Results, or Supplementary Methods text |
 | [references/common-failure-modes.md](references/common-failure-modes.md) | You see nested measurements, many comparisons, interaction claims, correlation/regression, outliers, tiny samples, or overstrong p-value language |
 | [references/figure-statistics.md](references/figure-statistics.md) | You are checking figure legends, panel statistics, error bars, stars, box/violin plots, source-data notes, or graphical reporting |

--- a/skills/nature-statistics/manifest.yaml
+++ b/skills/nature-statistics/manifest.yaml
@@ -1,5 +1,5 @@
 name: nature-statistics
-version: 1.2.0
+version: 1.3.0
 description: >
   Declarative manifest for the statistics-reporting workflow. SKILL.md uses
   this to keep the always-needed reporting rules small while loading specialized
@@ -19,6 +19,8 @@ references:
   on_demand:
     - condition: target is the flagship journal Nature, or the user requests an exact Nature Article statistical submission/readiness audit
       path: references/nature-article-requirements.md
+    - condition: target is Nature Machine Intelligence, or exact NMI legend statistics, source-data, reporting-summary, data/code, initial-submission, or production requirements affect the audit
+      path: ../nature-shared/journal-formats/nature-machine-intelligence.md
     - condition: nested data, pseudoreplication, repeated measures, many comparisons, correlations, regressions, outliers, small samples, or overstrong p-value language
       path: references/common-failure-modes.md
     - condition: checking figure legends, panel-level n, error bars, stars, box/violin plots, source-data notes, or statistical annotations

--- a/skills/nature-writing/README.md
+++ b/skills/nature-writing/README.md
@@ -14,6 +14,7 @@
 - 准备首次投稿 cover letter、title page、highlights、作者贡献、数据/代码可用性和其他声明。
 - 整理推荐审稿人、投稿材料矩阵和提交前完整性检查。
 - 对旗舰 `Nature Article` 执行分阶段官网清单：初投稿文件、标题/字数/display 限制、Extended Data、SI、Reporting Summary、伦理和专项材料。
+- 对 `Nature Machine Intelligence` 执行独立的分阶段投稿合同：Article/Analysis 字数与 6 个 display 上限、必需 cover letter、最多 10 个 Extended Data、会议论文实质扩展、数据与中心代码审查要求。
 
 ## 典型请求
 

--- a/skills/nature-writing/README_EN.md
+++ b/skills/nature-writing/README_EN.md
@@ -14,6 +14,7 @@
 - Prepare an initial cover letter, title page, highlights, author contributions, availability statements, and other declarations.
 - Organize reviewer suggestions, a deliverable matrix, and a pre-submission completeness audit.
 - Run the stage-aware official checklist for a flagship `Nature Article`: initial files, title/text/display limits, Extended Data, SI, Reporting Summary, ethics, and specialist materials.
+- Apply a dedicated stage-aware `Nature Machine Intelligence` contract covering Article/Analysis word and six-display limits, the required cover letter, up to ten Extended Data items, substantial conference-paper extensions, and data/central-code review access.
 
 ## Typical Requests
 

--- a/skills/nature-writing/SKILL.md
+++ b/skills/nature-writing/SKILL.md
@@ -30,10 +30,11 @@ For each axis in the manifest, decide the value using the manifest's `detect:` h
 - `paper_type` — research / methods / hypothesis / algorithmic / review. Default: research.
 - `section` — abstract / intro / related-work / method / experiments / discussion / conclusion / title. May be multiple. Ask the user if it is ambiguous and matters for the draft.
 - `language` — en or zh-to-en. Detect from the user's notes themselves.
-- `journal` — nature / nature-family / nat-comms / generic. Default: generic.
-  Use `nature` only for the flagship journal Nature, `nat-comms` for Nature
-  Communications, and `nature-family` for other Nature Portfolio titles or an
-  unspecified Nature-family request.
+- `journal` — nature / nature-family / nat-comms / nat-mach-intell / generic.
+  Default: generic. Use `nature` only for the flagship journal Nature,
+  `nat-comms` for Nature Communications, `nat-mach-intell` for Nature Machine
+  Intelligence (NMI), and `nature-family` for other Nature Portfolio titles or
+  an unspecified Nature-family request.
 
 State the detected axis values in one short line to the user before drafting, so they can correct you cheaply.
 
@@ -72,6 +73,9 @@ The files under `references/` are deep references and the example library, not d
 - The user requests a complete first-submission package, templates, or a submission-readiness audit → `references/submission-package.md`.
 - The target is the flagship journal Nature and exact submission or formatting
   requirements matter → `../nature-shared/journal-formats/nature.md`.
+- The target is Nature Machine Intelligence and exact content-type, submission,
+  data/code or production requirements matter →
+  `../nature-shared/journal-formats/nature-machine-intelligence.md`.
 - The work involves regulated or specialist research compliance →
   `../nature-shared/core/research-compliance.md`.
 

--- a/skills/nature-writing/manifest.yaml
+++ b/skills/nature-writing/manifest.yaml
@@ -1,5 +1,5 @@
 name: nature-writing
-version: 1.1.0
+version: 1.2.0
 description: >
   Declarative manifest for the static/dynamic split. SKILL.md uses this to
   decide which fragments to load for a drafting, restructuring, or
@@ -77,14 +77,16 @@ axes:
   journal:
     detect: |
       Use nature only for the flagship journal Nature. Use nat-comms for Nature
-      Communications. If the user says "Nature-family" generically or names a
-      different Nature Portfolio subjournal, use nature-family and check that
-      journal's current instructions before applying exact numbers. Otherwise
-      use generic.
+      Communications. Use nat-mach-intell when the user names Nature Machine
+      Intelligence or NMI. If the user says "Nature-family" generically or
+      names a different Nature Portfolio subjournal, use nature-family and
+      check that journal's current instructions before applying exact numbers.
+      Otherwise use generic.
     values:
       nature:         static/fragments/journal/nature.md
       nature-family:  static/fragments/journal/nature-family.md
       nat-comms:      static/fragments/journal/nat-comms.md
+      nat-mach-intell: static/fragments/journal/nat-mach-intell.md
       generic:        static/fragments/journal/generic.md
     default: generic
     multi: false
@@ -117,6 +119,8 @@ references:
       path: references/submission-package.md
     - condition: flagship Nature Article formatting, initial-submission package, submission-readiness audit, stage classification, or exact title/text/display/reference limits
       path: ../nature-shared/journal-formats/nature.md
+    - condition: Nature Machine Intelligence article-type selection, exact word/display limits, initial-submission package, stage classification, data/code duties, or production preflight
+      path: ../nature-shared/journal-formats/nature-machine-intelligence.md
     - condition: human or animal ethics, clinical research, reporting summaries, image integrity, structures, chemistry, taxonomy, geological, archaeological, or palaeontological compliance is involved
       path: ../nature-shared/core/research-compliance.md
     - condition: deeper Chinese-author repair patterns beyond the language fragment

--- a/skills/nature-writing/static/fragments/journal/nat-mach-intell.md
+++ b/skills/nature-writing/static/fragments/journal/nat-mach-intell.md
@@ -1,0 +1,78 @@
+# Journal: Nature Machine Intelligence — writing
+
+## Read the shared contract first
+
+Open
+`../../../../nature-shared/journal-formats/nature-machine-intelligence.md`.
+It is the canonical, stage-aware source for NMI content types, word/display
+limits, initial files, code/data policy and accepted-in-principle production
+rules.
+
+The notes below are the **drafting action layer** on top of those facts.
+
+## Audience and fit
+
+Write for readers across machine learning, robotics, AI applications and the
+scientific or societal domain affected by the work. The paper must still be
+technically exact, but the title, abstract and opening should explain the
+question and consequence without assuming one benchmark community's jargon.
+
+Do not equate a larger model, more compute, a small benchmark gain or an extra
+dataset with NMI-level significance. State what scientific, technical or
+societal understanding changes and bound transfer claims to the evaluated
+settings.
+
+## Article drafting contract
+
+- Budget no more than 3,500 words for Introduction + Results + Discussion;
+  Methods, abstract, references and legends are outside this count.
+- Keep the unreferenced abstract at no more than 150 words.
+- Use at most six figures and tables combined in the main display budget.
+- Plan around about 50 references unless the editor permits more.
+- Use an unheaded introduction followed by Results, Discussion and Methods.
+- Results and Methods may use topical subheadings; Discussion should not.
+
+Suggested starting budget for an Article:
+
+| Section | Suggested budget |
+|---|---:|
+| Introduction | 550–700 words |
+| Results | 2,100–2,350 words |
+| Discussion | 500–750 words |
+| **Counted main text** | **up to 3,500 words** |
+
+Methods has no fixed public numeric limit. Keep it concise, complete and
+reproducible instead of hiding essential details in Supplementary Information.
+
+## Machine-intelligence evidence gates
+
+Before strong novelty, generality or deployment language, ask for:
+
+- genuinely independent test data and leakage controls
+- baseline parity in data, supervision, tuning budget and compute
+- uncertainty, repeated runs and ablations for the claimed mechanism
+- robustness, failure cases and out-of-distribution limits
+- compute, hardware, software and environment detail sufficient to reproduce
+  the result
+- population, setting, human factors and prospective validation for real-world
+  or societal claims
+
+New code central to the conclusions requires a separate Code availability
+section, reviewer access and the Software Submission Checklist. Plan these
+artifacts while drafting Methods rather than after acceptance.
+
+## Submission-package actions
+
+- Treat the cover letter as part of the initial package. State importance,
+  NMI readership fit, related manuscripts and prior editor discussions.
+- If the manuscript extends a conference paper, identify the substantial new
+  results, methodology, analysis, conclusions or implications explicitly.
+- For double-anonymized review, move author contact information to the cover
+  letter and audit repositories, self-citations, acknowledgements and metadata.
+- Do not offer a presubmission enquiry; NMI does not consider them.
+
+## Numeric non-invention rule
+
+The current public NMI pages do not state a fixed title limit, Methods word
+limit or separate per-legend word limit. Do not borrow those numbers from
+flagship Nature or Nature Communications.

--- a/skills/nature-writing/static/fragments/task/submission-package.md
+++ b/skills/nature-writing/static/fragments/task/submission-package.md
@@ -11,6 +11,10 @@ Use this task only before the first editorial decision. Read `references/submiss
 4. For the flagship journal Nature, load
    `../../../../nature-shared/journal-formats/nature.md`; load the conditional
    research-compliance reference when its applicability gate is triggered.
+   For Nature Machine Intelligence, load
+   `../../../../nature-shared/journal-formats/nature-machine-intelligence.md`
+   and treat the cover letter, availability statements and central-code review
+   access as initial-package checks.
 5. Build a deliverable matrix: required, optional, not applicable, or author input needed.
 6. Draft only from author-supplied facts. Never invent author identities, affiliations, ORCIDs, funding numbers, ethics approvals, repository links, accession numbers, conflicts, reviewer identities, or permissions.
 7. Keep the initial cover letter concise and editor-facing: what the study shows, what is new, why it fits the journal/readership, and any required declarations.


### PR DESCRIPTION
## Summary
- add a dated, stage-aware Nature Machine Intelligence submission contract from official journal pages
- route NMI through writing, polishing, figure, data, and statistics skills without importing flagship Nature limits
- add bilingual documentation, semantic version bumps, and focused regression coverage

## Validation
- repository, metadata, README, README mirror, skill index, and workflow validators passed
- scripts/tests: 33 passed
- related skill packages: 30 passed
- skill-creator quick validation: 6 affected skills passed
- Codex and Claude Code installed trees: 19/19 MATCH each