### PR TITLE
Clarify NMI figure legend word guidance

### DIFF
--- a/scripts/tests/test_nmi_submission_requirements.py
+++ b/scripts/tests/test_nmi_submission_requirements.py
@@ -27,13 +27,14 @@ class NatureMachineIntelligenceSubmissionRequirementsTests(unittest.TestCase):
             "proof",
         ):
             self.assertIn(stage, rules)
-        self.assertIn("Verified **2026-08-12**", rules)
+        self.assertIn("Current pages verified **2026-08-14**", rules)
 
         for url in (
             "https://www.nature.com/natmachintell/submission-guidelines",
             "https://www.nature.com/natmachintell/content",
             "https://www.nature.com/natmachintell/editorial-policies/reporting-standards",
             "https://www.nature.com/natmachintell/editorial-policies/preprints-conference-proceedings",
+            "https://www.nature.com/documents/natmachintell-brief-submission-guide.pdf",
         ):
             self.assertIn(url, rules)
 
@@ -84,14 +85,38 @@ class NatureMachineIntelligenceSubmissionRequirementsTests(unittest.TestCase):
         ):
             self.assertIn(requirement, normalized)
 
-    def test_unpublished_numeric_limits_are_not_invented(self) -> None:
+    def test_current_limits_and_historical_legend_advisory_are_separate(self) -> None:
         rules = read(CONTRACT)
+        normalized = squash(rules)
 
         self.assertIn("do not publish", rules)
         self.assertIn("a fixed title character or word limit", rules)
         self.assertIn("a separate numeric Methods word limit", rules)
-        self.assertIn("a separate numeric per-figure-legend word limit", rules)
-        self.assertIn("do not import", rules)
+        self.assertIn("a current separate numeric per-figure-legend word limit", rules)
+        for requirement in (
+            "historical advisory ceiling",
+            "below **300 English words**",
+            "**150–250 English words**",
+            "one whole-figure legend",
+            "300 words is not a per-panel allowance",
+            "revised 9 July 2018",
+        ):
+            self.assertIn(requirement, normalized)
+
+    def test_legend_guardrail_reaches_figure_and_text_routes(self) -> None:
+        routes = (
+            "skills/nature-figure/SKILL.md",
+            "skills/nature-figure/references/figure-legend-conventions.md",
+            "skills/nature-writing/static/fragments/journal/nat-mach-intell.md",
+            "skills/nature-polishing/static/fragments/journal/nat-mach-intell.md",
+        )
+
+        for route in routes:
+            text = squash(read(route))
+            self.assertIn("2018", text)
+            self.assertIn("300", text)
+            self.assertIn("150–250", text)
+            self.assertIn("panel", text)
 
     def test_writing_and_polishing_have_distinct_nmi_routes(self) -> None:
         writing = read("skills/nature-writing/manifest.yaml")

--- a/skills/nature-figure/README.md
+++ b/skills/nature-figure/README.md
@@ -11,7 +11,7 @@
 - 规划 Figure 1、机制图、workflow、graphical abstract 或补充图。
 - 检查面板标签、配色与视觉层级、逐面板误差线、最终 PDF 实际字号、统计标注、source data 和导出格式。
 - 区分旗舰 `Nature` 初投稿、主图终稿和 Extended Data 的文件契约，并执行 `<250` 词图注上限。
-- 对 `Nature Machine Intelligence` 单独执行 6 个主 display、最多 10 个 Extended Data、初投稿/终稿边界、300 dpi/180 mm 和 source data 要求；不虚构 NMI 图注字数上限。
+- 对 `Nature Machine Intelligence` 单独执行 6 个主 display、最多 10 个 Extended Data、初投稿/终稿边界、300 dpi/180 mm 和 source data 要求；当前官网未给独立图注数字，保留 2018 官方 `<300` 英文词为历史建议线，整张图注建议 150–250 词且不是每个 panel 分别计算。
 - 在用户明确要求时，通过 OpenRouter Images API 调用 `openai/gpt-image-2` 生成 AI 概念示意图草稿。
 
 ## 工作方式

--- a/skills/nature-figure/README_EN.md
+++ b/skills/nature-figure/README_EN.md
@@ -11,7 +11,7 @@
 - Plan Figure 1, mechanism diagrams, workflows, graphical abstracts, or supplementary figures.
 - Check panel labels, color hierarchy, panel-by-panel uncertainty, actual PDF glyph sizes, statistical annotations, source data, and export formats.
 - Separate flagship `Nature` initial, final main-figure, and Extended Data file contracts, including the under-250-word legend limit.
