### PR TITLE
feat: add native Codex plugin page

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "nature-skills",
+  "interface": {
+    "displayName": "Nature Skills"
+  },
+  "plugins": [
+    {
+      "name": "nature-skills",
+      "source": {
+        "source": "local",
+        "path": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Research"
+    }
+  ]
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,38 @@
+{
+  "name": "nature-skills",
+  "version": "0.1.0",
+  "description": "Reusable research, literature, writing, review, data, citation, and figure workflows for AI scholars.",
+  "author": {
+    "name": "Yizhe Yuan and Nature Skills contributors",
+    "url": "https://github.com/Yuan1z0825"
+  },
+  "homepage": "https://yuan1z0825.github.io/nature-skills/",
+  "repository": "https://github.com/Yuan1z0825/nature-skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "research",
+    "academic-writing",
+    "literature-review",
+    "citations",
+    "scientific-figures"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Nature Skills",
+    "shortDescription": "Research and academic writing workflows",
+    "longDescription": "A collection of reusable research workflows for literature discovery, paper reading and writing, citation checking, reviewer responses, data analysis, and scientific figures.",
+    "developerName": "Yizhe Yuan and Nature Skills contributors",
+    "category": "Research",
+    "capabilities": [
+      "Research workflows",
+      "Academic writing",
+      "Citation verification"
+    ],
+    "websiteURL": "https://yuan1z0825.github.io/nature-skills/",
+    "defaultPrompt": [
+      "Show me the research workflows included in Nature Skills.",
+      "Help me review and improve this research manuscript.",
+      "Build a literature and citation workflow for this topic."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- add a native `.codex-plugin/plugin.json` with upstream ownership and reader-facing plugin metadata
- add a self-contained `.agents/plugins/marketplace.json` so the repository can be added directly as a Codex marketplace
- keep the existing portable `skills/` collection unchanged

## Validation

- `plugin-creator/scripts/validate_plugin.py` passes
- all marketplace and plugin manifests parse as JSON
- tested the complete local flow with `codex plugin marketplace add`, `codex plugin add`, `codex plugin remove`, and marketplace cleanup

This makes the collection manageable as one upstream-owned Codex plugin instead of requiring users to repackage each skill locally.
