### PR TITLE
chore: align Image2PPT metadata and CI dependencies

### DIFF
--- a/.github/workflows/test-skill-tooling.yml
+++ b/.github/workflows/test-skill-tooling.yml
@@ -58,6 +58,11 @@ jobs:
             skills/nature-downloader/requirements.txt
             skills/nature-image2ppt/requirements.txt
 
+      - name: Install Image2PPT system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends libreoffice-impress
+
       - name: Install test dependencies
         run: |
           python -m pip install \

--- a/skills/nature-image2ppt/agents/openai.yaml
+++ b/skills/nature-image2ppt/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Nature Image2PPT"
-  short_description: "将幻灯片图片和扫描页面重建为对象级可编辑 PowerPoint"
+  short_description: "Rebuild slide images and scans as editable PowerPoint objects"
   default_prompt: "Use $nature-image2ppt to reconstruct these slide images as a high-fidelity editable PowerPoint and complete rendered QA."


### PR DESCRIPTION
## What changed

- Replaced the Chinese `nature-image2ppt` UI short description with an English description.
- Installed `libreoffice-impress` in the Python CI job before running Image2PPT runtime tests.

## Why

The Nature Skills catalog uses English UI short descriptions consistently. The Image2PPT metadata was the lone localized exception.

The Image2PPT runtime requires LibreOffice on Linux for rendered QA, but the Ubuntu CI job installed only Python dependencies. This made `image2ppt doctor` report a missing renderer and caused five pre-existing runtime-test failures.

## Impact

The skill card now matches the rest of the catalog, and CI provides the documented Linux rendering dependency. Image2PPT runtime logic and skill triggering are unchanged.

## Checks

- `python scripts/validate-workflows.py`
- `python scripts/validate-repository.py`
- Five previously failing Image2PPT doctor/setup tests pass locally
- `git diff --check`
