### PR TITLE
fix: prefer modern PyMuPDF import

### DIFF
--- a/scripts/tests/test_nature_figure_ai_graphical_abstract.py
+++ b/scripts/tests/test_nature_figure_ai_graphical_abstract.py
@@ -57,7 +57,7 @@ class NatureFigureAIGraphicalAbstractTests(unittest.TestCase):
         for text in (skill, manifest, provider):
             self.assertIn("ai-graphical-abstract-workflow.md", text)
 
-        self.assertIn("version: 2.7.0", manifest)
+        self.assertIn("version: 2.7.1", manifest)
         self.assertIn("planning or auditing only", skill)
         self.assertIn("internal design use and submission eligibility", provider)
 

--- a/scripts/tests/test_nature_figure_collision_audit.py
+++ b/scripts/tests/test_nature_figure_collision_audit.py
@@ -22,7 +22,10 @@ def load_module(name: str, path: Path):
 
 
 AUDIT = load_module("nature_figure_collision_audit_test", SCRIPT)
-PYMUPDF_AVAILABLE = importlib.util.find_spec("fitz") is not None
+PYMUPDF_AVAILABLE = any(
+    importlib.util.find_spec(module_name) is not None
+    for module_name in ("pymupdf", "fitz")
+)
 
 
 def read(relative: str) -> str:
@@ -133,7 +136,10 @@ class CollisionGeometryTests(unittest.TestCase):
 @unittest.skipUnless(PYMUPDF_AVAILABLE, "PyMuPDF is not installed in this test runtime")
 class CollisionPdfEndToEndTests(unittest.TestCase):
     def test_real_pdf_detects_crossed_text_and_writes_overlay(self) -> None:
-        import fitz
+        try:
+            import pymupdf as fitz
+        except ImportError:
+            import fitz
 
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -194,7 +200,7 @@ class CollisionWorkflowIntegrationTests(unittest.TestCase):
         evals = json.loads(read("skills/nature-figure/evals/evals.json"))
         installer = read("scripts/update-codex-skills.sh")
 
-        self.assertIn("version: 2.7.0", manifest)
+        self.assertIn("version: 2.7.1", manifest)
         self.assertIn("PyMuPDF", requirements)
         for text in (readme_zh, readme_en):
             self.assertIn("audit_figure_collisions.py", text)

--- a/skills/nature-figure/manifest.yaml
+++ b/skills/nature-figure/manifest.yaml
@@ -1,5 +1,5 @@
 name: nature-figure
-version: 2.7.0
+version: 2.7.1
 description: >
   Declarative manifest for the static/dynamic split. SKILL.md uses this to
   decide which fragments to load for a given figure request. The main axis is

--- a/skills/nature-figure/scripts/audit_figure_collisions.py
+++ b/skills/nature-figure/scripts/audit_figure_collisions.py
@@ -244,12 +244,15 @@ def _text_from_chars(chars: Sequence[Sequence[Any]]) -> str:
 
 def extract_pdf_geometry(path: Path) -> list[PageGeometry]:
     try:
-        import fitz  # type: ignore
-    except ImportError as exc:
-        raise RuntimeError(
-            "PyMuPDF is required for rendered collision QA. Install it with: "
-            "python -m pip install -r skills/nature-figure/requirements.txt"
-        ) from exc
+        import pymupdf as fitz  # type: ignore
+    except ImportError:
+        try:
+            import fitz  # type: ignore
+        except ImportError as exc:
+            raise RuntimeError(
+                "PyMuPDF is required for rendered collision QA. Install it with: "
+                "python -m pip install -r skills/nature-figure/requirements.txt"
+            ) from exc
 
     document = fitz.open(path)
     pages: list[PageGeometry] = []
@@ -561,9 +564,12 @@ def audit_pdf(
 
 def write_overlay_pdf(source: Path, destination: Path, findings: Sequence[dict[str, Any]]) -> None:
     try:
-        import fitz  # type: ignore
-    except ImportError as exc:
-        raise RuntimeError("PyMuPDF is required to write the diagnostic overlay PDF") from exc
+        import pymupdf as fitz  # type: ignore
+    except ImportError:
+        try:
+            import fitz  # type: ignore
+        except ImportError as exc:
+            raise RuntimeError("PyMuPDF is required to write the diagnostic overlay PDF") from exc
     if source.resolve() == destination.resolve():
         raise ValueError("overlay PDF must not overwrite the source PDF")
     destination.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- prefer the modern `pymupdf` module name used by PyMuPDF 1.28+
- retain `fitz` fallback compatibility for older supported releases
- make end-to-end tests detect and use either module name
- bump nature-figure to 2.7.1

## Validation
- default Python CLI clean probe: exit 0, no fitz deprecation warning
- collision audit test file: 8 tests PASS
- scripts suite: 75 tests PASS
- nature-figure suite: 10 tests PASS
- repository, skill-index, metadata, and README mirror validators: PASS
- git diff --check: PASS