### PR TITLE
feat(image2ppt): add provider-neutral OpenAI-compatible image backend

### DIFF
--- a/skills/nature-image2ppt/README.md
+++ b/skills/nature-image2ppt/README.md
@@ -23,6 +23,7 @@
 - 幻灯片图片、扫描 PDF 或图片型 PPT/PPTX 文件。
 - 希望保留的页面范围、语言、尺寸或字体要求；没有特殊要求时可省略。
 - 是否允许复杂插图作为独立图片资产保留，以及材料是否必须离线处理。
+- 如需在线生成或编辑图片资产，需明确允许上传当前任务的提示词和必要页面图片，并提供 Codex OAuth 或兼容 OpenAI Images API 的服务配置。
 
 ## 工作方式
 
@@ -43,6 +44,7 @@
 - 使用 Python 3.10 或更高版本，并安装 `requirements.txt`。
 - 复制或同步技能文件不会自动安装 Python 包；必须在实际运行 CLI 的同一 Python 环境中安装依赖，并以 `doctor --json` 成功为准。
 - 使用 Microsoft PowerPoint（Windows）或 LibreOffice 完成渲染检查；以 `python cli/image2ppt/cli.py doctor --json` 的结果为准。
+- 图片生成和编辑可使用 Codex OAuth，或通过 `openai-compatible-api` 配置任意兼容 OpenAI Images API 的 Base URL、API Key 和模型 ID；第三方端点不会收到 Codex OAuth 凭证。
 - 在线文字识别使用百度 AI Studio `PADDLE_OCR_TOKEN`。将 `config.example.yaml` 复制为同目录的 `config.yaml` 后填写 Token；真实配置已被 Git 忽略，不能提交。
 - 完整实现同步自 [Paul-Jeo/Image2PPT](https://github.com/Paul-Jeo/Image2PPT)，并在本技能目录中保留 MIT License。
 
@@ -51,6 +53,7 @@
 - 只还原已有页面；根据论文、提纲或笔记创作新 deck 时使用 `nature-paper2ppt`。
 - 照片、复杂插画、密集知识图谱和难以稳定测量的视觉可能部分保留为图片资产。
 - 低分辨率输入、缺失字体和复杂曲线会限制还原精度，需要根据渲染对照复核。
+- 在线图片生成或编辑会把当前任务的提示词和必要页面图片发送到所选图片服务；敏感材料应选择离线模式或经批准的服务。
 - 在线 OCR 会把当前任务页面发送到百度服务；敏感材料应选择离线模式。
 
 ## 相关技能

--- a/skills/nature-image2ppt/README_EN.md
+++ b/skills/nature-image2ppt/README_EN.md
@@ -23,6 +23,7 @@
 - Slide images, a scanned PDF, or an image-only PPT/PPTX file.
 - Any required page range, language, slide size, or font constraints; omit them when there are no special requirements.
 - Whether complex illustrations may remain as separate image assets and whether processing must stay offline.
+- For online image generation or editing, explicit permission to upload the task prompt and required page images, plus either Codex OAuth or an OpenAI Images-compatible service configuration.
 
 ## Workflow
 
@@ -43,6 +44,7 @@
 - Use Python 3.10 or later and install `requirements.txt`.
 - Copying or synchronizing the skill does not install Python packages; install them in the same Python environment that runs the CLI and require `doctor --json` to pass.
 - Use Microsoft PowerPoint on Windows or LibreOffice for rendered checks; follow the result of `python cli/image2ppt/cli.py doctor --json`.
+- Image generation and editing can use Codex OAuth or an `openai-compatible-api` Base URL, API key, and arbitrary provider model ID; third-party endpoints never receive Codex OAuth credentials.
 - Online text recognition uses a Baidu AI Studio `PADDLE_OCR_TOKEN`. Copy `config.example.yaml` to the adjacent `config.yaml` and fill the Token there; Git ignores the real configuration and it must never be committed.
 - The complete implementation is synchronized from [Paul-Jeo/Image2PPT](https://github.com/Paul-Jeo/Image2PPT), with its MIT License retained in this skill directory.
 
@@ -51,6 +53,7 @@
 - The skill only reconstructs existing pages; use `nature-paper2ppt` to author a new deck from a paper, outline, or notes.
 - Photos, complex illustrations, dense knowledge graphs, and visuals that cannot be measured reliably may remain partially image-based.
 - Low-resolution inputs, missing fonts, and complex curves limit reconstruction accuracy and require rendered comparison.
+- Online image generation or editing sends the current task prompt and required page images to the selected image service; use offline mode or an approved service for sensitive material.
 - Online OCR sends the current task pages to Baidu services; use offline mode for sensitive material.
 
 ## Related Skills

--- a/skills/nature-image2ppt/SKILL.md
+++ b/skills/nature-image2ppt/SKILL.md
@@ -84,6 +84,14 @@ missing optional argument such as model, mask, size, quality, or output path nev
 authorizes fallback. Record the actual producer and permitted fallback reason in
 `imagegen-jobs.json`.
 
+The CLI image contract is provider-neutral at the transport boundary. Select
+`codex-oauth` only for GPT Image model ids. Select `openai-compatible-api` for any
+provider-specific model whose endpoint implements the OpenAI Images-compatible
+`/images/generations` and/or `/images/edits` schema. Do not infer the image backend
+from the task's language model. Use an explicit backend when provenance matters;
+`auto` uses Codex OAuth only for compatible GPT Image ids and otherwise selects the
+configured API without sending Codex OAuth credentials to third parties.
+
 ### 1. Preflight and OCR choice
 
 ```bash
@@ -101,6 +109,11 @@ not recognize characters; offer the configuration path in
 python <image2ppt-root>/cli/image2ppt/cli.py prepare <input...> \
   --out-root output/image2ppt --image-backend builtin-imagegen
 ```
+
+To pin a configured third-party provider/model for auditable provenance, prepare
+with `--image-backend openai-compatible-api`. The run contract records the exact
+`IMAGE2PPT_IMAGE_MODEL` from the active project config or environment; it does not
+substitute a GPT Image default merely because no `--model` flag was passed.
 
 Use `--no-text-hints` only when OCR processing is intentionally disabled. Regenerate
 hints without creating a new run when needed:

--- a/skills/nature-image2ppt/cli/image2ppt/runtime/configure_image_backend.py
+++ b/skills/nature-image2ppt/cli/image2ppt/runtime/configure_image_backend.py
@@ -1,8 +1,16 @@
 #!/usr/bin/env python3
 import argparse
 import json
+import os
 
 from deck_run_state import load_deck, load_jobs, read_json, run_dir_from_target, save_deck, write_json
+from runtime_env import DEFAULT_IMAGE_MODEL, config_path, read_config_file
+
+
+def configured_model() -> str:
+    """Resolve the provider model without assuming any vendor-specific id."""
+    values = read_config_file(config_path())
+    return str(os.getenv("IMAGE2PPT_IMAGE_MODEL") or values.get("IMAGE2PPT_IMAGE_MODEL") or DEFAULT_IMAGE_MODEL).strip()
 
 
 def backend_contract(args):
@@ -29,13 +37,17 @@ def backend_contract(args):
             "call image_gen.imagegen serially, then import the selected local output; "
             "use image2ppt image generate/edit only when the built-in tool fallback policy applies"
             if is_builtin
-            else "call image2ppt image generate/edit serially; the CLI selects Codex OAuth first and OpenAI-compatible API fallback second"
+            else "call image2ppt image generate/edit serially; --backend or IMAGE2PPT_IMAGE_BACKEND selects Codex OAuth versus an OpenAI Images-compatible API"
         ),
     }
     if is_builtin:
         contract.update(
             {
                 "fallback_order": ["codex-oauth", "openai-compatible-api"],
+                "fallback_selection_policy": (
+                    "auto uses codex-oauth only for GPT Image model ids with compatible auth; "
+                    "all other model ids use openai-compatible-api"
+                ),
                 "required_parameters": {
                     "generate": ["prompt"],
                     "edit": ["prompt", "referenced_image_paths"],
@@ -64,11 +76,22 @@ def main():
     )
     parser.add_argument("--tool-name")
     parser.add_argument("--tool-call")
-    parser.add_argument("--model", default="gpt-image-2")
+    parser.add_argument(
+        "--model",
+        default=None,
+        help="Exact provider model id. Defaults to IMAGE2PPT_IMAGE_MODEL from the active config/environment.",
+    )
     parser.add_argument("--fallback-command")
-    parser.add_argument("--runtime-home", default="~/.image2ppt")
+    parser.add_argument("--runtime-home", default=None)
     parser.add_argument("--input-context-policy")
     args = parser.parse_args()
+
+    if args.model is None:
+        args.model = configured_model()
+    if not args.model:
+        parser.error("--model or IMAGE2PPT_IMAGE_MODEL must be a non-empty provider model id")
+    if args.runtime_home is None:
+        args.runtime_home = str(config_path().parent)
 
     if args.backend_id == "builtin-imagegen":
         fixed_field_overrides = [

--- a/skills/nature-image2ppt/cli/image2ppt/runtime/image_gen.py
+++ b/skills/nature-image2ppt/cli/image2ppt/runtime/image_gen.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import argparse
 import base64
+import binascii
+import ipaddress
 import json
 import mimetypes
 import os
@@ -21,6 +23,7 @@ import sys
 import time
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 from urllib import error, request
+from urllib.parse import urljoin, urlparse
 
 DEFAULT_MODEL = "gpt-image-2"
 DEFAULT_SIZE = "auto"
@@ -33,8 +36,10 @@ DEFAULT_CODEX_MAX_RETRIES = 4
 DEFAULT_CODEX_RETRY_BASE_DELAY_SECONDS = 0.2
 GPT_IMAGE_MODEL_PREFIX = "gpt-image-"
 
-ALLOWED_LEGACY_SIZES = {"1024x1024", "1536x1024", "1024x1536", "auto"}
-ALLOWED_QUALITIES = {"low", "medium", "high", "auto"}
+BACKEND_AUTO = "auto"
+BACKEND_CODEX_OAUTH = "codex-oauth"
+BACKEND_OPENAI_COMPATIBLE = "openai-compatible-api"
+ALLOWED_BACKENDS = {BACKEND_AUTO, BACKEND_CODEX_OAUTH, BACKEND_OPENAI_COMPATIBLE}
 
 GPT_IMAGE_2_MODEL = "gpt-image-2"
 GPT_IMAGE_2_MIN_PIXELS = 655_360
@@ -45,22 +50,32 @@ GPT_IMAGE_2_MAX_RATIO = 3.0
 MAX_IMAGE_BYTES = 50 * 1024 * 1024
 DEFAULT_CODEX_AUTH_FILE = "~/.codex/auth.json"
 DEFAULT_CODEX_IMAGES_BASE_URL = "https://chatgpt.com/backend-api/codex"
-ENV_FIELDS = ("OPENAI_API_KEY", "OPENAI_BASE_URL", "IMAGE2PPT_IMAGE_MODEL")
+ENV_FIELDS = (
+    "OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
+    "IMAGE2PPT_IMAGE_MODEL",
+    "IMAGE2PPT_IMAGE_BACKEND",
+    "IMAGE2PPT_IMAGE_USER_AGENT",
+)
 MAX_CODEX_RESPONSE_BYTES = 64 * 1024 * 1024
 MAX_CODEX_BASE64_CHARS = 64 * 1024 * 1024
+MAX_MODEL_ID_CHARS = 256
+MAX_REMOTE_REDIRECTS = 5
 CHATGPT_AUTH_CLAIM = "https://api.openai.com/auth"
 CHATGPT_ACCOUNT_ID_CLAIM = "chatgpt_account_id"
 
 IMAGE_HELP_EPILOG = """\
 Backend selection:
-  Codex OAuth: uses ~/.codex/auth.json or CODEX_AUTH_FILE.
-  API fallback: uses OPENAI_API_KEY, OPENAI_BASE_URL, and
-  IMAGE2PPT_IMAGE_MODEL from the environment or the active config.yaml.
+  auto: uses Codex OAuth only for GPT Image model ids when compatible auth is
+  available; every other model uses the configured OpenAI Images-compatible API.
+  codex-oauth: explicitly uses ~/.codex/auth.json or CODEX_AUTH_FILE.
+  openai-compatible-api: explicitly uses OPENAI_API_KEY, OPENAI_BASE_URL, and
+  an arbitrary provider image model id. It never receives Codex OAuth credentials.
 
 Setup:
   codex login
-  image2ppt config --api-key "your-api-key" --model gpt-image-2
-  image2ppt config --api-key "your-api-key" --base-url https://example.test/v1 --model openai/gpt-image-2
+  image2ppt config --api-key "your-api-key" --image-backend openai-compatible-api \
+    --base-url https://example.test/v1 --model provider-image-model
 
 Input image rules:
   generate creates a new image from prompt only.
@@ -89,8 +104,8 @@ Output:
 
 GENERATE_HELP_EPILOG = """\
 Backend:
-  Uses Codex OAuth when available, otherwise API fallback from the active
-  Image2PPT config.yaml or environment variables.
+  Uses --backend or IMAGE2PPT_IMAGE_BACKEND. In auto mode, Codex OAuth is used
+  only for GPT Image model ids; other model ids use the OpenAI-compatible API.
 
 Use for:
   New supporting images that do not need to preserve an existing slide object.
@@ -102,8 +117,8 @@ Examples:
 
 EDIT_HELP_EPILOG = """\
 Backend:
-  Uses Codex OAuth when available, otherwise API fallback from the active
-  Image2PPT config.yaml or environment variables.
+  Uses --backend or IMAGE2PPT_IMAGE_BACKEND. In auto mode, Codex OAuth is used
+  only for GPT Image model ids; other model ids use the OpenAI-compatible API.
 
 Use for:
   Background cleanup, clean base creation, foreground icon extraction, and
@@ -169,6 +184,17 @@ def _default_model() -> str:
     return os.getenv("IMAGE2PPT_IMAGE_MODEL", DEFAULT_MODEL)
 
 
+def _default_backend() -> str:
+    return os.getenv("IMAGE2PPT_IMAGE_BACKEND", BACKEND_AUTO).strip().lower() or BACKEND_AUTO
+
+
+def _image_user_agent() -> Optional[str]:
+    value = os.getenv("IMAGE2PPT_IMAGE_USER_AGENT", "").strip()
+    if len(value) > 512 or any(ord(ch) < 32 for ch in value):
+        _die("IMAGE2PPT_IMAGE_USER_AGENT must be at most 512 characters with no control characters.")
+    return value or None
+
+
 def _api_base_url() -> Optional[str]:
     return os.getenv("OPENAI_BASE_URL") or None
 
@@ -178,6 +204,35 @@ def _api_target_label() -> str:
     if base_url:
         return f"OpenAI-compatible proxy (OPENAI_BASE_URL={base_url})"
     return "official OpenAI API (OPENAI_BASE_URL unset)"
+
+
+def _is_codex_compatible_model(model: str) -> bool:
+    return GPT_IMAGE_MODEL_PREFIX in model.lower()
+
+
+def _validate_backend(backend: str) -> None:
+    if backend not in ALLOWED_BACKENDS:
+        _die(
+            "backend must be one of auto, codex-oauth, or openai-compatible-api."
+        )
+
+
+def _select_backend(backend: str, model: str) -> str:
+    _validate_backend(backend)
+    if backend == BACKEND_CODEX_OAUTH:
+        if not _is_codex_compatible_model(model):
+            _die(
+                "codex-oauth supports GPT Image model ids only. Use "
+                "--backend openai-compatible-api for provider-specific image models."
+            )
+        if not _codex_available():
+            _die(f"Codex OAuth auth is missing. Expected {_codex_auth_file()}.")
+        return BACKEND_CODEX_OAUTH
+    if backend == BACKEND_OPENAI_COMPATIBLE:
+        return BACKEND_OPENAI_COMPATIBLE
+    if _is_codex_compatible_model(model) and _codex_available():
+        return BACKEND_CODEX_OAUTH
+    return BACKEND_OPENAI_COMPATIBLE
 
 
 def _codex_auth_file() -> Path:
@@ -465,12 +520,11 @@ def _ensure_api_key(dry_run: bool) -> None:
         command = f'image2ppt config --api-key "your-api-key" --model {model}'
         target_hint = "Detected official OpenAI API mode because OPENAI_BASE_URL is not set."
     _die(
-        "Neither Codex OAuth nor OPENAI_API_KEY is available for image2ppt image generation.\n"
+        "The selected openai-compatible-api backend requires OPENAI_API_KEY.\n"
         f"{target_hint}\n"
-        f"To use Codex OAuth, run `codex login` so {_codex_auth_file()} exists.\n"
-        "To use a third-party OpenAI-compatible image API, configure the active Image2PPT config.yaml once:\n"
+        "Configure the active Image2PPT config.yaml once:\n"
         f"  {command}\n"
-        "To use a third-party proxy, set OPENAI_BASE_URL and the provider's model name."
+        "For a third-party endpoint, also set OPENAI_BASE_URL and the provider's model id."
     )
 
 
@@ -538,24 +592,21 @@ def _validate_size(size: str, model: str) -> None:
     if _is_gpt_image_2_model(model):
         _validate_gpt_image_2_size(size)
         return
-
-    if size not in ALLOWED_LEGACY_SIZES:
-        _die(
-            "size must be one of 1024x1024, 1536x1024, 1024x1536, or auto for this GPT Image model."
-        )
+    if not isinstance(size, str) or not size.strip() or any(ord(ch) < 32 for ch in size):
+        _die("size must be a non-empty provider value without control characters.")
 
 
 def _validate_quality(quality: str) -> None:
-    if quality not in ALLOWED_QUALITIES:
-        _die("quality must be one of low, medium, high, or auto.")
+    if not isinstance(quality, str) or not quality.strip() or any(ord(ch) < 32 for ch in quality):
+        _die("quality must be a non-empty provider value without control characters.")
 
 
 def _validate_model(model: str) -> None:
-    if GPT_IMAGE_MODEL_PREFIX not in model:
+    if not isinstance(model, str) or not model.strip():
+        _die("model must be a non-empty image model id.")
+    if len(model) > MAX_MODEL_ID_CHARS or any(ord(ch) < 32 for ch in model):
         _die(
-            "model must be a GPT Image model name containing 'gpt-image-' "
-            "(for example gpt-image-2, openai/gpt-image-2, gpt-image-1.5, "
-            "gpt-image-1, or gpt-image-1-mini)."
+            f"model must be at most {MAX_MODEL_ID_CHARS} characters and contain no control characters."
         )
 
 
@@ -591,6 +642,104 @@ def _decode_and_write(images: List[str], outputs: List[Path], force: bool) -> No
         print(f"Wrote {out_path}")
 
 
+def _result_field(item: object, field: str) -> Optional[str]:
+    value = item.get(field) if isinstance(item, dict) else getattr(item, field, None)
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def _validate_remote_image_url(raw_url: str) -> str:
+    parsed = urlparse(raw_url)
+    if parsed.scheme.lower() != "https" or not parsed.hostname:
+        raise RuntimeError("Image result URL must be an absolute HTTPS URL.")
+    hostname = parsed.hostname.rstrip(".").lower()
+    if hostname == "localhost" or hostname.endswith(".localhost") or hostname.endswith(".local"):
+        raise RuntimeError("Image result URL may not target localhost or a local hostname.")
+    try:
+        addresses = {
+            info[4][0]
+            for info in socket.getaddrinfo(
+                hostname,
+                parsed.port or 443,
+                type=socket.SOCK_STREAM,
+            )
+        }
+    except socket.gaierror as exc:
+        raise RuntimeError(f"Could not resolve image result URL host: {hostname}") from exc
+    if not addresses:
+        raise RuntimeError(f"Image result URL host resolved to no addresses: {hostname}")
+    for address in addresses:
+        ip = ipaddress.ip_address(address.split("%", 1)[0])
+        if not ip.is_global:
+            raise RuntimeError("Image result URL may not resolve to a private or reserved address.")
+    return raw_url
+
+
+class _SafeImageRedirectHandler(request.HTTPRedirectHandler):
+    max_redirections = MAX_REMOTE_REDIRECTS
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        _validate_remote_image_url(urljoin(req.full_url, newurl))
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+_IMAGE_DOWNLOAD_OPENER = request.build_opener(_SafeImageRedirectHandler())
+
+
+def _download_image_result(raw_url: str, timeout: int) -> bytes:
+    url = _validate_remote_image_url(raw_url)
+    headers = {"Accept": "image/*"}
+    if _image_user_agent():
+        headers["User-Agent"] = _image_user_agent()
+    req = request.Request(url, headers=headers, method="GET")
+    try:
+        with _IMAGE_DOWNLOAD_OPENER.open(req, timeout=timeout) as response:
+            final_url = response.geturl()
+            _validate_remote_image_url(final_url)
+            payload = response.read(MAX_IMAGE_BYTES + 1)
+    except (error.HTTPError, error.URLError, TimeoutError, socket.timeout) as exc:
+        raise RuntimeError(f"Failed to download image result URL: {exc}") from exc
+    if not payload:
+        raise RuntimeError("Downloaded image result was empty.")
+    if len(payload) > MAX_IMAGE_BYTES:
+        raise RuntimeError("Downloaded image result exceeded 50MB limit.")
+    return payload
+
+
+def _api_result_bytes(item: object, timeout: int) -> bytes:
+    image_b64 = _result_field(item, "b64_json")
+    if image_b64:
+        if len(image_b64) > MAX_CODEX_BASE64_CHARS:
+            raise RuntimeError("Image payload exceeded size limit.")
+        try:
+            payload = base64.b64decode(image_b64, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise RuntimeError("Image API returned invalid base64 image data.") from exc
+        if not payload:
+            raise RuntimeError("Image API returned an empty base64 image payload.")
+        return payload
+    image_url = _result_field(item, "url")
+    if image_url:
+        return _download_image_result(image_url, timeout)
+    raise RuntimeError("Image API result included neither b64_json nor url.")
+
+
+def _write_api_results(items: Iterable[object], outputs: List[Path], force: bool, timeout: int) -> None:
+    wrote = 0
+    for idx, item in enumerate(items):
+        if idx >= len(outputs):
+            break
+        out_path = outputs[idx]
+        if out_path.exists() and not force:
+            _die(f"Output already exists: {out_path} (use --force to overwrite)")
+        payload = _api_result_bytes(item, timeout)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_bytes(payload)
+        print(f"Wrote {out_path}")
+        wrote += 1
+    if wrote == 0:
+        raise RuntimeError("Image API response did not include a usable image result.")
+
+
 def _run_codex_image(
     *,
     prompt: str,
@@ -600,7 +749,7 @@ def _run_codex_image(
     output_paths: List[Path],
     endpoint_label: str,
 ) -> bool:
-    if not _codex_available():
+    if getattr(args, "selected_backend", None) != BACKEND_CODEX_OAUTH:
         return False
     operation = "edit" if image_paths else "generate"
     body = _codex_image_body(
@@ -648,10 +797,24 @@ def _create_client():
         from openai import OpenAI
     except ImportError:
         _die(f"openai SDK not installed in the active environment. {_dependency_hint('openai')}")
-    return OpenAI(
+    kwargs = dict(
         api_key=os.getenv("OPENAI_API_KEY"),
         base_url=os.getenv("OPENAI_BASE_URL") or None,
     )
+    if _image_user_agent():
+        kwargs["default_headers"] = {"User-Agent": _image_user_agent()}
+    return OpenAI(**kwargs)
+
+
+def _api_payload(model: str, prompt: str, size: str, quality: str) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {"model": model, "prompt": prompt}
+    # For a provider-neutral API, auto means "let the provider choose" and is
+    # omitted. Explicit provider values are forwarded unchanged.
+    if size != DEFAULT_SIZE:
+        payload["size"] = size
+    if quality != DEFAULT_QUALITY:
+        payload["quality"] = quality
+    return payload
 
 
 def _check_mask_path(mask: Optional[str]) -> Optional[Path]:
@@ -670,12 +833,7 @@ def _check_mask_path(mask: Optional[str]) -> Optional[Path]:
 def _generate(args: argparse.Namespace) -> None:
     prompt = _read_prompt(args.prompt, args.prompt_file)
 
-    payload = {
-        "model": args.model,
-        "prompt": prompt,
-        "size": args.size,
-        "quality": args.quality,
-    }
+    payload = _api_payload(args.model, prompt, args.size, args.quality)
     output_paths = _build_output_paths(args.out)
 
     if args.dry_run:
@@ -718,8 +876,7 @@ def _generate(args: argparse.Namespace) -> None:
     elapsed = time.time() - started
     print(f"Generation completed in {elapsed:.1f}s.", file=sys.stderr)
 
-    images = [item.b64_json for item in result.data]
-    _decode_and_write(images, output_paths, force=args.force)
+    _write_api_results(result.data, output_paths, force=args.force, timeout=args.timeout)
 
 
 def _edit(args: argparse.Namespace) -> None:
@@ -728,12 +885,7 @@ def _edit(args: argparse.Namespace) -> None:
     image_paths = _check_image_paths(args.image)
     mask_path = _check_mask_path(args.mask)
 
-    payload = {
-        "model": args.model,
-        "prompt": prompt,
-        "size": args.size,
-        "quality": args.quality,
-    }
+    payload = _api_payload(args.model, prompt, args.size, args.quality)
     output_paths = _build_output_paths(args.out)
 
     if args.dry_run:
@@ -786,8 +938,7 @@ def _edit(args: argparse.Namespace) -> None:
 
     elapsed = time.time() - started
     print(f"Edit completed in {elapsed:.1f}s.", file=sys.stderr)
-    images = [item.b64_json for item in result.data]
-    _decode_and_write(images, output_paths, force=args.force)
+    _write_api_results(result.data, output_paths, force=args.force, timeout=args.timeout)
 
 
 def _open_files(paths: List[Path]):
@@ -850,17 +1001,38 @@ def _add_shared_args(
     include_prompt: bool = True,
     include_out: bool = True,
 ) -> None:
-    parser.add_argument("--model", default=_default_model(), help="Image model. Defaults to IMAGE2PPT_IMAGE_MODEL or gpt-image-2.")
+    parser.add_argument(
+        "--backend",
+        choices=sorted(ALLOWED_BACKENDS),
+        default=_default_backend(),
+        help=(
+            "Image transport backend. Defaults to IMAGE2PPT_IMAGE_BACKEND or auto. "
+            "Use openai-compatible-api for provider-specific models."
+        ),
+    )
+    parser.add_argument(
+        "--model",
+        default=_default_model(),
+        help="Provider image model id. Defaults to IMAGE2PPT_IMAGE_MODEL or gpt-image-2.",
+    )
     if include_prompt:
         parser.add_argument("--prompt", help="Prompt text. Use this or --prompt-file.")
         parser.add_argument("--prompt-file", help="Read prompt text from a file, or '-' for stdin.")
-    parser.add_argument("--size", default=DEFAULT_SIZE, help="Output size such as auto or 2560x1440.")
-    parser.add_argument("--quality", default=DEFAULT_QUALITY, help="Image quality: low, medium, high, or auto.")
+    parser.add_argument(
+        "--size",
+        default=DEFAULT_SIZE,
+        help="Provider output-size value. auto omits the API field; explicit values pass through.",
+    )
+    parser.add_argument(
+        "--quality",
+        default=DEFAULT_QUALITY,
+        help="Provider quality value. auto omits the API field; explicit values pass through.",
+    )
     if include_out:
         parser.add_argument("--out", default=DEFAULT_OUTPUT_PATH, help="Output file for one image.")
     parser.add_argument("--force", action="store_true", help="Overwrite existing output files.")
     parser.add_argument("--dry-run", action="store_true", help="Validate arguments and show the selected backend without calling it.")
-    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT, help="Network timeout in seconds for Codex OAuth requests.")
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT, help="Network timeout in seconds.")
 
 
 def main() -> int:
@@ -898,10 +1070,14 @@ asset sheets in image2ppt runs.
     edit_parser.set_defaults(func=_edit)
 
     args = parser.parse_args()
+    args.model = args.model.strip()
+    args.size = args.size.strip()
+    args.quality = args.quality.strip()
     _validate_model(args.model)
     _validate_size(args.size, args.model)
     _validate_quality(args.quality)
-    if not _codex_available():
+    args.selected_backend = _select_backend(args.backend, args.model)
+    if args.selected_backend == BACKEND_OPENAI_COMPATIBLE:
         _ensure_api_key(args.dry_run)
 
     args.func(args)

--- a/skills/nature-image2ppt/cli/image2ppt/runtime/main.py
+++ b/skills/nature-image2ppt/cli/image2ppt/runtime/main.py
@@ -70,6 +70,12 @@ def cmd_config(args: argparse.Namespace) -> int:
         argv.append("--clear-base-url")
     if args.model:
         argv.extend(["--model", args.model])
+    if getattr(args, "image_backend", None):
+        argv.extend(["--image-backend", args.image_backend])
+    if getattr(args, "image_user_agent", None):
+        argv.extend(["--image-user-agent", args.image_user_agent])
+    if getattr(args, "clear_image_user_agent", False):
+        argv.append("--clear-image-user-agent")
     if getattr(args, "paddle_ocr_token", None):
         argv.extend(["--paddle-ocr-token", args.paddle_ocr_token])
     return run_script("runtime_env.py", argv)
@@ -491,14 +497,25 @@ variables still win at runtime. API keys are masked in command output.
         formatter_class=HELP_FORMATTER,
         epilog="""Examples:
   image2ppt config --api-key "your-api-key" --model gpt-image-2
-  image2ppt config --api-key "your-api-key" --base-url https://example.test/v1 --model openai/gpt-image-2
+  image2ppt config --api-key "your-api-key" --image-backend openai-compatible-api --base-url https://example.test/v1 --model provider-image-model
   image2ppt config --clear-base-url
 """,
     )
     config.add_argument("--api-key", help="OpenAI or OpenAI-compatible API key to store.")
     config.add_argument("--base-url", help="OpenAI-compatible base URL, for example https://api.openai.com/v1.")
     config.add_argument("--clear-base-url", action="store_true", help="Remove OPENAI_BASE_URL from the config file.")
-    config.add_argument("--model", help="Default image model for API fallback.")
+    config.add_argument("--model", help="Default provider image model id.")
+    config.add_argument(
+        "--image-backend",
+        choices=["auto", "codex-oauth", "openai-compatible-api"],
+        help="Default transport backend for image generate/edit calls.",
+    )
+    config.add_argument("--image-user-agent", help="Optional User-Agent for the OpenAI-compatible API only.")
+    config.add_argument(
+        "--clear-image-user-agent",
+        action="store_true",
+        help="Remove IMAGE2PPT_IMAGE_USER_AGENT from the config file.",
+    )
     config.add_argument("--paddle-ocr-token", metavar="TOKEN", help="PaddleOCR-VL token for content-aware text hints. Apply at https://aistudio.baidu.com/account/accessToken.")
     config.set_defaults(func=cmd_config)
 
@@ -526,9 +543,12 @@ contract. The standalone CLI default is image2ppt-image-cli.
     prepare.add_argument("--max-concurrent-pages", type=int, metavar="N", help="Maximum concurrent page dispatch slots. Default: 6.")
     prepare.add_argument(
         "--image-backend",
-        choices=["builtin-imagegen", "image2ppt-image-cli"],
+        choices=["builtin-imagegen", "image2ppt-image-cli", "openai-compatible-api"],
         default="image2ppt-image-cli",
-        help="Run-level image backend contract. Defaults to image2ppt-image-cli; parent agents can select builtin-imagegen.",
+        help=(
+            "Run-level image backend contract. Defaults to image2ppt-image-cli; use openai-compatible-api "
+            "to pin a provider-neutral OpenAI Images-compatible transport."
+        ),
     )
     prepare.add_argument("--no-text-hints", action="store_true", help="Skip per-page text hint generation after preparing pages.")
     prepare.set_defaults(func=cmd_prepare)
@@ -769,25 +789,28 @@ comparison image.
         help="Generate/edit images and process image assets.",
         description="""Unified image generation/editing and deterministic image-file handling.
 
-Use generate/edit for Codex OAuth first, with OpenAI-compatible API fallback
-when local Codex auth is unavailable. Use process-sheet for deterministic
-asset-sheet splitting inside page directories.
+Use generate/edit with an explicit or configured transport backend. In auto mode,
+Codex OAuth is selected only for GPT Image model ids; provider-specific model ids
+use the OpenAI Images-compatible API. Use process-sheet for deterministic asset-
+sheet splitting inside page directories.
 """,
         formatter_class=HELP_FORMATTER,
         epilog="""Backend selection:
-  Codex OAuth uses ~/.codex/auth.json or CODEX_AUTH_FILE.
-  API fallback uses the active config.yaml or OPENAI_API_KEY, OPENAI_BASE_URL,
-  and IMAGE2PPT_IMAGE_MODEL. Third-party endpoints never receive Codex OAuth credentials.
+  auto uses Codex OAuth only for GPT Image model ids with compatible auth.
+  codex-oauth explicitly uses ~/.codex/auth.json or CODEX_AUTH_FILE.
+  openai-compatible-api explicitly uses the active config.yaml or OPENAI_API_KEY,
+  OPENAI_BASE_URL, and IMAGE2PPT_IMAGE_MODEL. Third-party endpoints never receive
+  Codex OAuth credentials.
 
 Setup:
   codex login
-  image2ppt config --api-key "your-api-key" --model gpt-image-2
-  image2ppt config --api-key "your-api-key" --base-url https://example.test/v1 --model openai/gpt-image-2
+  image2ppt config --api-key "your-api-key" --image-backend openai-compatible-api --base-url https://example.test/v1 --model provider-image-model
 
 Parameter surface:
-  generate/edit backend requests pass only model, prompt, size, and quality.
-  edit also passes input images and an optional mask. Local controls such as
-  --out, --force, --dry-run, and --timeout are not image API parameters.
+  generate/edit backend requests always pass model and prompt. Explicit non-auto
+  size and quality values are forwarded unchanged. edit also passes input images
+  and an optional mask. Local controls such as --backend, --out, --force,
+  --dry-run, and --timeout are not image API parameters.
 
 Patterns:
   image2ppt image edit --image pages/page_001/source.png --prompt-file clean-base.prompt.txt --out pages/page_001/assets/clean-base.png

--- a/skills/nature-image2ppt/cli/image2ppt/runtime/process_asset_sheet.py
+++ b/skills/nature-image2ppt/cli/image2ppt/runtime/process_asset_sheet.py
@@ -28,6 +28,17 @@ def configure_default_paths(args):
         args.split_manifest = args.split_manifest or "split_assets.json"
 
 
+def use_recorded_job_output(page_dir, args):
+    """Use the imported page-local output promised by the public CLI help."""
+    if args.asset_sheet_source or not args.job_id:
+        return
+    jobs = read_json(page_dir / "imagegen-jobs.json", default={})
+    for item in jobs.get("jobs", []):
+        if item.get("job_id") == args.job_id and item.get("output"):
+            args.asset_sheet_source = item["output"]
+            return
+
+
 def mark_processed(page_dir, args):
     if not args.job_id:
         return
@@ -95,6 +106,7 @@ def main():
     page_dir = Path(args.page_dir).resolve()
     if not page_dir.exists():
         raise SystemExit(f"Page folder does not exist: {page_dir}")
+    use_recorded_job_output(page_dir, args)
     process_sheet(args, page_dir)
     mark_processed(page_dir, args)
 

--- a/skills/nature-image2ppt/cli/image2ppt/runtime/record_imagegen_result.py
+++ b/skills/nature-image2ppt/cli/image2ppt/runtime/record_imagegen_result.py
@@ -31,6 +31,10 @@ def main():
         help="Actual image backend that produced the selected image.",
     )
     parser.add_argument(
+        "--model",
+        help="Optional exact image model id reported or requested for this output.",
+    )
+    parser.add_argument(
         "--fallback-reason",
         choices=["tool-unavailable", "tool-error", "input-unreadable", "no-valid-local-output"],
         help="Optional fallback event explaining why the preferred image backend was not used.",
@@ -104,6 +108,7 @@ def main():
             "output_sha256": sha256_file(dest),
             "prompt_file": args.prompt_file,
             "backend": args.backend,
+            "model": args.model,
             "fallback_reason": args.fallback_reason,
             "note": args.note,
             "recorded_at": now_iso(),

--- a/skills/nature-image2ppt/cli/image2ppt/runtime/runtime_env.py
+++ b/skills/nature-image2ppt/cli/image2ppt/runtime/runtime_env.py
@@ -18,7 +18,16 @@ from pathlib import Path
 DEFAULT_CONFIG_HOME = "~/.image2ppt"
 DEFAULT_CODEX_AUTH_FILE = "~/.codex/auth.json"
 DEFAULT_IMAGE_MODEL = "gpt-image-2"
-ENV_FIELDS = ("OPENAI_API_KEY", "OPENAI_BASE_URL", "IMAGE2PPT_IMAGE_MODEL", "PADDLE_OCR_TOKEN")
+DEFAULT_IMAGE_BACKEND = "auto"
+ALLOWED_IMAGE_BACKENDS = {"auto", "codex-oauth", "openai-compatible-api"}
+ENV_FIELDS = (
+    "OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
+    "IMAGE2PPT_IMAGE_MODEL",
+    "IMAGE2PPT_IMAGE_BACKEND",
+    "IMAGE2PPT_IMAGE_USER_AGENT",
+    "PADDLE_OCR_TOKEN",
+)
 PADDLE_TOKEN_APPLY_URL = "https://aistudio.baidu.com/account/accessToken"
 PADDLE_ENDPOINT = "https://paddleocr.aistudio-app.com/api/v2/ocr/jobs"
 PADDLE_MODEL = "PaddleOCR-VL-1.6"
@@ -119,6 +128,24 @@ def codex_oauth_ready() -> bool:
     return isinstance(tokens, dict) and bool(str(tokens.get("access_token") or "").strip())
 
 
+def codex_model_compatible(model: str) -> bool:
+    return "gpt-image-" in str(model).lower()
+
+
+def select_image_backend(values: dict, codex_ready: bool, api_ready: bool) -> tuple[str, bool]:
+    preference = str(values.get("IMAGE2PPT_IMAGE_BACKEND") or DEFAULT_IMAGE_BACKEND).strip().lower()
+    if preference not in ALLOWED_IMAGE_BACKENDS:
+        return "invalid", False
+    model = str(values.get("IMAGE2PPT_IMAGE_MODEL") or DEFAULT_IMAGE_MODEL)
+    if preference == "codex-oauth":
+        return "codex-oauth", bool(codex_ready and codex_model_compatible(model))
+    if preference == "openai-compatible-api":
+        return "openai-compatible-api", api_ready
+    if codex_ready and codex_model_compatible(model):
+        return "codex-oauth", True
+    return "openai-compatible-api", api_ready
+
+
 def config(args: argparse.Namespace) -> int:
     home = runtime_home()
     values = read_config_file(config_path(home))
@@ -131,6 +158,17 @@ def config(args: argparse.Namespace) -> int:
         values.pop("OPENAI_BASE_URL", None)
     if args.model is not None:
         values["IMAGE2PPT_IMAGE_MODEL"] = args.model.strip()
+    if args.image_backend is not None:
+        backend = args.image_backend.strip().lower()
+        if backend not in ALLOWED_IMAGE_BACKENDS:
+            raise SystemExit(
+                "--image-backend must be auto, codex-oauth, or openai-compatible-api"
+            )
+        values["IMAGE2PPT_IMAGE_BACKEND"] = backend
+    if args.image_user_agent is not None:
+        values["IMAGE2PPT_IMAGE_USER_AGENT"] = args.image_user_agent.strip()
+    if args.clear_image_user_agent:
+        values.pop("IMAGE2PPT_IMAGE_USER_AGENT", None)
     if args.paddle_ocr_token:
         values["PADDLE_OCR_TOKEN"] = args.paddle_ocr_token.strip()
     changed = sorted(key for key in ENV_FIELDS if before.get(key) != values.get(key))
@@ -267,7 +305,7 @@ def collect_status(check_api: bool = False, check_ocr: bool = False) -> dict:
     resources = internal_resource_status()
     api_ready = bool(values.get("OPENAI_API_KEY"))
     codex_ready = codex_oauth_ready()
-    cli_fallback_ready = codex_ready or api_ready
+    selected_backend, cli_fallback_ready = select_image_backend(values, codex_ready, api_ready)
     token = str(values.get("PADDLE_OCR_TOKEN") or "").strip()
     token_source = "environment" if os.getenv("PADDLE_OCR_TOKEN") else ("config" if token else "unset")
     offline_ready = modules["PIL"]["available"] and modules["numpy"]["available"]
@@ -316,9 +354,11 @@ def collect_status(check_api: bool = False, check_ocr: bool = False) -> dict:
                 "OPENAI_API_KEY": "set" if api_ready else "unset",
                 "OPENAI_BASE_URL": values.get("OPENAI_BASE_URL", "https://api.openai.com/v1"),
                 "IMAGE2PPT_IMAGE_MODEL": values.get("IMAGE2PPT_IMAGE_MODEL", DEFAULT_IMAGE_MODEL),
+                "IMAGE2PPT_IMAGE_USER_AGENT": values.get("IMAGE2PPT_IMAGE_USER_AGENT", "<default>"),
             },
+            "preference": values.get("IMAGE2PPT_IMAGE_BACKEND", DEFAULT_IMAGE_BACKEND),
             "cli_fallback_ready": cli_fallback_ready,
-            "selection": "codex-oauth" if codex_ready else ("openai-compatible-api" if api_ready else "missing"),
+            "selection": selected_backend,
         },
         "checks_requested": {"require_image_api": check_api, "require_network_ocr_token": check_ocr},
         "next": "no action needed" if ok else "inspect failed doctor sections and install/configure only the missing local or system dependency",
@@ -368,7 +408,18 @@ def main() -> None:
     cfg.add_argument("--api-key", help="OpenAI or OpenAI-compatible image API key to store.")
     cfg.add_argument("--base-url", help="OpenAI-compatible base URL.")
     cfg.add_argument("--clear-base-url", action="store_true", help="Remove OPENAI_BASE_URL from the config file.")
-    cfg.add_argument("--model", help="Default image model for API fallback.")
+    cfg.add_argument("--model", help="Default provider image model id.")
+    cfg.add_argument(
+        "--image-backend",
+        choices=sorted(ALLOWED_IMAGE_BACKENDS),
+        help="Default transport backend for image generate/edit calls.",
+    )
+    cfg.add_argument("--image-user-agent", help="Optional User-Agent for the OpenAI-compatible API only.")
+    cfg.add_argument(
+        "--clear-image-user-agent",
+        action="store_true",
+        help="Remove IMAGE2PPT_IMAGE_USER_AGENT from the config file.",
+    )
     cfg.add_argument("--paddle-ocr-token", help=f"Baidu AI Studio PaddleOCR token. Apply at {PADDLE_TOKEN_APPLY_URL}.")
     cfg.set_defaults(func=config)
     args = parser.parse_args()

--- a/skills/nature-image2ppt/config.example.yaml
+++ b/skills/nature-image2ppt/config.example.yaml
@@ -7,8 +7,13 @@
 # Apply at https://aistudio.baidu.com/account/accessToken
 PADDLE_OCR_TOKEN: ""
 
-# Optional image-generation API fallback. Leave empty when using the agent image
-# tool or Codex OAuth.
+# Optional image-generation transport. The API path is protocol-based rather than
+# provider-name based: any model is accepted when the endpoint implements the
+# OpenAI Images-compatible /images/generations and/or /images/edits contract.
+# auto uses Codex OAuth only for GPT Image model ids; other model ids use the API.
 # OPENAI_API_KEY: ""
 # OPENAI_BASE_URL: "https://api.openai.com/v1"
+# IMAGE2PPT_IMAGE_BACKEND: "auto"  # auto | codex-oauth | openai-compatible-api
 # IMAGE2PPT_IMAGE_MODEL: "gpt-image-2"
+# Optional compatibility override for relays that filter the default SDK client.
+# IMAGE2PPT_IMAGE_USER_AGENT: ""

--- a/skills/nature-image2ppt/references/assets-provenance-contract.md
+++ b/skills/nature-image2ppt/references/assets-provenance-contract.md
@@ -28,7 +28,10 @@ inputs remain page-confined and may not use `..` traversal.
 
 Valid producer identifiers are `builtin-imagegen`, `codex-oauth`, and
 `openai-compatible-api`. A fallback reason is allowed only when it matches the
-run/page image-backend contract.
+run/page image-backend contract. Record the exact provider model id with
+`image2ppt image import --model` when it is known; provider-specific model ids do
+not create new producer identifiers because the producer boundary is the transport
+backend plus the recorded model.
 
 ## `manifest.json.asset_provenance`
 

--- a/skills/nature-image2ppt/references/cli-helper.md
+++ b/skills/nature-image2ppt/references/cli-helper.md
@@ -65,9 +65,15 @@ image2ppt image edit --help
 image2ppt formula render-latex --help
 ```
 
-`image2ppt image` is the CLI fallback layer. Within that layer it automatically chooses Codex OAuth first, then OpenAI-compatible API credentials from the active `config.yaml` or environment variables if OAuth is unavailable. See `manifest-schema.md` for the run/page backend field contract. `image2ppt doctor` checks CLI backend readiness; it cannot discover whether an agent runtime exposes the built-in tool.
+`image2ppt image` is the CLI fallback layer. `--backend` (or `IMAGE2PPT_IMAGE_BACKEND`) selects `auto`, `codex-oauth`, or `openai-compatible-api`. `auto` uses Codex OAuth only for compatible GPT Image model ids; provider-specific model ids use the configured OpenAI Images-compatible API even when local Codex auth exists. See `manifest-schema.md` for the run/page backend field contract. `image2ppt doctor` checks CLI backend readiness; it cannot discover whether an agent runtime exposes the built-in tool.
 
-Public `image2ppt image generate/edit` parameters are intentionally narrow. Required request inputs are `--prompt` or `--prompt-file`, plus at least one `--image` for `edit`. CLI fallback calls should pass an explicit `--out`. Retained useful controls are `--model` (default `gpt-image-2`), `--size` (default `auto`), `--quality` (default `auto`), `--force`, `--dry-run`, `--timeout`, and edit-only `--mask`. The CLI does not pass any other image API options.
+Public `image2ppt image generate/edit` parameters are intentionally narrow. Required request inputs are `--prompt` or `--prompt-file`, plus at least one `--image` for `edit`. CLI fallback calls should pass an explicit `--out`. Retained useful controls are `--backend`, `--model` (default `gpt-image-2`), `--size` (default `auto`), `--quality` (default `auto`), `--force`, `--dry-run`, `--timeout`, and edit-only `--mask`. `auto` size/quality values are omitted on the API path so the provider chooses its defaults; explicit values pass through. The CLI does not pass any other image API options.
+
+`prepare --image-backend openai-compatible-api` is the provider-neutral pinned
+run contract. Its model metadata is resolved from the active
+`IMAGE2PPT_IMAGE_MODEL` configuration/environment unless `run backend --model`
+explicitly overrides it; preparing a third-party run must not silently record a
+GPT Image model id.
 
 ## Skill Script Commands
 
@@ -111,7 +117,7 @@ After the CLI is available, run local runtime checks:
 ```bash
 image2ppt setup
 image2ppt doctor
-image2ppt config --api-key "<key>" --base-url "<openai-compatible-base-url>" --model "<image-model>"
+image2ppt config --api-key "<key>" --image-backend openai-compatible-api --base-url "<openai-images-compatible-base-url>" --model "<provider-image-model>"
 ```
 
 Write `image2ppt config` only when API fallback is needed or when the user explicitly provides a third-party image API. Do not write API keys into the project directory, run directory, prompts, or manifests.
@@ -244,7 +250,7 @@ image2ppt image edit \
 
 When multiple fallback image outputs are required, run `image2ppt image generate` or `image2ppt image edit` calls serially. For foreground icons and small visual objects, prefer one sparse asset sheet with generous spacing; create a second sheet only when one sheet cannot fit the required objects cleanly.
 
-These commands select Codex OAuth first, then a configured OpenAI-compatible API fallback. In a network-restricted runtime, request approval before the call and state that only task-local prompts plus required page images/masks/references are uploaded for the current conversion.
+These commands follow the explicit/configured backend. In `auto`, they use Codex OAuth only for compatible GPT Image ids and otherwise use the configured OpenAI Images-compatible API. The API path accepts arbitrary provider model ids; compatibility is defined by the `/images/generations` and `/images/edits` request/response protocol, not by a provider-name allowlist. In a network-restricted runtime, request approval before the call and state that only task-local prompts plus required page images/masks/references are uploaded for the current conversion.
 
 ## Asset Processing Commands
 
@@ -256,10 +262,11 @@ image2ppt image import pages/page_001 \
   --source-image /tmp/generated.png \
   --dest assets/icon-sheet.png \
   --role asset_sheet \
-  --backend builtin-imagegen
+  --backend openai-compatible-api \
+  --model provider-image-model
 ```
 
-`--source-image` must be an existing, readable local image. `--backend` records the actual producer and is required; `--fallback-reason` is accepted only when it is consistent with the page's backend contract. Field values and provenance rules live in `manifest-schema.md`.
+`--source-image` must be an existing, readable local image. `--backend` records the actual producer and is required; pass `--model` whenever the provider model id is known. `--fallback-reason` is accepted only when it is consistent with the page's backend contract. Field values and provenance rules live in `manifest-schema.md`.
 
 Process a chroma-key asset sheet:
 

--- a/skills/nature-image2ppt/references/manifest-schema.md
+++ b/skills/nature-image2ppt/references/manifest-schema.md
@@ -46,6 +46,7 @@ Key fields:
     "save_path_policy": "use only an explicit valid local result/output_hint path, then image2ppt image import; never scan for a newest file",
     "fallback_command": "image2ppt image generate/edit",
     "fallback_order": ["codex-oauth", "openai-compatible-api"],
+    "fallback_selection_policy": "auto uses codex-oauth only for GPT Image model ids with compatible auth; all other model ids use openai-compatible-api",
     "fallback_policy": {
       "on": [
         "tool-unavailable",
@@ -71,7 +72,8 @@ For `backend_id: "builtin-imagegen"`, these fields are required and have fixed m
 - `input_context_policy`: requires `view_image` on every edit input before the built-in call; generation has no image input.
 - `save_path_policy`: permits only an explicit valid local result path, including `output_hint`, followed by `image2ppt image import`; newest-file directory scanning is forbidden.
 - `fallback_command`: the CLI surface used only after the fallback policy matches.
-- `fallback_order`: the CLI's internal order, Codex OAuth before a configured OpenAI-compatible API.
+- `fallback_order`: the two permitted CLI producers, retained for provenance compatibility.
+- `fallback_selection_policy`: model-aware routing inside the CLI: `auto` uses Codex OAuth only for compatible GPT Image ids and otherwise selects the configured OpenAI Images-compatible API. An explicit CLI `--backend` overrides `auto`.
 - `fallback_policy.on`: the only events that permit leaving the built-in tool: it is unavailable/not callable, its call errors, an edit input is unreadable, or it returns no valid local image.
 - `fallback_policy.missing_optional_parameters`: always `false`; absent optional controls never authorize fallback.
 
@@ -438,13 +440,14 @@ Each imported job records at least the selected output and the backend that actu
       "output": "assets/icon-sheet.png",
       "output_sha256": "...",
       "backend": "builtin-imagegen",
+      "model": null,
       "fallback_reason": null
     }
   ]
 }
 ```
 
-`backend` is the actual producer: `builtin-imagegen`, `codex-oauth`, or `openai-compatible-api`; `unknown` is reserved for legacy page directories that have no `image_backend` contract. `image2ppt image import` requires an explicit producer, rejects files that are not readable images, and checks `backend`/`fallback_reason` against the page contract. `fallback_reason` is `null` when the preferred backend succeeded or the run selected a CLI contract directly; when a built-in contract enters its CLI fallback, it records the matching event from `image_backend.fallback_policy.on`.
+`backend` is the actual producer: `builtin-imagegen`, `codex-oauth`, or `openai-compatible-api`; `unknown` is reserved for legacy page directories that have no `image_backend` contract. `model` is the optional exact provider model id requested or reported for that output. `image2ppt image import` requires an explicit producer, rejects files that are not readable images, and checks `backend`/`fallback_reason` against the page contract. `fallback_reason` is `null` when the preferred backend succeeded or the run selected a CLI contract directly; when a built-in contract enters its CLI fallback, it records the matching event from `image_backend.fallback_policy.on`.
 
 State and provenance record rules are described under "Preserve the single source
 of truth" in `SKILL.md` and in the asset processing examples in `cli-helper.md`.

--- a/skills/nature-image2ppt/tests/test_multi_agent_backend.py
+++ b/skills/nature-image2ppt/tests/test_multi_agent_backend.py
@@ -1,3 +1,4 @@
+import base64
 import io
 import json
 import os
@@ -27,7 +28,7 @@ CLI_ENV["PYTHONPATH"] = (
 )
 os.environ["PYTHONPATH"] = CLI_ENV["PYTHONPATH"]
 
-from image2ppt.runtime import image_gen
+from image2ppt.runtime import image_gen, runtime_env
 
 
 def write_json(path, data):
@@ -312,8 +313,8 @@ class MultiAgentBackendTest(unittest.TestCase):
         )
         self.assertEqual(0, result.returncode, result.stderr)
         self.assertIn("Backend selection:", result.stdout)
-        self.assertIn("Codex OAuth uses", result.stdout)
-        self.assertIn("API fallback uses", result.stdout)
+        self.assertIn("auto uses Codex OAuth", result.stdout)
+        self.assertIn("openai-compatible-api", result.stdout)
         self.assertIn("image2ppt image edit --image pages/page_001/source.png", result.stdout)
         self.assertNotIn("batch", result.stdout)
 
@@ -326,6 +327,7 @@ class MultiAgentBackendTest(unittest.TestCase):
         )
         self.assertEqual(0, result.returncode, result.stderr)
         for expected in (
+            "--backend",
             "--model",
             "--prompt",
             "--prompt-file",
@@ -372,7 +374,7 @@ class MultiAgentBackendTest(unittest.TestCase):
         self.assertIn("usage: image2ppt image edit", result.stdout)
         self.assertIn("Background cleanup", result.stdout)
         self.assertIn("strict visual reference", result.stdout)
-        for expected in ("--model", "--size", "--quality", "--image", "--mask", "--out", "--dry-run"):
+        for expected in ("--backend", "--model", "--size", "--quality", "--image", "--mask", "--out", "--dry-run"):
             self.assertIn(expected, result.stdout)
         self.assertNotIn("--input-fidelity", result.stdout)
         for removed in (
@@ -533,7 +535,7 @@ class MultiAgentBackendTest(unittest.TestCase):
             self.assertFalse((page_dir / "imagegen_asset_sheet_alpha.png").exists())
             self.assertFalse((page_dir / "split_assets.json").exists())
 
-    def test_process_sheet_preserves_explicit_source_contract(self):
+    def test_process_sheet_uses_imported_output_by_job_id(self):
         with tempfile.TemporaryDirectory() as tmp:
             page_dir = Path(tmp) / "pages/page_001"
             assets_dir = page_dir / "assets"
@@ -568,9 +570,9 @@ class MultiAgentBackendTest(unittest.TestCase):
             )
 
             self.assertEqual(0, result.returncode, result.stdout + result.stderr)
-            self.assertFalse((assets_dir / "icon-sheet.asset-sheet-alpha.png").is_file())
-            self.assertFalse((assets_dir / "icon-sheet.split-report.json").is_file())
-            self.assertFalse((assets_dir / "icon.png").is_file())
+            self.assertTrue((assets_dir / "icon-sheet.asset-sheet-alpha.png").is_file())
+            self.assertTrue((assets_dir / "icon-sheet.split-report.json").is_file())
+            self.assertTrue((assets_dir / "icon.png").is_file())
             self.assertEqual(read_json(page_dir / "imagegen-jobs.json")["jobs"][0]["status"], "processed")
 
     def test_process_sheet_checks_existing_alpha_before_copying_source(self):
@@ -655,6 +657,198 @@ class MultiAgentBackendTest(unittest.TestCase):
             payload = json.loads(result.stdout)
             self.assertEqual([str(source)], payload["image"])
             self.assertEqual("test", payload["prompt"])
+
+    def test_provider_specific_model_routes_to_api_even_when_codex_auth_exists(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "out.png"
+            auth = Path(tmp) / "auth.json"
+            write_json(auth, {"tokens": {"access_token": "test-token"}})
+            env = os.environ.copy()
+            env.update(
+                {
+                    "CODEX_AUTH_FILE": str(auth),
+                    "OPENAI_API_KEY": "test-api-key",
+                    "OPENAI_BASE_URL": "https://images.example.test/v1",
+                    "IMAGE2PPT_IMAGE_BACKEND": "auto",
+                    "IMAGE2PPT_IMAGE_MODEL": "provider/imagine-image-v2",
+                }
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "image2ppt.cli",
+                    "image",
+                    "generate",
+                    "--prompt",
+                    "test",
+                    "--out",
+                    str(out),
+                    "--dry-run",
+                ],
+                cwd=ROOT,
+                env=env,
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(0, result.returncode, result.stderr)
+            payload = json.loads(result.stdout)
+            self.assertEqual("openai-compatible-api", payload["backend"])
+            self.assertEqual("/v1/images/generations", payload["endpoint"])
+            self.assertEqual("provider/imagine-image-v2", payload["model"])
+            self.assertNotIn("size", payload)
+            self.assertNotIn("quality", payload)
+
+    def test_explicit_api_backend_overrides_codex_for_gpt_image_model(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "out.png"
+            auth = Path(tmp) / "auth.json"
+            write_json(auth, {"tokens": {"access_token": "test-token"}})
+            env = os.environ.copy()
+            env.update(
+                {
+                    "CODEX_AUTH_FILE": str(auth),
+                    "OPENAI_API_KEY": "test-api-key",
+                    "OPENAI_BASE_URL": "https://images.example.test/v1",
+                }
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "image2ppt.cli",
+                    "image",
+                    "generate",
+                    "--backend",
+                    "openai-compatible-api",
+                    "--model",
+                    "gpt-image-1.5",
+                    "--prompt",
+                    "test",
+                    "--out",
+                    str(out),
+                    "--dry-run",
+                ],
+                cwd=ROOT,
+                env=env,
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(0, result.returncode, result.stderr)
+            payload = json.loads(result.stdout)
+            self.assertEqual("openai-compatible-api", payload["backend"])
+
+    def test_explicit_codex_backend_rejects_provider_specific_model(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            auth = Path(tmp) / "auth.json"
+            write_json(auth, {"tokens": {"access_token": "test-token"}})
+            env = os.environ.copy()
+            env["CODEX_AUTH_FILE"] = str(auth)
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "image2ppt.cli",
+                    "image",
+                    "generate",
+                    "--backend",
+                    "codex-oauth",
+                    "--model",
+                    "provider/imagine-image-v2",
+                    "--prompt",
+                    "test",
+                    "--dry-run",
+                ],
+                cwd=ROOT,
+                env=env,
+                text=True,
+                capture_output=True,
+            )
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("supports GPT Image model ids only", result.stderr)
+
+    def test_api_result_supports_base64_and_url_shapes(self):
+        encoded = base64.b64encode(b"base64-image").decode("ascii")
+        self.assertEqual(b"base64-image", image_gen._api_result_bytes({"b64_json": encoded}, 10))
+        with mock.patch.object(
+            image_gen,
+            "_download_image_result",
+            return_value=b"url-image",
+        ) as download:
+            self.assertEqual(
+                b"url-image",
+                image_gen._api_result_bytes({"url": "https://cdn.example.test/image.png"}, 10),
+            )
+        download.assert_called_once_with("https://cdn.example.test/image.png", 10)
+
+    def test_api_client_applies_configured_user_agent_only_to_api_client(self):
+        with mock.patch.dict(
+            os.environ,
+            {
+                "OPENAI_API_KEY": "test-key",
+                "OPENAI_BASE_URL": "https://images.example.test/v1",
+                "IMAGE2PPT_IMAGE_USER_AGENT": "image2ppt-test-client/1.0",
+            },
+            clear=False,
+        ), mock.patch("openai.OpenAI") as openai_client:
+            image_gen._create_client()
+        self.assertEqual(
+            {"User-Agent": "image2ppt-test-client/1.0"},
+            openai_client.call_args.kwargs["default_headers"],
+        )
+
+    def test_runtime_backend_selection_is_model_aware_and_explicitly_overridable(self):
+        values = {
+            "IMAGE2PPT_IMAGE_BACKEND": "auto",
+            "IMAGE2PPT_IMAGE_MODEL": "provider/imagine-image-v2",
+        }
+        self.assertEqual(
+            ("openai-compatible-api", True),
+            runtime_env.select_image_backend(values, codex_ready=True, api_ready=True),
+        )
+        values.update(
+            {
+                "IMAGE2PPT_IMAGE_BACKEND": "openai-compatible-api",
+                "IMAGE2PPT_IMAGE_MODEL": "gpt-image-2",
+            }
+        )
+        self.assertEqual(
+            ("openai-compatible-api", True),
+            runtime_env.select_image_backend(values, codex_ready=True, api_ready=True),
+        )
+
+    def test_config_persists_generic_backend_model_and_user_agent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env = os.environ.copy()
+            env["IMAGE2PPT_CONFIG_HOME"] = tmp
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "image2ppt.cli",
+                    "config",
+                    "--api-key",
+                    "test-api-key",
+                    "--base-url",
+                    "https://images.example.test/v1",
+                    "--image-backend",
+                    "openai-compatible-api",
+                    "--model",
+                    "provider/imagine-image-v2",
+                    "--image-user-agent",
+                    "image2ppt-test-client/1.0",
+                ],
+                cwd=ROOT,
+                env=env,
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(0, result.returncode, result.stderr)
+            config = runtime_env.read_config_file(Path(tmp) / "config.yaml")
+            self.assertEqual("openai-compatible-api", config["IMAGE2PPT_IMAGE_BACKEND"])
+            self.assertEqual("provider/imagine-image-v2", config["IMAGE2PPT_IMAGE_MODEL"])
+            self.assertEqual("image2ppt-test-client/1.0", config["IMAGE2PPT_IMAGE_USER_AGENT"])
+            self.assertNotIn("test-api-key", result.stdout)
 
     def test_image_edit_dry_run_prefers_codex_oauth_when_auth_exists(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -1248,6 +1442,42 @@ class MultiAgentBackendTest(unittest.TestCase):
             self.assertEqual("image2ppt-image-cli", deck["image_backend"]["backend_id"])
             request = read_json(run_dir / "pages/page_002/page_request.json")
             self.assertEqual(deck["image_backend"], request["image_backend"])
+
+    def test_configure_image_backend_uses_configured_provider_model_by_default(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = make_minimal_run(tmp)
+            config_home = Path(tmp) / "config-home"
+            config_home.mkdir()
+            (config_home / "config.yaml").write_text(
+                "IMAGE2PPT_IMAGE_MODEL: provider/imagine-image-v2\n",
+                encoding="utf-8",
+            )
+            env = os.environ.copy()
+            env["IMAGE2PPT_CONFIG_HOME"] = str(config_home)
+            env.pop("IMAGE2PPT_IMAGE_MODEL", None)
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    RUNTIME_DIR / "configure_image_backend.py",
+                    run_dir,
+                    "--backend-id",
+                    "openai-compatible-api",
+                ],
+                env=env,
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(0, result.returncode, result.stderr)
+            deck = read_json(run_dir / "deck_manifest.json")
+            self.assertEqual("provider/imagine-image-v2", deck["image_backend"]["model"])
+            self.assertEqual(str(config_home), deck["image_backend"]["runtime_home"])
+            request = read_json(run_dir / "pages/page_002/page_request.json")
+            self.assertEqual("provider/imagine-image-v2", request["image_backend"]["model"])
+
+    def test_prepare_help_accepts_explicit_openai_compatible_backend(self):
+        result = run_cli("prepare", "--help")
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("openai-compatible-api", result.stdout)
 
     def test_builtin_image_backend_rejects_fixed_contract_overrides(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

This PR makes `nature-image2ppt` image generation provider-neutral at the transport layer instead of assuming every image model is a GPT Image model.

- add explicit `auto`, `codex-oauth`, and `openai-compatible-api` backend selection
- accept arbitrary non-empty provider image model IDs for OpenAI Images-compatible endpoints
- keep Codex OAuth credentials isolated from third-party base URLs
- support both `b64_json` and HTTPS `url` image responses, with bounded/private-address-safe downloads
- allow a provider-specific User-Agent and omit `size=auto` / `quality=auto` rather than forwarding unsupported sentinel values
- record the configured provider model and actual runtime home in run contracts/provenance
- fix `process-sheet --job-id` so it uses the imported job output promised by the CLI help

The existing GPT Image/Codex OAuth path remains available, while non-GPT provider models can now be selected without being rejected or accidentally routed through Codex OAuth.

## Motivation

The previous implementation treated Codex OAuth as the first route whenever local auth existed and restricted model IDs to names containing `gpt-image-`. That made an otherwise OpenAI Images-compatible provider model unusable even when `OPENAI_BASE_URL`, an API key, and the provider's model ID were configured correctly.

Some compatible providers also return `data[].url` instead of `data[].b64_json`, reject `auto` values, or require a compatible User-Agent. These are transport-level differences rather than reasons to hard-code a provider or model name.

## Usage

```bash
image2ppt config \
  --image-backend openai-compatible-api \
  --api-key "your-api-key" \
  --base-url https://example.test/v1 \
  --model provider-image-model

