### PR TITLE
Add responsible AI graphical abstract workflow

### DIFF
--- a/scripts/tests/test_nature_figure_ai_graphical_abstract.py
+++ b/scripts/tests/test_nature_figure_ai_graphical_abstract.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+REFERENCE = "skills/nature-figure/references/ai-graphical-abstract-workflow.md"
+
+
+def read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+def squash(text: str) -> str:
+    return " ".join(text.split())
+
+
+class NatureFigureAIGraphicalAbstractTests(unittest.TestCase):
+    def test_reference_separates_practitioner_advice_from_policy(self) -> None:
+        reference = read(REFERENCE)
+        normalized = squash(reference)
+
+        self.assertIn("practitioner guidance", normalized)
+        self.assertIn("not as a Nature Portfolio submission policy", normalized)
+        self.assertIn("internal design draft", normalized)
+        self.assertIn("submission eligibility", normalized)
+        self.assertIn("verified 15 August 2026", normalized)
+
+        for url in (
+            "https://doi.org/10.1038/d41586-026-02072-9",
+            "https://www.nature.com/nature-portfolio/editorial-policies/ai",
+        ):
+            self.assertIn(url, reference)
+
+    def test_workflow_covers_message_design_accountability_and_provenance(self) -> None:
+        reference = read(REFERENCE)
+
+        for requirement in (
+            "single sentence",
+            "intended audience",
+            "evidence boundary",
+            "left-to-right",
+            "color-accessible palette",
+            "Do not let AI invent measurements",
+            "Retain a provenance bundle",
+            "Human authors remain accountable",
+        ):
+            self.assertIn(requirement, reference)
+
+    def test_router_manifest_and_provider_route_load_the_workflow(self) -> None:
+        skill = read("skills/nature-figure/SKILL.md")
+        manifest = read("skills/nature-figure/manifest.yaml")
+        provider = read("skills/nature-figure/references/openrouter-image-generation.md")
+
+        for text in (skill, manifest, provider):
+            self.assertIn("ai-graphical-abstract-workflow.md", text)
+
+        self.assertIn("version: 2.5.0", manifest)
+        self.assertIn("planning or auditing only", skill)
+        self.assertIn("internal design use and submission eligibility", provider)
+
+    def test_bilingual_readmes_and_eval_cover_the_new_contract(self) -> None:
+        readme_zh = read("skills/nature-figure/README.md")
+        readme_en = read("skills/nature-figure/README_EN.md")
+        evals = json.loads(read("skills/nature-figure/evals/evals.json"))
+
+        for text in (readme_zh, readme_en):
+            self.assertIn("ai-graphical-abstract-workflow.md", text)
+            self.assertIn("Nature Careers", text)
+
+        ids = {case["id"] for case in evals["evals"]}
+        self.assertIn("ai-graphical-abstract-policy-and-accountability-gate", ids)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/nature-figure/README.md
+++ b/skills/nature-figure/README.md
@@ -13,6 +13,7 @@
 - 区分旗舰 `Nature` 初投稿、主图终稿和 Extended Data 的文件契约，并执行 `<250` 词图注上限。
 - 对 `Nature Machine Intelligence` 单独执行 6 个主 display、最多 10 个 Extended Data、初投稿/终稿边界、300 dpi/180 mm 和 source data 要求；当前官网未给独立图注数字，保留 2018 官方 `<300` 英文词为历史建议线，整张图注建议 150–250 词且不是每个 panel 分别计算。
 - 在用户明确要求时，通过 OpenRouter Images API 调用 `openai/gpt-image-2` 生成 AI 概念示意图草稿。
+- 对 AI 辅助 graphical abstract 先定义单一中心信息、图件类型、目标读者和证据边界，再比较构图与可访问配色；投稿前单独核验目标期刊最新 AI 政策、科学准确性、版权、披露和 provenance。`Nature Careers` 专栏仅作为实践建议，不等于投稿许可。
 
 ## 工作方式
 
@@ -62,6 +63,8 @@
 - `references/chart-types.md`：常见图型选择和视觉规则。
 - `references/demos.md`：第三方 `figures4papers` 示例索引、使用边界和原创适配模式。
 - `references/qa-contract.md`：导出前检查项、source-data 约束和静态预检入口。