-- Apply `Nature Machine Intelligence` (NMI)'s separate six-main-display, up-to-ten Extended Data, initial/final, 300-dpi/180-mm, and source-data requirements without inventing an NMI legend word limit.
+- Apply `Nature Machine Intelligence` (NMI)'s separate six-main-display, up-to-ten Extended Data, initial/final, 300-dpi/180-mm, and source-data requirements; the current pages give no standalone legend number, so retain the official 2018 `<300`-English-word rule only as a historical advisory, count the whole legend rather than each panel, and aim for 150–250 words.
 - When explicitly requested, call `openai/gpt-image-2` through the OpenRouter Images API to draft AI concept schematics.
 
 ## Workflow

--- a/skills/nature-figure/SKILL.md
+++ b/skills/nature-figure/SKILL.md
@@ -73,8 +73,12 @@ When the target is Nature Machine Intelligence, instead load
 `../nature-shared/journal-formats/nature-machine-intelligence.md`. Apply its
 combined six-item main display budget, ten-item Extended Data maximum,
 initial-versus-production boundary, 300-dpi/180-mm production checks and source-
-data contract. NMI's current public pages do not state a numeric per-legend
-word limit; do not import flagship Nature's limit.
+data contract. NMI's current live pages do not assign a standalone per-legend
+number, but its official 2018 brief guide set a historical advisory ceiling of
+fewer than 300 English words per complete figure legend. Count the whole legend,
+not each panel; aim for 150–250 words and keep it below 300 unless the live
+submission system or editor gives a newer instruction. Do not import flagship
+Nature's limit.
 
 The chart serves the scientific logic; aesthetic polish is subordinate to making the core conclusion clear, defensible, and reviewable.
 

--- a/skills/nature-figure/manifest.yaml
+++ b/skills/nature-figure/manifest.yaml
@@ -1,5 +1,5 @@
 name: nature-figure
-version: 2.4.0
+version: 2.4.1
 description: >
   Declarative manifest for the static/dynamic split. SKILL.md uses this to
   decide which fragments to load for a given figure request. The main axis is

--- a/skills/nature-figure/references/figure-legend-conventions.md
+++ b/skills/nature-figure/references/figure-legend-conventions.md
@@ -69,6 +69,12 @@ than figures.
   universal Nature Portfolio word limit.
 - For the flagship journal Nature, load `nature-article-requirements.md` and
   keep each complete figure legend below 250 words.
+- For Nature Machine Intelligence, load the shared NMI contract. Its current
+  live pages give no standalone per-legend number, while its official 2018
+  brief guide said to keep each figure legend below 300 English words. Count
+  the complete title-plus-panels legend, not each panel; aim for 150–250 words
+  and use below 300 as a historical advisory ceiling unless the live submission
+  system or editor gives a newer instruction.
 - For Nature Communications or another subjournal, verify the current journal
   and article-type instructions before enforcing a numerical cap.
 - Keep the `Fig. N |` title short and nominal; no numbers/results in the figure

--- a/skills/nature-polishing/manifest.yaml
+++ b/skills/nature-polishing/manifest.yaml
@@ -1,5 +1,5 @@
 name: nature-polishing
-version: 6.3.0
+version: 6.3.1
 description: >
   Declarative manifest for the static/dynamic split. SKILL.md uses this to
   decide which fragments to load for a given polishing request.

--- a/skills/nature-polishing/static/fragments/journal/nat-mach-intell.md
+++ b/skills/nature-polishing/static/fragments/journal/nat-mach-intell.md
@@ -49,5 +49,9 @@ the prose fit.
 - Preserve Data Availability and the separate Code availability section.
 - Flag missing reviewer access or a missing Software Submission Checklist when
   new code is central to the conclusions.
-- Do not apply a flagship Nature title, Methods or legend limit: NMI's current
-  public pages state no fixed number for those three items.
+- Do not apply a flagship Nature title, Methods or legend limit. NMI's current
+  public pages state no current fixed number for those items. For figure
+  legends, use the official 2018 NMI below-300-word instruction only as a
+  historical advisory ceiling: count the complete legend, not each panel, aim
+  for 150–250 English words, and obey any newer editor or submission-system
+  instruction.

--- a/skills/nature-shared/journal-formats/nature-machine-intelligence.md
+++ b/skills/nature-shared/journal-formats/nature-machine-intelligence.md
@@ -316,9 +316,27 @@ should define:
   applicable
 - scale bars and necessary sample identifiers
 
