### PR TITLE
feat: add Nature-wide evidence-chain writing guidance

### DIFF
--- a/scripts/tests/test_main_text_discipline.py
+++ b/scripts/tests/test_main_text_discipline.py
@@ -77,8 +77,8 @@ class MainTextDisciplineTests(unittest.TestCase):
         for relative in files:
             self.assertIn("main-text-discipline.md", read(relative), relative)
 
-        self.assertIn("version: 1.3.0", read("skills/nature-writing/manifest.yaml"))
-        self.assertIn("version: 6.4.0", read("skills/nature-polishing/manifest.yaml"))
+        self.assertIn("version: 1.4.0", read("skills/nature-writing/manifest.yaml"))
+        self.assertIn("version: 6.5.0", read("skills/nature-polishing/manifest.yaml"))
 
     def test_response_route_prevents_reviewer_driven_main_text_bloat(self) -> None:
         files = (
@@ -101,7 +101,7 @@ class MainTextDisciplineTests(unittest.TestCase):
 
     def test_shared_registry_docs_and_output_contracts_are_complete(self) -> None:
         shared_manifest = read("skills/nature-shared/manifest.yaml")
-        self.assertIn("version: 1.4.0", shared_manifest)
+        self.assertIn("version: 1.5.0", shared_manifest)
         self.assertIn("core/main-text-discipline.md", shared_manifest)
 
         for relative in (

--- a/scripts/tests/test_nature_abstract_guidance.py
+++ b/scripts/tests/test_nature_abstract_guidance.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+GUIDANCE = "skills/nature-shared/core/nature-abstract.md"
+
+
+def read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+def squash(text: str) -> str:
+    return " ".join(text.split())
+
+
+class NatureAbstractGuidanceTests(unittest.TestCase):
+    def test_guidance_is_corpus_derived_not_official_policy(self) -> None:
+        guidance = squash(read(GUIDANCE))
+
+        self.assertIn(
+            "corpus-derived writing guidance, not official journal requirements",
+            guidance,
+        )
+        self.assertIn("Current target-journal instructions", guidance)
+
+    def test_guidance_centres_the_discovery_evidence_chain(self) -> None:
+        guidance = squash(read(GUIDANCE))
+
+        for requirement in (
+            "shortest evidence chain",
+            "compressed Introduction",
+            "Use a discovery-centred architecture",
+            "Choose one central claim",
+            "one or two critical supporting findings or boundaries",
+            "The abstract is not a Methods summary",
+            "Experimental scale is a credibility cue, not the protagonist",
+        ):
+            self.assertIn(requirement, guidance)
+
+    def test_numeric_and_payoff_rules_are_selective(self) -> None:
+        guidance = squash(read(GUIDANCE))
+
+        for requirement in (
+            "Use numbers by necessity",
+            "do not require a numeric result merely to appear empirical",
+            "defines the strength or threshold of the main discovery",
+            "End with the conceptual payoff",
+            "Do not end with",
+            "Run the Nature abstract audit",
+        ):
+            self.assertIn(requirement, guidance)
+
+    def test_writing_and_polishing_routes_load_shared_guidance(self) -> None:
+        routes = (
+            "skills/nature-shared/SKILL.md",
+            "skills/nature-shared/manifest.yaml",
+            "skills/nature-writing/SKILL.md",
+            "skills/nature-writing/manifest.yaml",
+            "skills/nature-writing/static/fragments/journal/nat-mach-intell.md",
+            "skills/nature-polishing/SKILL.md",
+            "skills/nature-polishing/manifest.yaml",
+            "skills/nature-polishing/static/fragments/journal/nat-mach-intell.md",
+        )
+
+        for relative in routes:
+            self.assertIn("nature-abstract.md", read(relative), relative)
+
+    def test_section_fragments_do_not_require_decorative_numbers(self) -> None:
+        files = (
+            "skills/nature-writing/static/fragments/section/abstract.md",
+            "skills/nature-polishing/static/fragments/section/abstract.md",
+        )
+        combined = squash("\n".join(read(relative) for relative in files))
+
+        for requirement in (
+            "shortest evidence chain",
+            "one main claim",
+            "number is optional",
+            "numeric reporting is not mandatory",
+        ):
+            self.assertIn(requirement, combined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_nature_introduction_guidance.py
+++ b/scripts/tests/test_nature_introduction_guidance.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+GUIDANCE = "skills/nature-shared/core/nature-introduction.md"
+
+
+def read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+def squash(text: str) -> str:
+    return " ".join(text.split())
+
+
+class NatureIntroductionGuidanceTests(unittest.TestCase):
+    def test_guidance_is_corpus_derived_not_official_policy(self) -> None:
+        guidance = squash(read(GUIDANCE))
+
+        self.assertIn(
+            "corpus-derived writing guidance, not official journal requirements",
+            guidance,
+        )
+        self.assertIn("Current target-journal instructions", guidance)
+
+    def test_guidance_builds_an_exact_question_funnel(self) -> None:
+        guidance = squash(read(GUIDANCE))
+
+        for requirement in (
+            "Make the Introduction converge",
+            "exact unknown",
+            "It remains unclear whether, why, or under what conditions",
+            "Do not define the gap as the absence of the author's method",
+            "Organize citations by argumentative function",
+            "Prefer a question about a phenomenon, condition, mechanism, or boundary",
+            "Let the answer emerge late",
+        ):
+            self.assertIn(requirement, guidance)
+
+    def test_guidance_aligns_introduction_results_and_discussion(self) -> None:
+        guidance = squash(read(GUIDANCE))
+
+        for requirement in (
+            "End with a compact research route",
+            "Align Introduction, Results, and Discussion",
+            "establish why each central question must be asked",
+            "answer the questions through an escalating evidence chain",
+            "synthesize what those answers mean together",
+            "Run the Nature Introduction audit",
+            "Results answer",
+        ):
+            self.assertIn(requirement, guidance)
+
+    def test_writing_and_polishing_routes_load_shared_guidance(self) -> None:
+        routes = (
+            "skills/nature-shared/SKILL.md",
+            "skills/nature-shared/manifest.yaml",
+            "skills/nature-writing/SKILL.md",
+            "skills/nature-writing/manifest.yaml",
+            "skills/nature-writing/static/fragments/journal/nat-mach-intell.md",
+            "skills/nature-polishing/SKILL.md",
+            "skills/nature-polishing/manifest.yaml",
+            "skills/nature-polishing/static/fragments/journal/nat-mach-intell.md",
+        )
+
+        for relative in routes:
+            self.assertIn("nature-introduction.md", read(relative), relative)
+
+    def test_section_fragments_enforce_question_answer_alignment(self) -> None:
+        files = (
+            "skills/nature-writing/static/fragments/section/intro.md",
+            "skills/nature-polishing/static/fragments/section/intro.md",
+        )
+        combined = squash("\n".join(read(relative) for relative in files))
+
+        for requirement in (
+            "exact unresolved gap",
+            "known–unknown transition",
+            "absence of the author's method",
+            "question answered in Results",
+        ):
+            self.assertIn(requirement, combined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_nature_results_discussion_guidance.py
+++ b/scripts/tests/test_nature_results_discussion_guidance.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+GUIDANCE = "skills/nature-shared/core/nature-results-discussion.md"
+
+
+def read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+def squash(text: str) -> str:
+    return " ".join(text.split())
+
+
+class NatureResultsDiscussionGuidanceTests(unittest.TestCase):
+    def test_guidance_is_corpus_derived_not_official_policy(self) -> None:
+        guidance = squash(read(GUIDANCE))
+
+        self.assertIn(
+            "corpus-derived writing guidance, not official journal requirements",
+            guidance,
+        )
+        self.assertIn("Current target-journal instructions", guidance)
+        self.assertIn("corpus variation", guidance)
+
+    def test_results_claim_escalation_and_local_interpretation_are_operational(self) -> None:
+        guidance = squash(read(GUIDANCE))
+
+        for requirement in (
+            "establish and advance the paper's scientific claims",
+            "observation -> unresolved question -> targeted experiment",
+            "phenomenon -> source -> necessary condition or mechanism",
+            "association -> targeted disruption -> predicted degradation",
+            "Apply the local-interpretation gate",
+            "rules out a central alternative",
+            "reassurance that the same conclusion survives",
+        ):
+            self.assertIn(requirement, guidance)
+
+    def test_mixed_nature_corpus_supports_evidence_chain_archetypes(self) -> None:
+        guidance = squash(read(GUIDANCE))
+
+        for requirement in (
+            "author-supplied NMI reading set",
+            "flagship Nature papers",
+            "Discovery loop",
+            "Core capability and validation envelope",
+            "Capability ladder",
+            "establish the phenomenon -> stress-test it -> rule out alternatives",
+            "necessary comparators",
+            "content versus correct correspondence",
+            "If two adjacent subsections can both be summarized as `X helps`",
+        ):
+            self.assertIn(requirement, guidance)
+
+    def test_discussion_synthesizes_without_redemonstrating(self) -> None:
+        guidance = squash(read(GUIDANCE))
+
+        for requirement in (
+            "Write Discussion as synthesis, not re-demonstration",
+            "necessary recap / anchor",
+            "redundant re-demonstration",
+            "Scientific question",
+            "New claim",
+            "Inference gain",
+            "Evidence-chain role",
+            "Open by redefining the paper's central discovery",
+        ):
+            self.assertIn(requirement, guidance)
+
+    def test_writing_and_polishing_routes_load_shared_guidance(self) -> None:
+        routes = (
+            "skills/nature-shared/SKILL.md",
+            "skills/nature-shared/manifest.yaml",
+            "skills/nature-writing/SKILL.md",
+            "skills/nature-writing/manifest.yaml",
+            "skills/nature-writing/static/fragments/journal/nat-mach-intell.md",
+            "skills/nature-polishing/SKILL.md",
+            "skills/nature-polishing/manifest.yaml",
+            "skills/nature-polishing/static/fragments/journal/nat-mach-intell.md",
+        )
+
+        for relative in routes:
+            self.assertIn("nature-results-discussion.md", read(relative), relative)
+
+    def test_routes_cover_all_nature_portfolio_targets(self) -> None:
+        manifests = (
+            "skills/nature-shared/manifest.yaml",
+            "skills/nature-writing/manifest.yaml",
+            "skills/nature-polishing/manifest.yaml",
+        )
+
+        for relative in manifests:
+            route = squash(read(relative))
+            for target in (
+                "flagship Nature",
+                "Nature Communications",
+                "Nature Machine Intelligence",
+                "another Nature Portfolio title",
+            ):
+                self.assertIn(target, route, relative)
+
+    def test_old_facts_only_split_is_not_enforced(self) -> None:
+        files = (
+            "skills/nature-writing/static/fragments/section/experiments.md",
+            "skills/nature-writing/static/fragments/section/discussion.md",
+            "skills/nature-polishing/static/fragments/section/results.md",
+            "skills/nature-polishing/static/fragments/section/discussion.md",
+        )
+
+        combined = squash("\n".join(read(relative) for relative in files))
+        self.assertNotIn("Results = what we observed", combined)
+        self.assertNotIn("Results should answer what happened", combined)
+        self.assertIn("evidence chain that establishes and advances", combined)
+        self.assertIn("synthesizes across", combined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/nature-polishing/README.md
+++ b/skills/nature-polishing/README.md
@@ -10,6 +10,9 @@
 - 精简冗长句子，增强论证顺序和段落推进。
 - 按 Nature / Nature Communications / Nature Machine Intelligence 论文范式调整摘要、引言、结果、讨论或标题。
 - 对 NMI 识别独立路由，检查 3,500 词正文、150 词摘要、6 个 display、代码审查与会议论文实质扩展，不再误用旗舰 Nature 数字。
+- 对旗舰 Nature、Nature Communications、NMI 及其他 Nature Portfolio 期刊的 Results–Discussion，保留 claim 递进、证据绑定的局部解释和跨结果综合，区分必要回顾与重复论证。
+- 对所有 Nature / Nature Portfolio 目标的 Introduction，执行快速问题漏斗、精确 gap、文献张力、问题先行的 novelty 与 Introduction–Results 对齐检查。
+- 对所有 Nature / Nature Portfolio 目标的 Abstract，保留一个主发现、1–2 个决定性支撑或边界，只在数字定义或实质支撑核心 claim 时保留，并用有边界的意义句收尾。这三组默认最初来自 NMI 语料归纳，其中 Results–Discussion 又经旗舰 Nature 论文对照加强；它们均非官方规则。
 - 区分 research paper 与 methods paper 的写作重点。
 - 检查 AI 味、夸张声称、过度因果表达和不自然搭配。
 - 对全文或多轮修改稿执行一致性扫描，定位术语、单位、数值精度和内部声称漂移。

--- a/skills/nature-polishing/README_EN.md
+++ b/skills/nature-polishing/README_EN.md
@@ -10,6 +10,9 @@
 - Shorten long sentences and improve argument order and paragraph movement.
 - Adjust abstracts, introductions, results, discussions, or titles using Nature / Nature Communications / Nature Machine Intelligence article patterns.
 - Route NMI separately to check its 3,500-word main text, 150-word abstract, six-display budget, code-review duties, and substantial conference-paper extension without importing flagship Nature numbers.
+- For flagship Nature, Nature Communications, NMI, and other Nature Portfolio titles, preserve claim escalation, evidence-bound local interpretation, and cross-Results synthesis, distinguishing a necessary recap from redundant re-demonstration.
+- For every Nature / Nature Portfolio target, apply a fast problem funnel, exact gap, literature tension, question-first novelty, and Introduction–Results alignment.
+- For every Nature / Nature Portfolio target, keep one main discovery, one or two decisive supports or boundaries, only necessary core numbers, and a bounded payoff in the abstract. These three defaults were initially distilled from published NMI papers, with the Results–Discussion guidance further reinforced by flagship Nature comparisons, and generalized as Nature-style guidance; they are not official policy.
 - Distinguish research-paper and methods-paper writing priorities.
 - Check AI-like phrasing, exaggerated claims, excessive causal language, and unnatural collocations.
 - Sweep full or repeatedly revised manuscripts for terminology, unit, numeric-precision, and internal-claim drift.

--- a/skills/nature-polishing/SKILL.md
+++ b/skills/nature-polishing/SKILL.md
@@ -60,6 +60,22 @@ before sentence polishing. Classify each result, retain the shortest sufficient
 evidence chain, and require every addition to trigger a deletion or replacement
 check across the affected paragraph.
 
+For flagship Nature, Nature Communications, Nature Machine Intelligence, or
+another Nature Portfolio title, load the matching shared Nature-style corpus
+guidance:
+
+- Results or Discussion →
+  `../nature-shared/core/nature-results-discussion.md`
+- Introduction or whole-manuscript narrative →
+  `../nature-shared/core/nature-introduction.md`
+- Abstract → `../nature-shared/core/nature-abstract.md`
+
+Preserve claim escalation, the fast question funnel, Introduction–Results
+alignment, discovery-centred abstract compression, evidence-bound local
+interpretation, and cross-Results synthesis. These defaults were initially
+distilled from published NMI papers; treat them as corpus-derived guidance, not
+official policy, and obey the target journal's current rules when they differ.
+
 ### 5. Reach for references only when needed
 
 The files under `references/` are deep references, not defaults. Open them on demand per the `references.on_demand` table in the manifest, for example when the user explicitly asks for phrasebank-style alternatives or a stricter style audit.

--- a/skills/nature-polishing/manifest.yaml
+++ b/skills/nature-polishing/manifest.yaml
@@ -1,5 +1,5 @@
 name: nature-polishing
-version: 6.4.0
+version: 6.5.0
 description: >
   Declarative manifest for the static/dynamic split. SKILL.md uses this to
   decide which fragments to load for a given polishing request.
@@ -73,6 +73,12 @@ references:
   on_demand:
     - condition: polishing, restructuring, or shortening Results or full main text; deciding what belongs in main text versus captions or SI; preventing revision accretion; reducing statistical or claim repetition; or applying a paragraph necessity test
       path: ../nature-shared/core/main-text-discipline.md
+    - condition: target is flagship Nature, Nature Communications, Nature Machine Intelligence, or another Nature Portfolio title and the user is polishing or restructuring Results, Discussion, or their boundary; testing claim escalation; deciding whether local interpretation or robustness advances the claim; or separating necessary recap from redundant re-demonstration
+      path: ../nature-shared/core/nature-results-discussion.md
+    - condition: target is flagship Nature, Nature Communications, Nature Machine Intelligence, or another Nature Portfolio title and the user is polishing or restructuring the Introduction or whole-manuscript narrative; building a fast problem funnel, exact knowledge gap, literature tension, question-first novelty, compact study roadmap, or Introduction–Results alignment
+      path: ../nature-shared/core/nature-introduction.md
+    - condition: target is flagship Nature, Nature Communications, Nature Machine Intelligence, or another Nature Portfolio title and the user is polishing or restructuring the abstract; compressing the manuscript into a discovery-centred evidence chain; selecting one main claim, one or two decisive supports, optional core numbers, or a bounded field-level payoff
+      path: ../nature-shared/core/nature-abstract.md
     - condition: needs Nature/Nature Communications article-level patterns for abstracts, intros, Results openings, Discussion, conclusions, titles
       path: references/published-article-patterns.md
     - condition: empirical 2025 Nat Commun diction calibration — connector frequencies, the significantly red line, hedge/booster/tense word choices

--- a/skills/nature-polishing/static/fragments/journal/nat-mach-intell.md
+++ b/skills/nature-polishing/static/fragments/journal/nat-mach-intell.md
@@ -7,6 +7,18 @@ Open
 the exact, stage-aware NMI facts. This fragment controls polishing decisions,
 not the submission numbers themselves.
 
+For Results or Discussion, also open
+`../../../../nature-shared/core/nature-results-discussion.md`. It is
+corpus-derived Nature-style writing guidance, not an official NMI requirement.
+
+For Introduction polishing, also open
+`../../../../nature-shared/core/nature-introduction.md`. It is corpus-derived
+Nature-style writing guidance, not an official NMI requirement.
+
+For abstract polishing, also open
+`../../../../nature-shared/core/nature-abstract.md`. It is corpus-derived
+Nature-style writing guidance, not an official NMI requirement.
+
 ## Audience and stance
 
 Polish for readers across AI, robotics, machine learning and the scientific or
@@ -42,6 +54,39 @@ the prose fit.
   into causal, clinical or societal effectiveness.
 - Define specialist abbreviations and remove jargon that is not needed for
   technical accuracy.
+
+## Results–Discussion calibration
+
+- Preserve a claim-escalating Results sequence rather than flattening related
+  subsections into parallel experiment reports.
+- Keep a bounded local inference in Results when it directly resolves the
+  current experiment; move cross-result synthesis and broader implications to
+  Discussion.
+- Keep conclusion-changing robustness and failure boundaries visible in the
+  main text; move reassurance-only variants to SI.
+- Permit a brief finding anchor in Discussion, but remove repeated evidence,
+  effect sizes, and tests that merely re-demonstrate the Results claim.
+
+## Introduction calibration
+
+- Compress broad context until the specific unresolved problem appears early.
+- Replace vague limitation language with the exact unknown, condition,
+  mechanism, boundary, or literature tension.
+- Reorganize citation catalogues into a known–unknown argument.
+- Replace novelty adjectives with the research question and the design that can
+  answer it.
+- Check that each Introduction question maps to a Results answer and that the
+  closing paragraph previews this route without replaying the paper.
+
+## Abstract calibration
+
+- Rebuild the abstract around one main discovery rather than a list of
+  datasets, models, metrics, and completed analyses.
+- Keep only enough method information to show why the design answers the gap.
+- Retain no more than one or two decisive supporting claims or boundaries.
+- Keep a number only when it defines, supports, or bounds the main discovery.
+- Make the final sentence state the bounded conceptual or field-level payoff,
+  not merely superior performance.
 
 ## Submission-sensitive checks
 

--- a/skills/nature-polishing/static/fragments/section/abstract.md
+++ b/skills/nature-polishing/static/fragments/section/abstract.md
@@ -1,8 +1,9 @@
 # Section: Abstract
 
-The abstract is a mini-paper:
+The abstract is the manuscript's shortest evidence chain, not a compressed
+Introduction:
 
-`context/problem -> gap/objective -> approach -> key results -> implication`
+`precise problem/gap -> answer-enabling design -> main discovery -> decisive support/boundary -> implication`
 
 It should answer:
 
@@ -17,4 +18,9 @@ Some journals require a strict abstract format. Follow the journal if it conflic
 
 - Cut sentences that summarize background that the title already implies.
 - Make the gap and the contribution one short, locatable sentence each.
+- Organize the abstract around one main claim and at most one or two decisive
+  supporting claims or boundaries; do not inventory every Results subsection.
+- Keep method detail only when it explains why the question is answerable.
+- Keep a number only when it defines, supports, or materially bounds the main
+  discovery; numeric reporting is not mandatory by itself.
 - The last sentence should state significance, not repeat the result.

--- a/skills/nature-polishing/static/fragments/section/discussion.md
+++ b/skills/nature-polishing/static/fragments/section/discussion.md
@@ -9,10 +9,15 @@ Discussion should answer:
 - how the findings are interpreted
 - when that interpretation may fail
 
+Begin with a brief central-finding anchor when needed, then synthesize across
+Results claims. Do not replay the comparison, effect size, statistical test,
+and inference used to demonstrate each claim.
+
 Short rule:
 
-- `Results = what we observed`
-- `Discussion = how we understand it, and when it may fail`
+- `Results = the evidence chain that establishes and advances claims`
+- `Discussion = what those claims mean together, how they relate to the field,
+  and when the synthesis may fail`
 
 ## Sentence syntax
 

--- a/skills/nature-polishing/static/fragments/section/intro.md
+++ b/skills/nature-polishing/static/fragments/section/intro.md
@@ -10,6 +10,14 @@ The Introduction should:
 - state what question the paper asks
 - indicate how the study addresses it
 
+Use a converging funnel:
+
+`important problem -> specific phenomenon or difficulty -> what prior work establishes -> exact unknown -> research question or hypothesis -> study route`
+
+Make literature serve the known–unknown transition rather than catalogue the
+field. Let novelty emerge from the question and the design capable of answering
+it, not from adjectives.
+
 Do not summarize the Results section here. Do not summarize the Conclusion here.
 
 ## Common failure modes
@@ -18,3 +26,8 @@ Do not summarize the Results section here. Do not summarize the Conclusion here.
 - The gap is implied but never explicitly named.
 - The transition from "what is known" to "what this paper does" is missing.
 - Methods are previewed in detail; keep that for Methods.
+- The gap is defined as the absence of the author's method rather than a
+  scientific unknown.
+- Background paragraphs do not narrow toward a question answered in Results.
+- The closing paragraph lists contributions but does not preview the study's
+  question–answer route.

--- a/skills/nature-polishing/static/fragments/section/results.md
+++ b/skills/nature-polishing/static/fragments/section/results.md
@@ -1,6 +1,12 @@
 # Section: Results
 
-Results are a summary of the data collected to address the problem stated in the Introduction.
+Results are the evidence chain that establishes and advances the paper's
+scientific claims.
+
+Load `../../../../nature-shared/core/nature-results-discussion.md` when the
+target is Nature / Nature Portfolio. Rebuild the section around a discovery
+loop, a core-capability validation envelope, or a capability ladder rather than
+an experiment inventory.
 
 Results writing should:
 
@@ -15,7 +21,10 @@ Results writing should:
 - report the main descriptive quantity and primary inferential support once;
   avoid duplicating the full report in both Results and captions
 
-Results should answer `what happened`, not `what it ultimately means`.
+End each coherent evidence unit with the bounded inference it supports. Keep
+local interpretation when it directly answers the current experiment and the
+supporting evidence is visible there; move cross-result synthesis, extensive
+literature comparison, and broad implications to Discussion.
 
 ## Sentence syntax (Results vs Discussion)
 
@@ -27,11 +36,13 @@ Results sentences usually report:
 - `enabled`
 - `achieved`
 
-Do not let a Results paragraph drift into Discussion syntax (`may reflect`, `suggests that`, `is likely due to`) unless the transition is intentional.
+Use interpretive syntax (`may reflect`, `suggests that`, `is likely due to`)
+only when the transition is intentional, evidence-bound, and calibrated.
 
 ## Common failure modes
 
-- Interpreting findings inline instead of in Discussion.
+- Adding an inline interpretation that is unsupported by the current evidence,
+  or expanding a bounded inference into broad Discussion.
 - Citing supplementary data when the result should stand in the main text.
 - Treating every completed analysis as main-text material.
 - Appending reviewer-defense sentences without checking what they replace.
@@ -40,6 +51,9 @@ Do not let a Results paragraph drift into Discussion syntax (`may reflect`, `sug
 - Restating the same claim in a heading, transition, caption, Results paragraph,
   and closing sentence without adding a new function.
 - Vague comparisons (`higher than control`) without effect size or test.
+- Replaying an earlier baseline or control and drawing the same conclusion in a
+  later subsection, instead of centring the new perturbation, falsification,
+  stronger comparator, or boundary that creates the deeper inference.
 
 After restructuring, apply the paragraph necessity test to every Results
 paragraph and record whether text was retained, compressed, relocated, or

--- a/skills/nature-shared/README.md
+++ b/skills/nature-shared/README.md
@@ -20,6 +20,9 @@ always_load:
 | `core/terminology-ledger.md` | `nature-polishing`, `nature-writing`, `nature-reader`, `nature-paper2ppt` |
 | `core/consistency-sweep.md` | `nature-polishing`, `nature-reviewer`, `nature-response`, `nature-statistics` |
 | `core/main-text-discipline.md` | `nature-writing`, `nature-polishing`, `nature-response` |
+| `core/nature-results-discussion.md` | `nature-writing`, `nature-polishing` 通用的 Nature / Nature Portfolio Results claim 递进与 Discussion 综合（来自 NMI 与旗舰 Nature 已发表论文语料归纳，非官方规则） |
+| `core/nature-introduction.md` | `nature-writing`, `nature-polishing` 通用的 Nature / Nature Portfolio 问题漏斗、精确 gap 与 Introduction–Results 对齐（最初来自 NMI 语料归纳，非官方规则） |
+| `core/nature-abstract.md` | `nature-writing`, `nature-polishing` 通用的 Nature / Nature Portfolio 发现中心型摘要证据链、claim 层级与数字取舍（最初来自 NMI 语料归纳，非官方规则） |
 | `journal-formats/nat-comms.md` | `nature-polishing`, `nature-writing` |
 | `journal-formats/nature.md` | `nature-writing` 及需要旗舰 `Nature Article` 精确投稿规则的技能 |
 | `journal-formats/nature-machine-intelligence.md` | NMI 投稿的写作、润色、图表、数据与统计工作流 |

--- a/skills/nature-shared/README_EN.md
+++ b/skills/nature-shared/README_EN.md
@@ -20,6 +20,9 @@ always_load:
 | `core/terminology-ledger.md` | `nature-polishing`, `nature-writing`, `nature-reader`, `nature-paper2ppt` |
 | `core/consistency-sweep.md` | `nature-polishing`, `nature-reviewer`, `nature-response`, `nature-statistics` |
 | `core/main-text-discipline.md` | `nature-writing`, `nature-polishing`, `nature-response` |
+| `core/nature-results-discussion.md` | Nature / Nature Portfolio Results claim escalation and Discussion synthesis for `nature-writing` and `nature-polishing`, distilled from published NMI and flagship Nature papers (not official policy) |
+| `core/nature-introduction.md` | Nature / Nature Portfolio problem funnels, exact gaps, and Introduction–Results alignment for `nature-writing` and `nature-polishing`, initially distilled from NMI papers (not official policy) |
+| `core/nature-abstract.md` | Nature / Nature Portfolio discovery-centred abstract evidence chains, claim hierarchy, and numeric selection for `nature-writing` and `nature-polishing`, initially distilled from NMI papers (not official policy) |
 | `journal-formats/nat-comms.md` | `nature-polishing`, `nature-writing` |
 | `journal-formats/nature.md` | `nature-writing` and skills needing exact flagship `Nature Article` submission rules |
 | `journal-formats/nature-machine-intelligence.md` | Writing, polishing, figure, data, and statistics workflows for NMI submissions |

--- a/skills/nature-shared/SKILL.md
+++ b/skills/nature-shared/SKILL.md
@@ -17,4 +17,14 @@ Use this package only as a dependency of another installed Nature skill.
   requirements; do not import flagship Nature or Nature Communications limits.
 - Use `core/main-text-discipline.md` for result placement, main-text compression,
   revision accretion, caption/SI allocation, and claim-repetition checks.
+- Use `core/nature-results-discussion.md` for corpus-derived Nature-style
+  Results claim escalation, evidence-bound local interpretation, and Discussion
+  synthesis; do not present it as official journal policy.
+- Use `core/nature-introduction.md` for corpus-derived Nature-style problem
+  funnels, exact knowledge gaps, literature tension, question-first novelty,
+  and Introduction–Results alignment; do not present it as official journal
+  policy.
+- Use `core/nature-abstract.md` for corpus-derived Nature-style
+  discovery-centred abstract compression, claim hierarchy, selective numeric
+  support, and field-level payoff; do not present it as official journal policy.
 - Return to the requesting skill for task logic, output format, and final QA.

--- a/skills/nature-shared/core/nature-abstract.md
+++ b/skills/nature-shared/core/nature-abstract.md
@@ -1,0 +1,171 @@
+# Nature Abstract Corpus Guidance
+
+Use this reference when drafting, restructuring, or polishing an abstract for
+flagship **Nature**, **Nature Communications**, **Nature Machine Intelligence**,
+or another **Nature Portfolio** title. The patterns were initially distilled
+from an author-supplied reading set of published NMI papers and are generalized
+here as Nature-style defaults. They are **corpus-derived writing guidance, not
+official journal requirements**. Current target-journal instructions,
+article-type rules, reporting standards, and the paper's actual evidence always
+take precedence.
+
+## Contents
+
+- [Treat the abstract as the shortest evidence chain](#treat-the-abstract-as-the-shortest-evidence-chain)
+- [Use a discovery-centred architecture](#use-a-discovery-centred-architecture)
+- [Make the gap sharp and brief](#make-the-gap-sharp-and-brief)
+- [Keep only answer-enabling method logic](#keep-only-answer-enabling-method-logic)
+- [Select one main claim](#select-one-main-claim)
+- [Use numbers by necessity](#use-numbers-by-necessity)
+- [End with the conceptual payoff](#end-with-the-conceptual-payoff)
+- [Align the abstract with the manuscript](#align-the-abstract-with-the-manuscript)
+- [Run the Nature abstract audit](#run-the-nature-abstract-audit)
+
+## Treat the abstract as the shortest evidence chain
+
+Do not write the abstract as a compressed Introduction or a catalogue of
+sections. Compress the entire paper into the shortest chain that makes the
+central discovery understandable, credible, and consequential:
+
+`precise problem or gap -> what the study does to resolve it -> main discovery -> decisive support or boundary -> what the discovery establishes -> why it matters`
+
+Draft the abstract after the Introduction question, Results evidence chain,
+and Discussion synthesis are stable. The abstract should reveal the paper's
+argument, not the chronology of the research process.
+
+## Use a discovery-centred architecture
+
+Use this default move order for a Nature Portfolio research article:
+
+1. known phenomenon or important problem
+2. precise unresolved question
+3. study design or conceptual move used to answer it
+4. main discovery
+5. one or two critical supporting findings or boundaries
+6. conceptual, technical, or field-level implication
+
+Move rapidly into the present study. Spend only enough background to make the
+gap intelligible. The centre of gravity must be `we found X`, not `we evaluated
+many models and datasets` or `we propose a framework`.
+
+This move order is rhetorical guidance, not a requirement for six sentences.
+Combine moves when needed to satisfy the current target-journal abstract limit.
+
+## Make the gap sharp and brief
+
+Use one sentence, or at most the minimum needed, to join the known phenomenon
+to the exact unknown. Prefer:
+
+`X is increasingly used or observed, but whether, why, or under what conditions Y remains unclear.`
+
+Do not spend abstract space proving that the whole field is important,
+summarizing several generations of prior work, or rehearsing the Introduction
+funnel. Avoid generic gaps such as `existing methods still face challenges`
+when the paper addresses a precise source, condition, mechanism, or boundary.
+
+## Keep only answer-enabling method logic
+
+Describe the method at the minimum level needed to understand why the design
+can answer the stated question. Include, when central:
+
+- the controlled factor or contrast that identifies the claim
+- the perturbation, intervention, or decomposition that tests the proposed
+  source or mechanism
+- the scope needed to judge generalization
+- the theoretical property needed to understand the contribution
+
+Omit learning rates, hardware, routine data splits, implementation modules,
+and dataset-by-dataset detail unless one of them defines the discovery or its
+boundary. The abstract is not a Methods summary.
+
+## Select one main claim
+
+Choose one central claim and at most one or two supporting claims. Compress the
+remaining Results into evidence categories or omit them.
+
+Use this hierarchy:
+
+| Role | Abstract decision |
+|---|---|
+| Main claim | State explicitly and give it the most space |
+| Decisive support | Keep when needed to make the main claim credible |
+| Boundary | Keep when it materially changes how the claim must be read |
+| Scope credential | Mention briefly only when breadth itself supports the inference |
+| Secondary analysis | Omit or reserve for the main text/SI |
+
+Do not give every Results subsection one sentence. Experimental scale is a
+credibility cue, not the protagonist: use `across ... settings` only when that
+scope is necessary to understand generality or confidence.
+
+## Use numbers by necessity
+
+Nature Portfolio abstracts do not require a numeric result merely to appear
+empirical.
+Include a number only when it performs one of these functions:
+
+- defines the strength or threshold of the main discovery
+- is itself the paper's principal law, prediction, or selection result
+- makes a decisive comparison interpretable
+- establishes a boundary that qualitative wording would obscure
+
+Omit numbers when the conceptual or mechanistic claim is the contribution and
+the number would displace the evidence logic. Comparative wording may be
+adequate when the exact effect size is not the headline claim.
+
+If several numbers compete for space, keep the one that most changes the
+reader's understanding of the central claim. Do not report sample counts,
+benchmarks, models, metrics, and multiple effect sizes simply because they are
+available.
+
+## End with the conceptual payoff
+
+Use the final sentence to state what the findings change, enable, connect, or
+make predictable. Prefer a bounded field-level payoff over self-evaluation:
+
+- a mechanism or principle becomes identifiable
+- a design or architecture choice becomes predictable
+- a method becomes applicable to a previously inaccessible regime
+- two areas become conceptually connected
+- a practical decision gains a quantitative or mechanistic basis
+
+Do not end with `the proposed method achieves superior performance` or a broad
+promise unsupported by the tested scope.
+
+## Align the abstract with the manuscript
+
+Treat the four sections as different compressions of the same central claim:
+
+- **Abstract:** the manuscript's shortest claim–evidence–implication chain
+- **Introduction:** why the exact question must be asked
+- **Results:** the full escalating evidence chain that answers it
+- **Discussion:** what the answers mean together
+
+Every abstract claim must map to visible Results evidence. The final implication
+must match the Discussion synthesis without exceeding its boundaries. Do not
+introduce a claim, mechanism, or application in the abstract that the main text
+does not establish.
+
+## Run the Nature abstract audit
+
+Build this compact map before sentence polishing:
+
+| Abstract move | Content | Manuscript support | Keep test |
+|---|---|---|---|
+| Gap | Exact unresolved question | Introduction | Can it be stated in one sharp sentence? |
+| Design | Answer-enabling logic | Methods/Results | Does it explain why the question is answerable? |
+| Main discovery | One central claim | Results | Is this the paper's real advance? |
+| Support/boundary | One or two decisive findings | Results | Does each materially strengthen or bound the claim? |
+| Payoff | What the finding changes | Discussion | Is it important and scope-calibrated? |
+
+Then delete or compress:
+
+- background already implied by the title
+- implementation detail that does not explain identification or inference
+- experiment inventory presented instead of a discovery
+- secondary Results included only for completeness
+- numbers that do not define, support, or bound the main claim
+- a final sentence that merely says the method performs well
+
+Read the abstract once with all method and dataset names hidden. If the central
+discovery and why it matters are no longer clear, the abstract is organized
+around implementation rather than insight.

--- a/skills/nature-shared/core/nature-introduction.md
+++ b/skills/nature-shared/core/nature-introduction.md
@@ -1,0 +1,164 @@
+# Nature Introduction Corpus Guidance
+
+Use this reference when drafting, restructuring, or polishing an Introduction
+for flagship **Nature**, **Nature Communications**, **Nature Machine
+Intelligence**, or another **Nature Portfolio** title. The patterns were
+initially distilled from an author-supplied reading set of published NMI papers
+and are generalized here as Nature-style defaults. They are **corpus-derived
+writing guidance, not official journal requirements**. Current target-journal
+instructions, article-type rules, reporting standards, and the paper's actual
+evidence always take precedence.
+
+## Contents
+
+- [Make the Introduction converge](#make-the-introduction-converge)
+- [State an exact knowledge gap](#state-an-exact-knowledge-gap)
+- [Use literature to construct the gap](#use-literature-to-construct-the-gap)
+- [Frame a scientific question](#frame-a-scientific-question)
+- [Let the answer emerge late](#let-the-answer-emerge-late)
+- [End with a compact research route](#end-with-a-compact-research-route)
+- [Align Introduction, Results, and Discussion](#align-introduction-results-and-discussion)
+- [Run the Nature Introduction audit](#run-the-nature-introduction-audit)
+
+## Make the Introduction converge
+
+Build a narrowing argument rather than an extended topic overview:
+
+`important problem -> specific phenomenon or difficulty -> what existing approaches establish -> unresolved limitation or tension -> exact unknown -> research question or hypothesis -> what this study does`
+
+Move quickly. Assume the target journal's readers understand the broad field's
+importance; use only enough context to make the specific unresolved problem
+intelligible. By the end of the opening paragraph, expose the concrete
+phenomenon, contradiction, failure condition, or bottleneck whenever the
+material permits it.
+
+Delete or compress background that neither narrows the problem nor makes the
+eventual question necessary. A history of the field is not a substitute for a
+problem funnel.
+
+## State an exact knowledge gap
+
+Express the gap as something genuinely unknown, disputed, or untested. Prefer:
+
+- what causes an observed advantage or failure
+- under what conditions a claimed benefit appears or disappears
+- which mechanism, information source, or design choice is necessary
+- why two credible bodies of evidence disagree
+- whether a proposed representation or signal adds information beyond the
+  current baseline
+
+Avoid `existing methods have limitations` unless the next clause names the
+specific limitation and why resolving it matters. The reader should be able to
+complete the sentence:
+
+> It remains unclear whether, why, or under what conditions ______.
+
+Do not define the gap as the absence of the author's method. `No one has used
+our architecture for this task` is not yet a scientific unknown.
+
+## Use literature to construct the gap
+
+Organize citations by argumentative function, not as an author-by-author
+catalogue:
+
+1. establish the known capability, phenomenon, or prevailing explanation
+2. show what prior work has already resolved
+3. expose the unresolved condition, boundary, or contradiction
+4. make the present research question unavoidable
+
+When the literature contains tension, state both sides fairly and use the
+tension to motivate a discriminating question. Avoid generic transitions such
+as `substantial progress has been made, but challenges remain` when the cited
+work supports a more exact conflict or boundary.
+
+Every literature paragraph must earn its place by narrowing the question. Move
+material that only demonstrates breadth to Related Work, Methods context, or a
+shorter citation cluster.
+
+## Frame a scientific question
+
+Prefer a question about a phenomenon, condition, mechanism, or boundary over a
+method-demand claim:
+
+- weak: `Existing methods are limited; therefore, a new method is needed.`
+- stronger: `Performance improves in some settings but deteriorates in others;
+  which condition determines whether the proposed mechanism is beneficial?`
+
+Let novelty arise from the unanswered question and the study design capable of
+answering it. Remove unsupported novelty adjectives such as `novel`,
+`groundbreaking`, `unprecedented`, or `innovative` when the question,
+controlled comparison, or diagnostic perturbation already demonstrates the
+advance.
+
+## Let the answer emerge late
+
+Do not force the paper's preferred concept, mechanism, or framework into the
+opening before the problem logic has motivated it. First establish the
+phenomenon, limitation, and exact unknown; then introduce the study's conceptual
+move as the natural way to resolve that unknown.
+
+Use transitions such as `To address this question`, `To test this possibility`,
+or `To this end` only after the question is explicit. Do not use the transition
+to conceal a missing gap.
+
+## End with a compact research route
+
+Prefer one connected closing paragraph over a ceremonial contribution list for
+a Nature Portfolio research article, unless the target journal, article type,
+editor, or user requires another structure. The paragraph should state:
+
+`research question -> study design or conceptual move -> decisive evaluation route -> principal scope of inference`
+
+Preview the logic of the Results without replaying all findings, metrics, or
+figure-level detail. A restrained result-level statement is acceptable when it
+clarifies the paper's answer, but do not turn the final paragraph into an
+abstract or Discussion.
+
+The route should tell the reader why the chosen comparisons, perturbations,
+decompositions, or boundary tests can answer the stated question. Method names
+alone do not provide that logic.
+
+## Align Introduction, Results, and Discussion
+
+Treat the three sections as one story at different levels:
+
+- **Introduction:** establish why each central question must be asked.
+- **Results:** answer the questions through an escalating evidence chain.
+- **Discussion:** synthesize what those answers mean together.
+
+Draft backward from the paper's actual Results claims. For every central
+Results subsection, identify the question that the Introduction must motivate.
+For every question or hypothesis introduced, identify the Results subsection
+that answers it. Do not create parallel stories.
+
+A useful alignment pattern is:
+
+`Introduction: phenomenon -> unresolved source -> necessary-condition question -> decomposition question`
+
+`Results: establish phenomenon -> identify source -> perturb or test necessity -> decompose contributions -> establish boundaries`
+
+`Discussion: synthesize the answers -> relate to theory and prior work -> state implications and limits`
+
+## Run the Nature Introduction audit
+
+First state the paper's exact unknown in one sentence. If that sentence is
+vague, repair the gap before polishing prose.
+
+Then build this reverse-outline table:
+
+| Introduction unit | Narrowing move | Literature function | Question motivated | Results answer |
+|---|---|---|---|---|
+| Paragraph or sentence block | What becomes more specific here? | Establish, resolve, contrast, or expose gap | Which exact question follows? | Which Results subsection answers it? |
+
+Flag and revise any unit that:
+
+- adds field background without narrowing the problem
+- lists studies without constructing a known–unknown transition
+- introduces the solution before the reader can see why it is needed
+- claims novelty mainly through adjectives
+- previews a Results claim for which no question has been motivated
+- motivates a question that the Results never answer
+
+Before finalizing, run a deletion test: if removing a paragraph leaves the
+exact gap, research question, and Results roadmap intact, compress, relocate, or
+delete that paragraph.

--- a/skills/nature-shared/core/nature-results-discussion.md
+++ b/skills/nature-shared/core/nature-results-discussion.md
@@ -1,0 +1,215 @@
+# Nature Results–Discussion Corpus Guidance
+
+Use this reference when drafting, restructuring, or polishing Results and
+Discussion for flagship **Nature**, **Nature Communications**, **Nature Machine
+Intelligence**, or another **Nature Portfolio** title. The patterns were
+initially distilled from an author-supplied NMI reading set and reinforced by a
+second author-supplied comparison set of flagship Nature papers. They are
+generalized here as Nature-style defaults and remain **corpus-derived writing
+guidance, not official journal requirements**. Current target-journal
+instructions, article-type rules, reporting standards, and the paper's actual
+evidence always take precedence.
+
+## Contents
+
+- [Core division of labour](#core-division-of-labour)
+- [Build Results as claim escalation](#build-results-as-claim-escalation)
+- [Choose an evidence-chain archetype](#choose-an-evidence-chain-archetype)
+- [Prevent same-level repetition](#prevent-same-level-repetition)
+- [Prefer diagnostic experiments when mechanism matters](#prefer-diagnostic-experiments-when-mechanism-matters)
+- [End evidence units with an inference](#end-evidence-units-with-an-inference)
+- [Apply the local-interpretation gate](#apply-the-local-interpretation-gate)
+- [Write Discussion as synthesis, not re-demonstration](#write-discussion-as-synthesis-not-re-demonstration)
+- [Run the Nature claim-escalation audit](#run-the-nature-claim-escalation-audit)
+
+## Core division of labour
+
+- **Results:** establish and advance the paper's scientific claims through an
+  evidence chain. Results may include comparison, ablation, perturbation,
+  robustness, failure analysis, directly evidence-bound interpretation, and a
+  local inference.
+- **Discussion:** synthesize several established claims into a higher-order
+  understanding, relate that understanding to prior work, explain its
+  importance, and bound its implications.
+
+Do not enforce the mechanical split `Results = facts only` and
+`Discussion = all interpretation`. The operative boundary is local versus
+synthetic interpretation: keep an explanation in Results when it directly
+resolves the experiment just reported; move broader theory, literature
+integration, general implications, and extended speculation to Discussion.
+
+## Build Results as claim escalation
+
+Make each Results subsection answer one scientific question and establish one
+new claim. Prefer a conclusion-bearing heading over a procedural experiment
+label when the evidence supports it.
+
+Order adjacent subsections so that each result creates the next question:
+
+`observation -> unresolved question -> targeted experiment -> comparison or perturbation -> local interpretation -> stronger claim -> next question`
+
+At paper level, prefer an escalating arc such as:
+
+`phenomenon -> source -> necessary condition or mechanism -> decomposition -> boundary or robustness`
+
+Do not substitute repeated demonstrations of the same claim for escalation.
+Two subsections may share data, conditions, or methods; they become redundant
+only when they collapse to the same inferential conclusion.
+
+## Choose an evidence-chain archetype
+
+Organize Results by inferential function, not by a routine inventory such as
+`system description -> benchmark -> ablation`. Select or combine the archetype
+that matches the scientific claim:
+
+### Discovery loop
+
+Use when evidence changes what should be tested next:
+
+`initial hypothesis -> real or decisive test -> analyse the resulting evidence -> refine the hypothesis -> next test -> architecture or mechanism validation`
+
+The Results should preserve the epistemic loop without becoming a chronological
+lab notebook. Keep only iterations that change the claim or the next scientific
+question.
+
+### Core capability and validation envelope
+
+Use when the paper establishes one central capability, then asks whether it is
+reliable, safe, general, or confounded:
+
+`establish core capability -> validate in decisive settings -> test safety or bias -> rule out central alternatives -> define limits`
+
+Treat medication, subgroup, decision, bias, or perturbation analyses as the
+validation envelope of the main story when they answer whether the same core
+capability survives important conditions. Do not present each check as an
+unrelated second discovery.
+
+### Capability ladder
+
+Use when a system or model supports progressively stronger claims:
+
+`quantitative performance -> robustness to data properties -> stronger competitors or tuned ensembles -> interpretability -> broader foundation or transfer abilities`
+
+Each rung must justify a stronger inference. More datasets or another benchmark
+at the same inferential level do not automatically create a new rung.
+
+Across archetypes, the most common functional chain is:
+
+`establish the phenomenon -> stress-test it -> rule out alternatives -> broaden it -> interpret it -> bound it`
+
+Not every paper needs every move. Preserve the shortest chain sufficient for
+the central claim.
+
+## Prevent same-level repetition
+
+A later subsection may reuse an earlier baseline, control, or reference
+contrast, but it must not present the same comparison and conclusion as a new
+result. Treat reused conditions as **necessary comparators**, not as the centre
+of the later subsection.
+
+Ask what deeper discriminator the later analysis adds:
+
+- content versus correct correspondence
+- association versus necessity
+- nominal performance versus robustness
+- apparent gain versus a data, compute, or tuning confound
+- one setting versus the boundary of generalization
+
+Make the new perturbation, falsification, stronger comparator, or boundary test
+the subsection's decisive evidence. If two adjacent subsections can both be
+summarized as `X helps`, merge them, compress the repeated contrast, or move the
+weaker demonstration to SI. A valid progression looks like:
+
+`X is associated with the effect -> disrupting the proposed relation removes the effect -> therefore the relation, not merely the presence of X, is necessary within the tested design`
+
+## Prefer diagnostic experiments when mechanism matters
+
+When the claim concerns why a result occurs, do more than show performance with
+and without a component. Where scientifically valid, perturb, shuffle, mask,
+misalign, remove, or otherwise disrupt the proposed information or mechanism,
+then test whether the predicted degradation occurs.
+
+Use the logic:
+
+`association -> targeted disruption -> predicted degradation -> bounded mechanism inference`
+
+Do not turn this pattern into automatic causal language. Calibrate the
+inference to the intervention, controls, design, and alternative explanations.
+
+## End evidence units with an inference
+
+After a coherent group of measurements, state what the evidence establishes;
+do not stop at a sequence of numbers. The inference must be no broader than the
+evaluated conditions.
+
+Report failures, reversals, anomalous scaling, weak subgroups, and performance
+trade-offs when they materially define where the claim holds, weakens, or
+fails. Do not hide a conclusion-changing boundary in Supplementary
+Information.
+
+Place robustness in the main text when it establishes a necessary condition,
+rules out a central alternative, reveals a failure boundary, or otherwise
+creates an independent scientific inference. Route it to SI when it only adds
+reassurance that the same conclusion survives another seed, estimator,
+threshold, or secondary specification.
+
+## Apply the local-interpretation gate
+
+Results may use calibrated language such as `suggests`, `indicates`, `likely
+because`, `probably owing to`, or `we speculate that` only when all of the
+following hold:
+
+1. the interpretation answers the question raised by the immediately preceding
+   result
+2. the evidence for it is visible in the current subsection
+3. uncertainty and alternative explanations remain explicit
+4. the passage closes the local evidence unit instead of opening a broad field
+   discussion
+
+If several sentences are needed to reconcile theory, prior literature, or
+competing mechanisms, state the bounded local inference in Results and move the
+extended synthesis to Discussion or SI as appropriate.
+
+## Write Discussion as synthesis, not re-demonstration
+
+Use the move order:
+
+`brief central finding anchor -> cross-Results synthesis -> relation to prior work or theory -> importance -> boundary conditions and limitations -> broader implications or future directions`
+
+Open by redefining the paper's central discovery in one compressed judgement.
+A short recap—and occasionally one indispensable anchor number—is acceptable.
+Then move immediately to mechanism or conceptual interpretation, significance,
+limitations, and future directions. Do not repeat the full comparison, effect
+size, statistical test, and inference already used to demonstrate the claim in
+Results.
+
+Distinguish:
+
+- **necessary recap / anchor:** `Results establishes X; taken together, X implies Y`
+- **redundant re-demonstration:** Results and Discussion both replay
+  `A versus B -> effect -> test -> therefore X`
+
+Some published Nature Portfolio content types may use a Conclusion rather than
+a standalone Discussion. Treat that as corpus variation, not permission to
+ignore the current target-journal article-type instructions or an
+editor-provided template.
+
+## Run the Nature claim-escalation audit
+
+For each Results subsection, record:
+
+| Audit field | Question |
+|---|---|
+| Scientific question | What unresolved question does this subsection answer? |
+| New claim | What proposition becomes supportable here that was not supportable before? |
+| Evidence-chain role | Establish, stress-test, discriminate, broaden, interpret, or bound? |
+| Decisive evidence | Which comparison, perturbation, or analysis establishes it? |
+| Inference gain | What independent inference would disappear if the subsection were removed? |
+| Next question | What uncertainty naturally motivates the following subsection? |
+
+Flag adjacent subsections when their `New claim` or `Inference gain` entries are
+substantively identical. Merge, compress, or move the weaker repetition to SI.
+
+Before finalizing Discussion, map every repeated claim to a distinct rhetorical
+function: `anchor`, `synthesize`, `relate`, `bound`, or `extend`. Delete any
+repetition that only re-demonstrates the Results evidence.

--- a/skills/nature-shared/manifest.yaml
+++ b/skills/nature-shared/manifest.yaml
@@ -1,5 +1,5 @@
 name: nature-shared
-version: 1.4.0
+version: 1.5.0
 description: >
   Declarative manifest for shared Nature reference modules. This package is not
   a standalone workflow; installed Nature skills use it to load exact shared
@@ -27,6 +27,12 @@ core:
       path: core/consistency-sweep.md
     - condition: drafting, restructuring, compressing, or reviewer-revising scientific main text — classify results as core/support/qualification/robustness/heterogeneity/provenance/alternative inference/edge case; allocate evidence across main text, captions, and SI; run paragraph-necessity, deletion, statistics-location, and claim-repetition checks
       path: core/main-text-discipline.md
+    - condition: drafting, restructuring, or polishing Results or Discussion for flagship Nature, Nature Communications, Nature Machine Intelligence, or another Nature Portfolio title; auditing claim escalation, evidence-bound local interpretation, diagnostic perturbation, necessary recap versus redundant re-demonstration, or cross-Results synthesis
+      path: core/nature-results-discussion.md
+    - condition: drafting, restructuring, or polishing an Introduction for flagship Nature, Nature Communications, Nature Machine Intelligence, or another Nature Portfolio title; building a fast problem funnel, exact knowledge gap, literature tension, question-first novelty, compact study roadmap, or Introduction–Results alignment audit
+      path: core/nature-introduction.md
+    - condition: drafting, restructuring, or polishing an abstract for flagship Nature, Nature Communications, Nature Machine Intelligence, or another Nature Portfolio title; compressing the manuscript into a discovery-centred evidence chain; selecting one main claim, one or two decisive supports, optional core numbers, and a bounded field-level payoff
+      path: core/nature-abstract.md
 
 journal_formats:
   on_demand:

--- a/skills/nature-writing/README.md
+++ b/skills/nature-writing/README.md
@@ -16,6 +16,9 @@
 - 整理推荐审稿人、投稿材料矩阵和提交前完整性检查。
 - 对旗舰 `Nature Article` 执行分阶段官网清单：初投稿文件、标题/字数/display 限制、Extended Data、SI、Reporting Summary、伦理和专项材料。
 - 对 `Nature Machine Intelligence` 执行独立的分阶段投稿合同：Article/Analysis 字数与 6 个 display 上限、必需 cover letter、最多 10 个 Extended Data、会议论文实质扩展、数据与中心代码审查要求。
+- 对旗舰 Nature、Nature Communications、NMI 及其他 Nature Portfolio 期刊的 Results，按“每节推进一个 claim”组织证据链，允许直接服务于当前实验的局部解释，并将 Discussion 收束为跨结果综合而非重复论证。
+- 对所有 Nature / Nature Portfolio 目标的 Introduction，快速从具体问题收敛到精确 unknown，用文献建立 known–unknown 张力，以问题和可回答它的设计体现 novelty，并逐项对齐 Introduction 问题链与 Results 答案链。
+- 对所有 Nature / Nature Portfolio 目标的 Abstract，按“精确 gap → 可回答的设计 → 主发现 → 1–2 个决定性支撑/边界 → 意义”压缩为最短证据链，数字仅在定义或实质支撑核心 claim 时保留。这三组默认最初来自 NMI 已发表论文语料归纳，其中 Results–Discussion 又经旗舰 Nature 论文对照加强；它们适用于 Nature 风格写作，但都不是官方投稿规则。
 
 ## 典型请求
 

--- a/skills/nature-writing/README_EN.md
+++ b/skills/nature-writing/README_EN.md
@@ -16,6 +16,9 @@
 - Organize reviewer suggestions, a deliverable matrix, and a pre-submission completeness audit.
 - Run the stage-aware official checklist for a flagship `Nature Article`: initial files, title/text/display limits, Extended Data, SI, Reporting Summary, ethics, and specialist materials.
 - Apply a dedicated stage-aware `Nature Machine Intelligence` contract covering Article/Analysis word and six-display limits, the required cover letter, up to ten Extended Data items, substantial conference-paper extensions, and data/central-code review access.
+- For flagship Nature, Nature Communications, NMI, and other Nature Portfolio titles, structure Results so each subsection advances a claim, permit evidence-bound local interpretation, and make Discussion synthesize across Results rather than re-demonstrate them.
+- For every Nature / Nature Portfolio target, make Introductions converge rapidly on an exact unknown, use literature to construct the known–unknown tension, express novelty through the question and answerable design, and align each Introduction question with a Results answer.
+- For every Nature / Nature Portfolio target, compress abstracts into a shortest evidence chain—exact gap, answer-enabling design, one main discovery, one or two decisive supports or boundaries, and a bounded payoff—retaining numbers only when they define or materially support the central claim. These three defaults were initially distilled from published NMI papers, with the Results–Discussion guidance further reinforced by flagship Nature comparisons, and generalized as Nature-style guidance; they are not official submission rules.
 
 ## Typical Requests
 

--- a/skills/nature-writing/SKILL.md
+++ b/skills/nature-writing/SKILL.md
@@ -64,6 +64,22 @@ text, captions, Methods/source data, and SI, then draft the shortest sufficient
 evidence chain. Do not equate a complete analysis record with a complete main
 text.
 
+When the target is flagship Nature, Nature Communications, Nature Machine
+Intelligence, or another Nature Portfolio title, load the matching shared
+Nature-style corpus guidance for the section being drafted:
+
+- Results or Discussion →
+  `../nature-shared/core/nature-results-discussion.md`
+- Introduction or whole-manuscript narrative →
+  `../nature-shared/core/nature-introduction.md`
+- Abstract → `../nature-shared/core/nature-abstract.md`
+
+Use these files for claim escalation, question-chain alignment,
+discovery-centred compression, and synthesis. They were initially distilled
+from published NMI papers and generalized as Nature-style defaults; do not
+present them as official policy, and let the target journal's current rules
+override them.
+
 For `task=submission-package`, follow `static/fragments/task/submission-package.md` and `references/submission-package.md` instead. Build the deliverable matrix and readiness audit; do not force manuscript paragraph architecture onto administrative submission materials.
 
 If essential evidence or boundary is missing, write a placeholder and list it under `Assumptions or missing inputs:` instead of inventing content.
@@ -86,6 +102,15 @@ The files under `references/` are deep references and the example library, not d
 - The target is Nature Machine Intelligence and exact content-type, submission,
   data/code or production requirements matter →
   `../nature-shared/journal-formats/nature-machine-intelligence.md`.
+- Any Nature / Nature Portfolio target needs Results claim progression,
+  evidence-bound interpretation, robustness placement, or Discussion synthesis
+  → `../nature-shared/core/nature-results-discussion.md`.
+- Any Nature / Nature Portfolio target needs an Introduction funnel, exact gap,
+  literature logic, question-first novelty, study roadmap, or alignment with
+  Results → `../nature-shared/core/nature-introduction.md`.
+- Any Nature / Nature Portfolio target needs abstract evidence-chain,
+  main/supporting-claim, numeric-result, or final-payoff decisions →
+  `../nature-shared/core/nature-abstract.md`.
 - The work involves regulated or specialist research compliance →
   `../nature-shared/core/research-compliance.md`.
 

--- a/skills/nature-writing/manifest.yaml
+++ b/skills/nature-writing/manifest.yaml
@@ -1,5 +1,5 @@
 name: nature-writing
-version: 1.3.0
+version: 1.4.0
 description: >
   Declarative manifest for the static/dynamic split. SKILL.md uses this to
   decide which fragments to load for a drafting, restructuring, or
@@ -95,6 +95,12 @@ references:
   on_demand:
     - condition: task is manuscript and the user is drafting, restructuring, or compressing Results or full main text; deciding what belongs in main text versus captions or SI; preventing revision accretion; reducing statistical or claim repetition; or building the shortest sufficient evidence chain
       path: ../nature-shared/core/main-text-discipline.md
+    - condition: target is flagship Nature, Nature Communications, Nature Machine Intelligence, or another Nature Portfolio title and the user is drafting or restructuring Results, Discussion, or their boundary; testing claim escalation; deciding whether local interpretation or robustness advances the claim; or separating necessary recap from redundant re-demonstration
+      path: ../nature-shared/core/nature-results-discussion.md
+    - condition: target is flagship Nature, Nature Communications, Nature Machine Intelligence, or another Nature Portfolio title and the user is drafting or restructuring the Introduction or whole-manuscript narrative; building a fast problem funnel, exact knowledge gap, literature tension, question-first novelty, compact study roadmap, or Introduction–Results alignment
+      path: ../nature-shared/core/nature-introduction.md
+    - condition: target is flagship Nature, Nature Communications, Nature Machine Intelligence, or another Nature Portfolio title and the user is drafting or restructuring the abstract; compressing the manuscript into a discovery-centred evidence chain; selecting one main claim, one or two decisive supports, optional core numbers, or a bounded field-level payoff
+      path: ../nature-shared/core/nature-abstract.md
     - condition: needs section-level structure, argument order, or published-article patterns
       path: references/article-architecture.md
     - condition: genre-aware 2025 Nat Commun empirical structure, quantified connector/diction preferences, or research/review/perspective/comment/benchmark differences

--- a/skills/nature-writing/static/fragments/journal/nat-mach-intell.md
+++ b/skills/nature-writing/static/fragments/journal/nat-mach-intell.md
@@ -10,6 +10,20 @@ rules.
 
 The notes below are the **drafting action layer** on top of those facts.
 
+For Results or Discussion drafting, also open
+`../../../../nature-shared/core/nature-results-discussion.md`. It records
+corpus-derived Nature-style writing patterns, not official submission
+requirements.
+
+For Introduction drafting, also open
+`../../../../nature-shared/core/nature-introduction.md`. It records
+corpus-derived Nature-style writing patterns, not official submission
+requirements.
+
+For abstract drafting, also open
+`../../../../nature-shared/core/nature-abstract.md`. It records corpus-derived
+Nature-style writing patterns, not official submission requirements.
+
 ## Audience and fit
 
 Write for readers across machine learning, robotics, AI applications and the
@@ -60,6 +74,42 @@ Before strong novelty, generality or deployment language, ask for:
 New code central to the conclusions requires a separate Code availability
 section, reviewer access and the Software Submission Checklist. Plan these
 artifacts while drafting Methods rather than after acceptance.
+
+## Results–Discussion action
+
+- Build Results as claim escalation: each subsection should answer a new
+  scientific question and add an independent inference.
+- Allow a bounded local explanation in Results when it directly resolves the
+  experiment just reported; reserve cross-result, literature, and broader
+  implications for Discussion.
+- Keep robustness in the main text when it establishes or materially bounds a
+  claim; route reassurance-only checks to SI.
+- Let Discussion briefly anchor the central finding, then synthesize rather
+  than replay the Results evidence and statistics.
+
+## Introduction action
+
+- Narrow quickly from the important problem to a specific unresolved
+  phenomenon, condition, mechanism, or contradiction.
+- State the gap as an exact unknown; do not define it as the absence of the
+  author's method.
+- Organize literature to construct the known–unknown transition, not to display
+  coverage.
+- Let the study's answer emerge only after the question is motivated, and use
+  the closing paragraph as a compact roadmap of how the study answers it.
+- Require every central Introduction question to map to a Results answer and
+  every central Results claim to have a motivated question.
+
+## Abstract action
+
+- Treat the abstract as the manuscript's shortest evidence chain, not a
+  compressed Introduction or experiment inventory.
+- State one sharp gap, the minimum design logic needed to answer it, one main
+  discovery, and no more than one or two decisive supports or boundaries.
+- Include a number only when it defines, supports, or materially bounds the
+  central claim; a decorative numeric result is not required.
+- End with what the finding changes or enables within the tested scope, not
+  with a claim that the method performs well.
 
 ## Submission-package actions
 

--- a/skills/nature-writing/static/fragments/section/abstract.md
+++ b/skills/nature-writing/static/fragments/section/abstract.md
@@ -1,19 +1,19 @@
 # Section: Abstract (writing)
 
-The abstract is a mini-paper. Draft it last, when Results and Discussion are stable.
+The abstract is the manuscript's shortest evidence chain, not a compressed
+Introduction. Draft it last, when Results and Discussion are stable.
 
 ## Default Nature pattern
 
-`context / problem -> gap -> approach -> key result -> implication -> boundary`
+`precise problem / gap -> answer-enabling design -> main discovery -> decisive support / boundary -> implication`
 
 ## Paragraph movement (recommended)
 
-1. Field-scale context or problem.
-2. Why current routes do not fully solve it.
-3. What this paper introduces or demonstrates.
-4. The strongest result, with quantitative or comparative support.
-5. The mechanism, workflow, or practical consequence.
-6. Bounded implication.
+1. State the problem and exact unresolved question with minimal background.
+2. Explain only the design logic needed to see how the question is answered.
+3. State one main discovery.
+4. Add one or two decisive supporting findings or boundaries.
+5. End with the bounded conceptual, technical, or field-level implication.
 
 ## Pattern variants for technical / method-heavy papers
 
@@ -29,10 +29,15 @@ Open `references/abstract.md` for templates and examples.
 
 - Beginning with `Here, we` may signal missing context.
 - Ending with a broad promise may need scope control.
-- No number, comparison, or concrete test may feel ungrounded.
+- A result may feel ungrounded when neither a decisive comparison nor the logic
+  of the supporting test is visible. A number is optional unless it defines the
+  central claim.
 
 ## Drafting discipline
 
 - Keep it compact. Cut sentences that re-summarize background the title already implies.
-- Include quantitative or comparative detail when the user provided it. Do not invent numbers.
+- Include a quantitative result only when it defines, supports, or materially
+  bounds the central claim. Do not invent numbers or fill the abstract with an
+  experiment inventory.
+- Keep one main claim and no more than one or two supporting claims.
 - End with what the work enables, not generic importance.

--- a/skills/nature-writing/static/fragments/section/discussion.md
+++ b/skills/nature-writing/static/fragments/section/discussion.md
@@ -6,7 +6,8 @@
 
 ## Drafting rules
 
-- Discussion **interprets**, it does not repeat Results figure by figure.
+- Discussion **synthesizes across established Results claims**; it does not
+  repeat the evidence figure by figure.
 - Address rival explanations before generalizing. Reviewers look for this.
 - Hedging strength must match evidence strength. Do not promote a "consistent with" finding to "demonstrates" wording.
 - Limitations come from inside the paper, not from generic disclaimers. Name the specific condition or dataset where the result stops holding.
@@ -30,5 +31,6 @@ Discussion sentences interpret:
 
 ## Short rule to memorize
 
-- Results = what we observed
-- Discussion = how we understand it, and when it may fail
+- Results = the evidence chain that establishes and advances claims
+- Discussion = what those claims mean together, how they relate to the field,
+  and when the synthesis may fail

--- a/skills/nature-writing/static/fragments/section/experiments.md
+++ b/skills/nature-writing/static/fragments/section/experiments.md
@@ -2,9 +2,14 @@
 
 ## Default evidence ladder
 
-`system / workflow validation -> main result -> baseline comparison -> ablation / mechanism analysis -> application or generalization -> stress tests / failure modes`
+`establish the phenomenon -> stress-test it -> rule out alternatives -> broaden it -> interpret it -> bound it`
 
 Each subsection has a claim-first opening, then data support.
+
+Depending on the paper, instantiate this as a discovery loop, a core-capability
+plus validation envelope, or a capability ladder. Load
+`../../../../nature-shared/core/nature-results-discussion.md` for the three
+archetypes and the same-level-repetition test.
 
 ## Drafting rules
 
@@ -31,17 +36,26 @@ Results sentences usually report:
 
 - `was detected` / `increased` / `showed` / `enabled` / `achieved`
 
-Do not drift into Discussion syntax (`may reflect`, `suggests`, `is likely due to`) unless the transition is intentional.
+Close each coherent evidence unit with the bounded inference it supports.
+Calibrated interpretation (`suggests`, `indicates`, `likely because`) may remain
+in Results when it directly answers the current experiment and the supporting
+evidence is visible there. Move literature synthesis, broad implications, and
+extended mechanistic reconciliation to Discussion.
 
 ## Common failure modes when drafting
 
-- Mixing observation and interpretation in the same paragraph.
+- Mixing observation with an interpretation that is not supported by the
+  current experiment, or allowing local interpretation to expand into a broad
+  Discussion.
 - Citing supplementary data when the result should be in the main text.
 - Appending robustness or reviewer-defense prose until the central evidence chain
   disappears.
 - Repeating the same effects, intervals, and P values in Results and captions.
 - Vague comparisons (`higher than control`) without effect size, sample size, or test.
 - Per-paragraph claims without per-paragraph evidence.
+- Reusing an earlier baseline or control as the centre of a later subsection
+  and restating the same claim, instead of making the new perturbation,
+  falsification, stronger comparator, or boundary the decisive evidence.
 
 ## Deeper reference
 

--- a/skills/nature-writing/static/fragments/section/intro.md
+++ b/skills/nature-writing/static/fragments/section/intro.md
@@ -2,7 +2,7 @@
 
 ## Default funnel
 
-`field scale -> bottleneck -> prior attempts -> unresolved gap -> present study`
+`important problem -> specific phenomenon or difficulty -> what prior work establishes -> exact unresolved gap -> research question or hypothesis -> present study`
 
 For a broad-audience `Nature` summary paragraph, strengthen this into (See `references/nature-summary-paragraph.md`.):
 
@@ -11,9 +11,10 @@ For a broad-audience `Nature` summary paragraph, strengthen this into (See `refe
 ## Paragraph jobs (typical 4-paragraph intro)
 
 1. Establish the field stake. Make it land for a non-specialist if the target is broad (Nature, Science).
-2. Identify the bottleneck in existing practice.
-3. Summarize what prior work has and has not solved. Synthesize, do not list.
-4. State what this paper does and how it addresses the gap. Preview the contribution, not the results in detail.
+2. Narrow quickly to the specific phenomenon, tension, or bottleneck.
+3. Summarize what prior work has and has not resolved. Synthesize, do not list.
+4. State the exact unknown and research question, then explain how this paper
+   addresses it. Preview the study route, not the Results in detail.
 
 ## Pipeline variants — pick one based on the material
 
@@ -34,3 +35,10 @@ Tell the user which variant you picked and why.
 - Do not summarize results in detail. The final paragraph states the contribution and approach, not the numbers.
 - Cite prior work to position, not to demonstrate breadth. Each citation should earn its place.
 - The transition from "what is known" to "what this paper does" must be explicit, not implied.
+- Define the gap as an unknown, disputed condition, mechanism, or boundary; do
+  not define it as the absence of the author's method.
+- Make each background paragraph narrow toward the research question. Delete or
+  compress field history that does not prepare a question answered in Results.
+- Draft backward from the Results claims: every central Introduction question
+  needs a Results answer, and every central Results claim needs a motivated
+  question.


### PR DESCRIPTION
## Summary
- add shared Nature / Nature Portfolio guidance for abstracts, introductions, and Results–Discussion
- route nature-writing and nature-polishing across flagship Nature, Nature Communications, NMI, and other Nature Portfolio titles
- add claim-escalation, evidence-chain archetypes, local-interpretation, repetition, and section-alignment audits
- preserve corpus-derived guidance separately from official journal requirements

## Validation
- 61 Python tests passed
- repository validation passed
- bilingual README mirror validation passed
- skill metadata validation passed
- quick validation passed for nature-writing, nature-polishing, and nature-shared