### PR TITLE
修复 Windows 下 Mermaid 路径含空格时的渲染失败

### DIFF
--- a/skills/nature-paper-to-patent/scripts/disclosure/mermaid_render.py
+++ b/skills/nature-paper-to-patent/scripts/disclosure/mermaid_render.py
@@ -36,7 +36,7 @@ import tempfile
 from pathlib import Path
 
 
-def _local_mmdc() -> tuple[list[str], bool] | None:
+def _local_mmdc() -> list[str] | None:
     """``scripts/disclosure/npm install`` 后可用 ``node_modules/.bin/mmdc``，避免每次 npx 拉包。"""
     here = Path(__file__).resolve().parent
     if sys.platform == "win32":
@@ -44,25 +44,27 @@ def _local_mmdc() -> tuple[list[str], bool] | None:
     else:
         cand = here / "node_modules" / ".bin" / "mmdc"
     if cand.is_file():
-        return [str(cand)], False
+        return [str(cand)]
     return None
 
 
-def _find_mmdc_invocation() -> tuple[list[str], bool]:
+def _find_mmdc_invocation() -> list[str]:
     """
-    返回 (argv 前缀, use_shell)。
-    Windows 上 npx 常为 .ps1，无独立 .exe，需 shell=True 调用 ``npx ...``。
-    PATH 中的 ``mmdc`` 一般为 npm 全局安装的官方 CLI。
+    返回 argv 前缀。
+
+    始终保留参数列表，交由 subprocess 处理路径引用。Windows 上若把参数
+    拼成 shell 字符串，含空格的项目目录会被 cmd.exe 拆成多个参数。
     """
     local = _local_mmdc()
     if local:
         return local
     mmdc = shutil.which("mmdc")
     if mmdc and Path(mmdc).suffix.lower() not in (".ps1",):
-        return [mmdc], False
-    if sys.platform == "win32":
-        return ["npx", "-y", "@mermaid-js/mermaid-cli", "mmdc"], True
-    return ["npx", "-y", "@mermaid-js/mermaid-cli", "mmdc"], False
+        return [mmdc]
+    npx = shutil.which("npx")
+    if not npx:
+        raise RuntimeError("未找到 mmdc 或 npx，请先安装 Node.js 或 @mermaid-js/mermaid-cli")
+    return [npx, "-y", "@mermaid-js/mermaid-cli", "mmdc"]
 
 
 def _mmdc_extra_args(
@@ -87,7 +89,6 @@ def _render_one_mermaid(
     png_path: Path,
     mmdc_base: list[str],
     *,
-    use_shell: bool,
     scale: float,
     width: int,
     height: int,
@@ -103,42 +104,22 @@ def _render_one_mermaid(
         tmp_path = Path(tmp.name)
     try:
         extra = _mmdc_extra_args(scale=scale, width=width, height=height)
-        if use_shell:
-            parts = [
-                *mmdc_base,
-                "-i",
-                str(tmp_path),
-                "-o",
-                str(png_path),
-                "-b",
-                "white",
-                *extra,
-            ]
-            cmd = " ".join(shlex.quote(p) for p in parts)
-            r = subprocess.run(
-                cmd,
-                shell=True,
-                capture_output=True,
-                text=True,
-                timeout=180,
-            )
-        else:
-            cmd = [
-                *mmdc_base,
-                "-i",
-                str(tmp_path),
-                "-o",
-                str(png_path),
-                "-b",
-                "white",
-                *extra,
-            ]
-            r = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=180,
-            )
+        cmd = [
+            *mmdc_base,
+            "-i",
+            str(tmp_path),
+            "-o",
+            str(png_path),
+            "-b",
+            "white",
+            *extra,
+        ]
+        r = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
         if r.returncode != 0:
             err = (r.stderr or r.stdout or "").strip()
             raise RuntimeError(f"mmdc 失败 (exit {r.returncode}): {err[:2000]}")
@@ -187,7 +168,7 @@ def render_markdown_mermaid(
     failed = 0
     block_idx = 0
     assets_dir = out_md_path.parent / assets_rel
-    mmdc_base, use_shell = _find_mmdc_invocation()
+    mmdc_base = _find_mmdc_invocation()
 
     while i < len(lines):
         line = lines[i]
@@ -230,7 +211,6 @@ def render_markdown_mermaid(
                     "".join(body),
                     png_path,
                     mmdc_base,
-                    use_shell=use_shell,
                     scale=mmdc_scale,
                     width=mmdc_width,
                     height=mmdc_height,

--- a/skills/nature-paper-to-patent/tests/test_mermaid_render.py
+++ b/skills/nature-paper-to-patent/tests/test_mermaid_render.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "disclosure" / "mermaid_render.py"
+SPEC = importlib.util.spec_from_file_location("mermaid_render", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class MermaidCommandTests(unittest.TestCase):
+    def test_windows_npx_is_resolved_to_an_executable_path(self) -> None:
+        def which(command: str) -> str | None:
+            if command == "npx":
+                return r"C:\Program Files\nodejs\npx.cmd"
+            return None
+
+        with mock.patch.object(MODULE, "_local_mmdc", return_value=None), mock.patch.object(
+            MODULE.shutil, "which", side_effect=which
+        ):
+            command = MODULE._find_mmdc_invocation()
+
+        self.assertEqual(command[0], r"C:\Program Files\nodejs\npx.cmd")
+        self.assertEqual(command[1:], ["-y", "@mermaid-js/mermaid-cli", "mmdc"])
+
+    def test_render_keeps_paths_as_separate_arguments(self) -> None:
+        completed = subprocess.CompletedProcess([], 0, "", "")
+        with tempfile.TemporaryDirectory(prefix="mermaid path ") as directory, mock.patch.object(
+            MODULE.subprocess, "run", return_value=completed
+        ) as run:
+            output = Path(directory) / "figures & charts" / "diagram.png"
+            MODULE._render_one_mermaid(
+                "graph TD; A-->B",
+                output,
+                [r"C:\Program Files\nodejs\npx.cmd", "-y", "@mermaid-js/mermaid-cli", "mmdc"],
+                scale=2.0,
+                width=1400,
+                height=1050,
+            )
+
+        command = run.call_args.args[0]
+        self.assertIsInstance(command, list)
+        self.assertIn(str(output), command)
+        self.assertNotIn("shell", run.call_args.kwargs)
+
+    def test_missing_mermaid_runtime_has_an_actionable_error(self) -> None:
+        with mock.patch.object(MODULE, "_local_mmdc", return_value=None), mock.patch.object(
+            MODULE.shutil, "which", return_value=None
+        ):
+            with self.assertRaisesRegex(RuntimeError, "Node.js"):
+                MODULE._find_mmdc_invocation()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题

Windows 下未安装全局 `mmdc` 时，脚本会把 `npx` 调用拼成 shell 字符串，并使用 POSIX 风格的单引号处理参数。`cmd.exe` 不识别这种引用方式，因此项目目录或输出目录含空格时，Mermaid 渲染会失败。

## 修改

- 通过 `shutil.which` 解析实际的 `mmdc` 或 `npx` 路径
- Mermaid 渲染始终使用参数列表调用，不再经过 `shell=True`
- 缺少 Node.js 和 Mermaid CLI 时给出明确的安装提示
- 增加含空格、特殊字符路径及运行时缺失场景的回归测试

## 验证

- `nature-paper-to-patent` 测试：6 项通过
- 静态检查与语法编译通过
- Windows 本机验证可直接调用 `C:\Program Files\nodejs\npx.CMD`