-Avoid placing a second Methods section in the legend. The current public NMI
-pages do **not** state a separate numeric per-legend word limit; do not import
-the flagship *Nature* below-250-word limit or invent an NMI number.
+Avoid placing a second Methods section in the legend. The current live NMI AIP
+page says that a legend should not exceed the word limit of the article type,
+but the current Content Types page does **not** assign a separate numeric limit
+to each figure legend.
+
+The official NMI brief submission guide revised 9 July 2018 explicitly said to
+keep each figure legend below **300 English words**. Because that number is not
+repeated on the current live pages, treat it as a **historical advisory ceiling**,
+not as a current journal hard limit.
+
+Use this operating guardrail unless the live submission system or handling
+editor gives a newer instruction:
+
+- count the title and all panel descriptions as **one whole-figure legend**;
+  300 words is not a per-panel allowance
+- aim for **150–250 English words** for an ordinary multi-panel legend
+- keep the complete legend below **300 English words** as a conservative
+  preflight ceiling
+- move expendable methodological detail to Methods or Supplementary
+  Information, but retain the `n`, uncertainty and statistical information
+  needed to interpret the figure
 
 ### Supplementary Information
 
@@ -376,11 +394,14 @@ The current official NMI pages reviewed for this contract do not publish:
 
 - a fixed title character or word limit
 - a separate numeric Methods word limit
-- a separate numeric per-figure-legend word limit
+- a current separate numeric per-figure-legend word limit; the older official
+  2018 guide's below-300-word instruction is retained only as an advisory
+  preflight ceiling
 
-Do not borrow numbers from flagship *Nature*, *Nature Communications*, a third-
-party checklist or an older template. Write concisely, then verify any new
-editor- or system-provided limit at the active submission stage.
+Do not borrow numbers from flagship *Nature*, *Nature Communications* or a
+third-party checklist. Do not present NMI's historical below-300-word figure-
+legend instruction as a current hard limit. Write concisely, then follow any
+new editor- or submission-system instruction at the active stage.
 
 Open-access article-processing charges and currencies can change. If the author
 asks for cost planning, check the live Publishing Options page instead of
@@ -388,7 +409,7 @@ treating a stored price as a submission rule.
 
 ## 12. Official sources
 
-Verified **2026-08-12**:
+Current pages verified **2026-08-14**:
 
 - Submission guidelines: <https://www.nature.com/natmachintell/submission-guidelines>
 - Content types: <https://www.nature.com/natmachintell/content>
@@ -403,3 +424,8 @@ Verified **2026-08-12**:
 - Presubmission enquiries: <https://www.nature.com/natmachintell/submission-guidelines/presubmission-enquiries>
 - Aims and scope: <https://www.nature.com/natmachintell/aims>
 - Publishing options: <https://www.nature.com/natmachintell/submission-guidelines/publishing-options>
+
+Historical official source retained for conservative preflight only:
+
+- Brief guide for submission to Nature Machine Intelligence, revised 9 July
+  2018: <https://www.nature.com/documents/natmachintell-brief-submission-guide.pdf>

--- a/skills/nature-shared/manifest.yaml
+++ b/skills/nature-shared/manifest.yaml
@@ -1,5 +1,5 @@
 name: nature-shared
-version: 1.3.0
+version: 1.3.1
 description: >
   Declarative manifest for shared Nature reference modules. This package is not
   a standalone workflow; installed Nature skills use it to load exact shared

--- a/skills/nature-writing/manifest.yaml
+++ b/skills/nature-writing/manifest.yaml
@@ -1,5 +1,5 @@
 name: nature-writing
-version: 1.2.0
+version: 1.2.1
 description: >
   Declarative manifest for the static/dynamic split. SKILL.md uses this to
   decide which fragments to load for a drafting, restructuring, or

--- a/skills/nature-writing/static/fragments/journal/nat-mach-intell.md
+++ b/skills/nature-writing/static/fragments/journal/nat-mach-intell.md
@@ -74,5 +74,8 @@ artifacts while drafting Methods rather than after acceptance.
 ## Numeric non-invention rule
 
 The current public NMI pages do not state a fixed title limit, Methods word
-limit or separate per-legend word limit. Do not borrow those numbers from
-flagship Nature or Nature Communications.
+limit or current separate per-legend word limit. Do not borrow those numbers
+from flagship Nature or Nature Communications. For figure legends, retain the
+official 2018 NMI below-300-word instruction only as a historical advisory:
+count the complete legend rather than each panel, aim for 150–250 English words,
+and follow any newer editor or submission-system instruction.


### PR DESCRIPTION
## Summary
- distinguish current live NMI guidance from the official 2018 historical figure-legend ceiling
- use 150–250 English words as the normal working range and below 300 as a conservative whole-legend advisory, not a per-panel allowance
- route the guidance through figure, writing, and polishing skills with version bumps and regression coverage

## Validation
- repository, metadata, README, README mirror, skill index, and workflow validators passed
- scripts/tests: 34 passed
- nature-shared and nature-figure package tests: 15 passed
- skill-creator quick validation: 4 affected skills passed