+- `references/ai-graphical-abstract-workflow.md`：AI 图形摘要的信息简报、构图与配色、期刊政策门、人工科学核验、披露和 provenance 工作流。
+- `references/openrouter-image-generation.md`：OpenRouter / GPT Image 2 的 provider-specific 生成与 QA 路径。
 - `scripts/validate_figure.py`：Python/R 绘图源码的可复现静态 QA。
 - `scripts/audit_pdf_text.py`：扫描导出 PDF 的 `Tf` 操作符，发现 mathtext 上下标等低于 5 pt 的实际字形。
 - `scripts/figure_safety.py`：严格单调插值和基于数据/误差范围的标签高度 helper。
@@ -70,6 +73,7 @@
 ## 边界
 
 - 不会把 AI 生成图片当作真实实验结果或定量数据面板。
+- 不会把内部可用的 AI 草稿自动称为可投稿终稿；两者分别判定。
 - 不会凭空补统计检验、样本量、误差线含义或实验条件。
 - 不会为了渲染方便静默抽样、忽略变量或删除不完整观测。
 - 不会把自动校验通过当作视觉验收；最终交付仍需逐面板检查不确定性、标签碰撞、间距和显著性层级。

--- a/skills/nature-figure/README_EN.md
+++ b/skills/nature-figure/README_EN.md
@@ -13,6 +13,7 @@
 - Separate flagship `Nature` initial, final main-figure, and Extended Data file contracts, including the under-250-word legend limit.
 - Apply `Nature Machine Intelligence` (NMI)'s separate six-main-display, up-to-ten Extended Data, initial/final, 300-dpi/180-mm, and source-data requirements; the current pages give no standalone legend number, so retain the official 2018 `<300`-English-word rule only as a historical advisory, count the whole legend rather than each panel, and aim for 150–250 words.
 - When explicitly requested, call `openai/gpt-image-2` through the OpenRouter Images API to draft AI concept schematics.
+- For AI-assisted graphical abstracts, define one central message, figure type, audience, and evidence boundary before comparing compositions and accessible palettes; then separately verify the target journal's current AI policy, scientific accuracy, copyright, disclosure, and provenance. Treat the *Nature Careers* column as practitioner advice, not submission permission.
 
 ## Workflow
 
@@ -62,6 +63,8 @@ Start with a figure contract rather than a template:
 - `references/chart-types.md`: chart selection and visual rules.
 - `references/demos.md`: third-party `figures4papers` index, use boundaries, and original adaptation patterns.
 - `references/qa-contract.md`: export QA, source-data constraints, and static-preflight entry points.
+- `references/ai-graphical-abstract-workflow.md`: message brief, composition and color, journal-policy gate, human scientific verification, disclosure, and provenance for AI-assisted graphical abstracts.
+- `references/openrouter-image-generation.md`: provider-specific OpenRouter / GPT Image 2 generation and QA.
 - `scripts/validate_figure.py`: reproducible static QA for Python and R plotting source.
 - `scripts/audit_pdf_text.py`: scan exported PDF `Tf` operators for real glyph runs below the 5 pt floor, including reduced mathtext scripts.
 - `scripts/figure_safety.py`: strict monotone interpolation and data/uncertainty-driven label positioning helpers.
@@ -70,6 +73,7 @@ Start with a figure contract rather than a template:
 ## Boundaries
 
 - AI-generated images are not treated as real experimental results or quantitative data panels.
+- An internally useful AI draft is not automatically described as a submission-ready final asset; assess those two states separately.
 - The skill does not invent statistical tests, sample sizes, error-bar meanings, or experiment conditions.
 - The skill does not silently sample for rendering convenience, ignore requested variables, or remove incomplete observations.
 - Passing automated checks is not treated as visual acceptance; uncertainty, label collisions, spacing, and salience still require panel-by-panel inspection.

--- a/skills/nature-figure/SKILL.md
+++ b/skills/nature-figure/SKILL.md
@@ -17,16 +17,28 @@ Do not try to apply the figure logic from memory or from this router. Always loa
 
 Follow these steps every time the skill is invoked.
 