image2ppt image generate \
  --backend openai-compatible-api \
  --prompt "Create a clean isolated scientific icon" \
  --out icon.png
```

`auto` selects Codex OAuth only for GPT Image model IDs when compatible auth exists. Other model IDs select `openai-compatible-api`. An explicit backend always wins.

## Compatibility and safety

- defaults remain `auto` plus `gpt-image-2`
- the Codex OAuth endpoint and credential flow are unchanged
- third-party endpoints receive only the configured API key, never Codex OAuth credentials
- returned image URLs must be HTTPS and may not resolve to local, private, or reserved addresses
- provider-specific behavior is configured through generic fields; no provider name or endpoint is hard-coded

## Validation

- `53/53` applicable `test_multi_agent_backend` tests passed locally
- the one excluded Windows short-path assertion fails identically on unmodified upstream `main` (`ADMINI~1` versus the expanded temp path), so it is not introduced by this patch
- focused provider-model, explicit-backend, job-output, alpha-preservation, and path-confinement regression tests passed (`5/5`)
- repository README validation passed
- Skill quick validation passed
- `git diff --check` passed
- real-world manual validation completed for both image generation and image editing through an OpenAI Images-compatible relay, followed by a complete editable-PPT build and reviewed final QA

No credentials, private endpoint, OCR token, generated research asset, or local machine path is included in this PR.
