### PR TITLE
补齐技能与内容契约测试覆盖

### DIFF
--- a/.github/workflows/test-content-contracts.yml
+++ b/.github/workflows/test-content-contracts.yml
@@ -1,0 +1,49 @@
+name: Test content contracts
+
+on:
+  pull_request:
+    paths:
+      - 'skills/**'
+      - 'scripts/tests/**'
+      - '.github/requirements-ci.txt'
+      - '.github/workflows/test-content-contracts.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'skills/**'
+      - 'scripts/tests/**'
+      - '.github/requirements-ci.txt'
+      - '.github/workflows/test-content-contracts.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  content-contracts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: |
+            .github/requirements-ci.txt
+            skills/nature-figure/requirements.txt
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install \
+            -c .github/requirements-ci.txt \
+            pytest \
+            pyyaml \
+            matplotlib \
+            -r skills/nature-figure/requirements.txt
+
+      - name: Test repository content contracts
+        run: python -m pytest -q scripts/tests

--- a/.github/workflows/test-skill-tooling.yml
+++ b/.github/workflows/test-skill-tooling.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     paths:
       - 'skills/nature-academic-search/mcp-server/**'
+      - 'skills/nature-citation/**'
       - 'skills/nature-downloader/**'
+      - 'skills/nature-figure/**'
       - 'skills/nature-image2ppt/**'
       - 'skills/nature-paper-card/**'
       - 'skills/nature-paper-to-patent/**'
@@ -22,7 +24,9 @@ on:
       - main
     paths:
       - 'skills/nature-academic-search/mcp-server/**'
+      - 'skills/nature-citation/**'
       - 'skills/nature-downloader/**'
+      - 'skills/nature-figure/**'
       - 'skills/nature-image2ppt/**'
       - 'skills/nature-paper-card/**'
       - 'skills/nature-paper-to-patent/**'
@@ -76,9 +80,17 @@ jobs:
         working-directory: skills/nature-academic-search/mcp-server
         run: python -m pytest -q tests
 
+      - name: Test nature-citation
+        working-directory: skills/nature-citation
+        run: python -m pytest -q tests
+
       - name: Test nature-downloader Python tooling
         working-directory: skills/nature-downloader
         run: python -m pytest -q tests/python
+
+      - name: Test nature-figure safety helpers
+        working-directory: skills/nature-figure
+        run: python -m pytest -q tests
 
       - name: Test nature-image2ppt full Linux runtime
         working-directory: skills/nature-image2ppt


### PR DESCRIPTION
## 背景

仓库中已有 `nature-citation`、`nature-figure` 和根级内容契约测试，但现有工作流没有执行这些测试。相关功能发生回归时，CI 仍可能显示通过。

## 修改

- 将 `nature-citation` 和 `nature-figure` 的测试接入技能工具测试工作流
- 新增轻量的内容契约测试工作流，在技能或契约测试变化时执行 `scripts/tests`
- 沿用现有依赖约束和固定版本的 Action 引用

## 验证

- 工作流路径校验通过
- 根级内容契约测试：103 通过，1 跳过
- `nature-citation`：9 通过
- `nature-figure`：13 通过