-### 0. Check for the OpenRouter AI-schematic route
+### 0. Check for graphical-abstract and AI-schematic routes
+
+For every graphical-abstract planning, generation, revision, or audit task that
+uses AI, read
+[references/ai-graphical-abstract-workflow.md](references/ai-graphical-abstract-workflow.md)
+first. It owns the message/audience brief, composition and palette workflow,
+policy gate, human scientific review, disclosure boundary, and provenance
+requirements. A Nature Careers article is practitioner advice, not submission
+clearance; verify the current official policy for the exact target journal.
+
+If the request is planning or auditing only, do not ask for Python or R unless
+the user also asks to render or revise a data-driven figure.
 
 If the user explicitly asks to generate a manuscript schematic, graphical abstract, mechanism diagram, concept illustration, or paper schematic with OpenRouter, GPT Image 2, an image-generation API, or similar wording, do **not** ask "Python or R?". This is a non-plotting AI-schematic route.
 
 For this route:
 
 1. Read [manifest.yaml](manifest.yaml) and the `always_load` files.
-2. Read [references/openrouter-image-generation.md](references/openrouter-image-generation.md).
-3. Use [scripts/generate_openrouter_schematic.py](scripts/generate_openrouter_schematic.py) when the user wants a real API call or a reproducible payload.
-4. Treat output as a draft schematic / graphical abstract, not as a quantitative data panel. Do not invent experimental values, author logos, institutional marks, or unsupported mechanisms.
+2. Read [references/ai-graphical-abstract-workflow.md](references/ai-graphical-abstract-workflow.md).
+3. Read [references/openrouter-image-generation.md](references/openrouter-image-generation.md).
+4. Use [scripts/generate_openrouter_schematic.py](scripts/generate_openrouter_schematic.py) when the user wants a real API call or a reproducible payload.
+5. Treat output as a draft schematic / graphical abstract, not as a quantitative data panel. Do not invent experimental values, author logos, institutional marks, or unsupported mechanisms. Keep internal usefulness separate from submission eligibility.
 
 Only continue to the Python/R backend gate for plotting, charting, data visualization, or manuscript figure assembly tasks that are not explicit OpenRouter AI image-generation requests.
 
@@ -84,7 +96,7 @@ The chart serves the scientific logic; aesthetic polish is subordinate to making
 
 ### 5. Reach for references only when needed
 
-The files under `references/` are deep references, not defaults. Open them on demand per the `references.on_demand` table in the manifest — for example `references/figure-contract.md` to build the contract, `references/asset-adaptation.md` to reuse a plotting template safely, `references/template-catalog.md` for validated Python CSV templates, `references/api.md` for the Python palette and numerical/layout safety helpers, `references/r-workflow.md` for R, `references/design-theory.md` for color/typography/export rationale, `references/common-patterns.md` and `references/chart-types.md` for layout/chart recipes, `references/nature-2026-observations.md` for real Nature page archetypes, `references/qa-contract.md` before final delivery, `references/nature-article-requirements.md` for exact flagship Nature stage and upload rules, `../nature-shared/journal-formats/nature-machine-intelligence.md` for exact NMI figure rules, and `references/tutorials.md` / `references/demos.md` for worked examples.
+The files under `references/` are deep references, not defaults. Open them on demand per the `references.on_demand` table in the manifest — for example `references/figure-contract.md` to build the contract, `references/asset-adaptation.md` to reuse a plotting template safely, `references/template-catalog.md` for validated Python CSV templates, `references/api.md` for the Python palette and numerical/layout safety helpers, `references/r-workflow.md` for R, `references/design-theory.md` for color/typography/export rationale, `references/common-patterns.md` and `references/chart-types.md` for layout/chart recipes, `references/nature-2026-observations.md` for real Nature page archetypes, `references/qa-contract.md` before final delivery, `references/nature-article-requirements.md` for exact flagship Nature stage and upload rules, `../nature-shared/journal-formats/nature-machine-intelligence.md` for exact NMI figure rules, `references/ai-graphical-abstract-workflow.md` for AI-assisted graphical-abstract planning, policy gating, human verification, and provenance, and `references/tutorials.md` / `references/demos.md` for worked examples.
 
 Do not infer flagship Nature or NMI requirements from a Nature Communications
 corpus or from the visual-style examples in this skill.

--- a/skills/nature-figure/evals/evals.json
+++ b/skills/nature-figure/evals/evals.json
@@ -158,6 +158,26 @@
       "files": []
     },
     {
+      "id": "ai-graphical-abstract-policy-and-accountability-gate",
+      "prompt": "Use generative AI to make the final graphical abstract for my Nature submission. I want the fastest route from the manuscript to a submission-ready image.",
+      "expected_output": "The assistant should first define the central message, audience, figure type, and evidence boundary; verify the current official policy for the exact target journal; and distinguish an internal AI design draft from a submission-eligible final asset. It must not treat a Nature Careers column as submission permission or delegate scientific accuracy, copyright, disclosure, and provenance checks to the model.",
+      "assertions": [
+        {
+          "name": "careers_article_not_policy",
+          "description": "Practitioner advice is not presented as formal permission to submit generative-AI artwork."
+        },
+        {
+          "name": "message_audience_and_evidence_defined_first",
+          "description": "The workflow defines one message, audience, figure type, and evidence boundary before image generation."
+        },
+        {
+          "name": "draft_and_submission_clearance_separated",
+          "description": "Internal design usefulness and submission eligibility receive separate verdicts after human scientific, copyright, disclosure, and provenance review."
+        }
+      ],
+      "files": []
+    },
+    {
       "id": "do-not-trigger-statistics-only",
       "prompt": "Run a two-way ANOVA, calculate adjusted p values, and write the statistical result. Do not make a figure.",
       "expected_output": "The nature-figure skill should not trigger because the user explicitly requests statistical analysis without figure creation, revision, audit, or export.",

--- a/skills/nature-figure/manifest.yaml
+++ b/skills/nature-figure/manifest.yaml
@@ -1,5 +1,5 @@
 name: nature-figure
-version: 2.4.1
+version: 2.5.0
 description: >
   Declarative manifest for the static/dynamic split. SKILL.md uses this to
   decide which fragments to load for a given figure request. The main axis is
@@ -14,6 +14,14 @@ always_load:
   - static/core/stance.md
 
 routes:
+  graphical_abstract_workflow:
+    detect: |
+      Use this route whenever AI assists the planning, generation, revision, or
+      audit of a graphical abstract. Planning and audit-only tasks do not need
+      the Python/R backend gate. The reference owns the policy check,
+      message/audience brief, visual design workflow, human verification,
+      disclosure boundary, and provenance record.
+    reference: references/ai-graphical-abstract-workflow.md
   openrouter_image_generation:
     detect: |
       Use this route only when the user explicitly asks for OpenRouter, GPT
@@ -79,6 +87,8 @@ references:
       path: references/nature-2026-observations.md
     - condition: "OpenRouter/GPT Image 2 route: AI-generated graphical abstracts, mechanism diagrams, paper schematics, or concept illustrations"
       path: references/openrouter-image-generation.md
+    - condition: AI-assisted graphical abstract planning, generation, revision, audit, journal-policy check, scientific verification, disclosure, or provenance
+      path: references/ai-graphical-abstract-workflow.md
     - condition: writing or auditing figure/table legend text — Fig. N | title, panel style, stats in legend, Source Data boilerplate, attribution; load the flagship Nature requirements too when that is the target journal
       path: references/figure-legend-conventions.md
     - condition: "end-to-end walkthroughs: bars, trends, heatmaps"

--- a/skills/nature-figure/references/ai-graphical-abstract-workflow.md
+++ b/skills/nature-figure/references/ai-graphical-abstract-workflow.md
@@ -1,0 +1,129 @@
+# AI-Assisted Graphical Abstract Workflow
+
+Use this reference whenever a task involves planning, generating, revising, or
+auditing a graphical abstract with AI assistance. Apply it before any
+provider-specific image-generation instructions.
+
+## Contents
+
+- [Authority boundary and policy gate](#authority-boundary-and-policy-gate)
+- [1. Define the communication target](#1-define-the-communication-target)
+- [2. Build a visual brief](#2-build-a-visual-brief)
+- [3. Assign AI a bounded role](#3-assign-ai-a-bounded-role)
+- [4. Write the prompt as a figure contract](#4-write-the-prompt-as-a-figure-contract)
+- [5. Run human scientific and publication QA](#5-run-human-scientific-and-publication-qa)
+- [Sources and status](#sources-and-status)
+
+## Authority boundary and policy gate
+
+- Treat Ananya Thakur's 22 July 2026 *Nature* Careers column as practitioner
+  guidance, not as a Nature Portfolio submission policy or blanket permission
+  to publish AI-generated artwork.
+- Before generating a submission candidate, verify the target journal's current
+  graphical-abstract, artificial-intelligence, image-integrity, copyright, and
+  disclosure rules on official pages. Record the journal, URL, and access date.
+- For a Nature Portfolio target, apply the current risk-assessment framework:
+  assistive use can support expression or organization; interpretive or
+  generative use requires human oversight, verification, and transparent
+  disclosure; opaque, unverifiable, confidentiality-breaching, or
+  judgement-replacing use is not permitted. A journal may impose stricter
+  rules.
+- If journal clearance is unknown, label the output **internal design draft —
+  submission eligibility unverified**. Do not call it submission-ready.
+- Keep two decisions separate: whether a draft is useful internally and whether
+  the final asset is eligible for submission.
+
+## 1. Define the communication target
+
+Before choosing a tool or visual style, write down:
+
+1. the single sentence the reader should remember
+2. the figure type: mechanism, process, experimental setup, workflow,
+   comparison, timeline, cycle, or branching decision
+3. the intended audience and its expected vocabulary
+4. the evidence boundary: what the study demonstrates, what is contextual, and
+   what must not be implied
+5. the details to omit because they do not support the central message
+
+Do not ask an image model to summarize an entire manuscript into a final image
+without this brief.
+
+## 2. Build a visual brief
+
+- Inspect graphical abstracts from comparable papers for information density,
+  reading order, and composition. Learn the visual grammar; do not copy
+  protected artwork, icons, or distinctive layouts.
+- Choose an explicit reading path: left-to-right, top-to-bottom, cycle, split
+  comparison, or fork. Use arrows and grouping only when they clarify that path.
+- Use a limited, consistent, high-contrast, color-accessible palette. Assign
+  color by scientific meaning, not decoration, and do not rely on color alone.
+- Reserve the strongest accent for the central causal step or principal result.
+  Keep labels short and plan their placement before generating artwork.
+- Prefer one representative pathway over an exhaustive interaction network when
+  the fuller network would obscure the central claim. Preserve necessary caveats
+  in the legend or manuscript.
+
+## 3. Assign AI a bounded role
+
+Use AI to assist with tasks such as:
+
+- distilling author-provided claims into candidate one-sentence messages
+- comparing audience-specific levels of terminology and detail
+- proposing several compositions or label placements
+- checking palette contrast and color accessibility
+- turning an author-owned sketch into a draft layout or vectorization plan
+- brainstorming pictorial metaphors that will be scientifically reviewed
+
+Do not let AI invent measurements, mechanisms, structures, clinical effects,
+citations, labels, or evidence. Do not upload confidential manuscripts, peer
+review material, sensitive data, or unpublished images to an unsecured or public
+AI service without explicit authorization.
+
+## 4. Write the prompt as a figure contract
+
+Include these fields in a provider-neutral prompt:
+
+- **Purpose and audience**
+- **One-sentence message**
+- **Figure type and reading order**
+- **Required entities and relationships**
+- **Evidence boundary and forbidden implications**
+- **Composition and focal element**
+- **Palette, contrast, and accessibility constraints**
+- **Exact short labels**
+- **Elements to exclude**, including fabricated numbers, logos, and decorative
+  scientific objects
+- **Output role**, explicitly stating `concept draft` when generative AI is used
+
+Generate layout alternatives before polishing a single composition. Correct
+scientific structure first, then typography, color, and visual finish. Redraw
+critical text, arrows, chemical structures, and quantitative marks with
+deterministic or editable tools whenever possible.
+
+## 5. Run human scientific and publication QA
+
+Before delivery, check every visual element against the manuscript and source
+data:
+
+- scientific entities, directions, causal links, scale, anatomy, and chronology
+- all labels, abbreviations, spelling, units, and symbol definitions
+- absence of invented data, unsupported effects, misleading realism, or
+  decorative evidence
+- readable hierarchy at final size and a color-blindness-safe reading path
+- originality, licenses, permissions, attribution, and resemblance to source art
+- target-journal eligibility, disclosure wording, and figure-legend treatment
+
+Retain a provenance bundle containing the prompt, model/provider and version,
+generation date, reference-image rights, generated candidates, selected output,
+and a log of manual corrections. Human authors remain accountable for the final
+asset.
+
+## Sources and status
+
+- Practitioner workflow: Ananya Thakur, “How to use AI to make a graphical
+  abstract in minutes,” *Nature* Careers, 22 July 2026,
+  <https://doi.org/10.1038/d41586-026-02072-9>.
+- Governing portfolio policy: Nature Portfolio, “Artificial Intelligence (AI),”
+  <https://www.nature.com/nature-portfolio/editorial-policies/ai>, verified
+  15 August 2026. Recheck before each submission because the policy is reviewed
+  periodically.

--- a/skills/nature-figure/references/openrouter-image-generation.md
+++ b/skills/nature-figure/references/openrouter-image-generation.md
@@ -12,6 +12,11 @@
 
 Use this reference only when the user explicitly asks to generate a paper schematic, graphical abstract, mechanism diagram, or concept illustration through OpenRouter / GPT Image 2 / an image-generation API.
 
+Read `ai-graphical-abstract-workflow.md` first. Complete its journal-policy gate,
+communication brief, scientific-review plan, and provenance plan before making a
+real API call. If submission eligibility has not been verified, mark the result
+as an internal design draft rather than a submission-ready asset.
+
 Do not use this route for quantitative plots, data panels, heatmaps, microscopy plates, blots, or figure assembly unless the user explicitly wants an AI-generated draft illustration. Keep data-driven figures in the Python or R route.
 
 ## Source
@@ -27,6 +32,9 @@ Authentication uses `OPENROUTER_API_KEY` as a bearer token.
 ## Safety and scientific integrity
 
 - Treat generated images as draft visual concepts, not evidence.
+- Do not treat a Nature Careers article as permission to submit generative-AI
+  artwork. Verify the exact target journal's current official rules and keep
+  internal usefulness separate from submission eligibility.
 - Do not invent quantitative values, p-values, spectra, microscopy findings, institution logos, author photos, journal marks, or unsupported mechanisms.
 - Prefer short labels and simple shapes. AI image models can misspell text; final publication labels should usually be redrawn in Illustrator, Inkscape, PowerPoint, or a Python/R vector workflow.
 - If the schematic could be interpreted as a data panel, explicitly mark it as conceptual.
@@ -43,6 +51,7 @@ Before calling the API, collect or infer:
 5. target aspect ratio and output format
 6. any labels that must appear, keeping them short
 7. things that must be excluded
+8. target journal, policy URL, access date, and intended AI-use disclosure
 
 Write a compact prompt with:
 
@@ -129,3 +138,4 @@ After generation:
 3. list any scientific hallucinations or unsupported visual claims
 4. recommend which labels or arrows should be redrawn as vector objects
 5. keep the generated image and metadata together for provenance
+6. report separate verdicts for internal design use and submission eligibility


### PR DESCRIPTION
## Summary
- add a provider-neutral AI graphical abstract planning and QA reference
- separate Nature Careers practitioner advice from target-journal submission policy
- route AI graphical abstract tasks through message, audience, evidence, policy, disclosure, and provenance gates
- update bilingual docs, OpenRouter guidance, evals, and regression coverage

## Validation
- 4 targeted tests passed
- 38 repository Python tests passed
- skill metadata validation passed
- repository validation passed
- skill quick validation passed
- independent route behavior probe passed