### PR TITLE
Clarify figure backend gates and manuscript editing completion

### DIFF
--- a/skills/nature-figure/SKILL.md
+++ b/skills/nature-figure/SKILL.md
@@ -48,14 +48,16 @@ Read [manifest.yaml](manifest.yaml). It declares the `backend` axis, the allowed
 
 Also read every file listed under `always_load` (`static/core/contract.md` and `static/core/stance.md`). These hold the figure contract, the backend gate, the missing-runtime rule, the privacy rule, and the default operating stance that apply to every figure job.
 
-### 2. Resolve the backend — a blocking gate
+### 2. Resolve the plotting backend
 
-Backend selection blocks plotting tasks, but it should not annoy the same user forever. Decide the `backend` value in this order:
+Backend selection applies only to rendering or editing plotting code. Reuse a choice already established in the same task and its follow-ups; do not ask again merely because a new message omits the language. Read-only figure review and backend-independent data inspection may proceed without this choice. If the backend remains unresolved, retain the one-time Python/R question and pause only dependent plotting steps. Explicit approval requirements and backend exclusivity remain in force.
+
+Resolve the plotting backend from the current task before consulting the saved default. Decide the `backend` value in this order:
 
 1. If the current request explicitly chooses Python or R, use that backend and save it with `scripts/nature_figure_backend.py set python` or `scripts/nature_figure_backend.py set r`.
 2. If the request provides a clearly language-specific input file/workflow, use that backend and save it.
-3. Otherwise run `scripts/nature_figure_backend.py get`. If it returns `python` or `r`, use the saved preference.
-4. If no saved preference exists, ask exactly one concise question — **Python or R? I will remember this as your default.** — and stop. After the user answers, save the answer before proceeding.
+3. Otherwise reuse a Python/R choice already established in this task. If none exists, run `scripts/nature_figure_backend.py get` and use a returned `python` or `r` preference.
+4. If neither a task choice nor a saved preference exists, ask exactly one concise question — **Python or R? I will remember this as your default.** — and pause only dependent plotting steps. After the user answers, save the answer before proceeding.
 
 - `python` — matplotlib / seaborn.
 - `r` — ggplot2 / patchwork / ComplexHeatmap.

--- a/skills/nature-figure/references/backend-selection.md
+++ b/skills/nature-figure/references/backend-selection.md
@@ -9,14 +9,16 @@
 - [Recommendation language](#recommendation-language)
 
 
+Backend selection applies only to rendering or editing plotting code. Reuse a choice already established in the same task and its follow-ups; do not ask again merely because a new message omits the language. Read-only figure review and backend-independent data inspection may proceed without this choice. If the backend remains unresolved, retain the one-time Python/R question and pause only dependent plotting steps. Explicit approval requirements and backend exclusivity remain in force.
+
 At the start of a plotting task, resolve the user's preferred backend in this order:
 
 1. explicit Python/R choice in the current request;
 2. clearly language-specific input file or workflow;
-3. saved preference from `scripts/nature_figure_backend.py get`;
-4. if no preference exists, ask **Python or R? I will remember this as your default.**
+3. choice already established in this task, then saved preference from `scripts/nature_figure_backend.py get`;
+4. if neither exists, ask **Python or R? I will remember this as your default.**
 
-Stop after asking and wait for the user's answer. After the answer, save it with
+Pause dependent plotting steps after asking and wait for the user's answer; continue independent inspection. After the answer, save it with
 `scripts/nature_figure_backend.py set python` or `scripts/nature_figure_backend.py set r`.
 Do not infer Python just because the task involves simulation, NumPy-like data, or
 custom layout, and do not infer R just because the task is biological or omics-adjacent.

--- a/skills/nature-figure/references/figure-contract.md
+++ b/skills/nature-figure/references/figure-contract.md
@@ -62,7 +62,7 @@ panels. This claim-first pass prevents redundant figures that restate the same r
   the hero panel or the clearest axis; controls and robustness panels should be
   visually quieter.
 - If the user provides data but no claim, infer a provisional claim from the data
-  request and ask for confirmation before final styling.
+  request. Confirm only an unresolved interpretive claim that materially changes the final figure; continue independent data checks and layout preparation while waiting. Do not add unsupported causal claims.
 - If observations are matched by dataset, subject, seed, task, or specimen, decide
   whether the claim concerns the paired change. Marginal distributions can overlap
   because of between-unit heterogeneity even when paired differences are consistent.

--- a/skills/nature-figure/references/r-workflow.md
+++ b/skills/nature-figure/references/r-workflow.md
@@ -21,7 +21,7 @@ claim first, evidence hierarchy second, plotting code third.
 When the user has selected R, do all figure drawing, previewing, exporting, and
 visual QA in R. Do not call Python/matplotlib/seaborn/plotly to create a temporary
 preview, fallback export, or layout approximation. If R, `Rscript`, or required R
-packages are missing, stop before rendering and report the missing dependency. You
+packages are missing, pause rendering, continue independent script or data checks, and report the missing dependency. You
 may still write the R script, provide `install.packages()` commands, or ask permission
 to install dependencies, but do not cross-render the figure in another language.
 

--- a/skills/nature-figure/static/core/contract.md
+++ b/skills/nature-figure/static/core/contract.md
@@ -2,13 +2,15 @@
 
 A publication-quality scientific figure is a visual argument, not an isolated pretty plot. Every figure starts from a claim, an evidence hierarchy, and a review-risk check before code or aesthetics. Before generating or editing code, establish the contract below.
 
-## Backend selection uses a saved preference
+## Backend selection uses the task context and saved preference
+
+Backend selection applies only to rendering or editing plotting code. Reuse a choice already established in the same task and its follow-ups; do not ask again merely because a new message omits the language. Read-only figure review and backend-independent data inspection may proceed without this choice. If the backend remains unresolved, retain the one-time Python/R question and pause only dependent plotting steps. Explicit approval requirements and backend exclusivity remain in force.
 
 For plotting tasks, first honor an explicit Python/R choice in the current request or a clearly language-specific input file/workflow. Save that backend as the user's default with `scripts/nature_figure_backend.py set python` or `scripts/nature_figure_backend.py set r`.
 
-If the current request does not specify a backend, check the saved preference with `scripts/nature_figure_backend.py get`. If it returns `python` or `r`, use that backend without asking again.
+If the current request does not specify a backend, first reuse the choice established in this task; otherwise check the saved preference with `scripts/nature_figure_backend.py get`. If it returns `python` or `r`, use that backend without asking again.
 
-If no saved preference exists, ask one concise question: **Python or R? I will remember this as your default.** Then stop and wait for the user's answer. Do not generate mock data, write scripts, create figures, or choose Python/R by default before this first preference is established. After the user answers, save it and proceed.
+If no saved preference exists, ask one concise question: **Python or R? I will remember this as your default.** Pause dependent plotting steps and wait for the user's answer; continue independent inspection. Do not generate mock data, write scripts, create figures, or choose Python/R by default before this first preference is established. After the user answers, save it and proceed.
 
 Only recommend a backend when the user explicitly asks you to choose or recommend one. In that case, use `references/backend-selection.md`, state the reason, save the selected backend, and then proceed with the recommended backend.
 
@@ -26,7 +28,7 @@ figure authoritative.
 
 ## Missing runtime/package rule
 
-After the backend is selected, check the selected runtime early (`Rscript`/R for R; Python and required plotting packages for Python). If the selected runtime or required packages are unavailable, stop before rendering and report the exact blocker. You may provide a selected-backend script and installation commands, or ask permission to install dependencies, but you must not fall back to the other language to make a substitute figure.
+After the backend is selected, check the selected runtime early (`Rscript`/R for R; Python and required plotting packages for Python). If the selected runtime or required packages are unavailable, pause rendering, continue independent script or data checks, and report the exact blocker. You may provide a selected-backend script and installation commands, or ask permission to install dependencies, but you must not fall back to the other language to make a substitute figure.
 
 ## Data-integrity gate
 

--- a/skills/nature-figure/static/fragments/backend/python.md
+++ b/skills/nature-figure/static/fragments/backend/python.md
@@ -1,6 +1,6 @@
 # Backend: Python (matplotlib / seaborn)
 
-**Python-only execution rule.** When the user has selected Python, do all figure drawing, previewing, exporting, and visual QA in Python. Do not call R/ggplot2, ComplexHeatmap, patchwork, or any R graphics device to create a temporary preview, fallback export, or layout approximation. If Python or required Python plotting packages are missing, stop before rendering and report the missing dependency. You may still write the Python script, provide `pip`/environment install commands, or ask permission to install dependencies, but do not cross-render the figure in R.
+**Python-only execution rule.** When the user has selected Python, do all figure drawing, previewing, exporting, and visual QA in Python. Do not call R/ggplot2, ComplexHeatmap, patchwork, or any R graphics device to create a temporary preview, fallback export, or layout approximation. If Python or required Python plotting packages are missing, pause rendering, continue independent script or data checks, and report the missing dependency. You may still write the Python script, provide `pip`/environment install commands, or ask permission to install dependencies, but do not cross-render the figure in R.
 
 ## Python quick-start
 

--- a/skills/nature-figure/static/fragments/backend/r.md
+++ b/skills/nature-figure/static/fragments/backend/r.md
@@ -1,6 +1,6 @@
 # Backend: R (ggplot2 / patchwork / ComplexHeatmap)
 
-**R-only execution rule.** When the user has selected R, do all figure drawing, previewing, exporting, and visual QA in R. Do not call matplotlib/seaborn or any Python graphics device to create a temporary preview, fallback export, or layout approximation. If `Rscript`/R or required R packages are missing, stop before rendering and report the exact blocker. You may still write the R script, provide install commands (for example `install.packages(...)`), or ask permission to install dependencies, but do not cross-render the figure in Python.
+**R-only execution rule.** When the user has selected R, do all figure drawing, previewing, exporting, and visual QA in R. Do not call matplotlib/seaborn or any Python graphics device to create a temporary preview, fallback export, or layout approximation. If `Rscript`/R or required R packages are missing, pause rendering, continue independent script or data checks, and report the exact blocker. You may still write the R script, provide install commands (for example `install.packages(...)`), or ask permission to install dependencies, but do not cross-render the figure in Python.
 
 ## R quick-start
 

--- a/skills/nature-polishing/SKILL.md
+++ b/skills/nature-polishing/SKILL.md
@@ -34,7 +34,7 @@ For each axis in the manifest, decide the value using the manifest's `detect:` h
   Communications and `nat-mach-intell` for Nature Machine Intelligence (NMI).
   Do not route another Nature Portfolio title through flagship Nature rules.
 
-State the detected axis values in one short line to the user before proceeding, so they can correct you cheaply.
+State the detected axis values in one short line to the user before proceeding, so they can correct you cheaply. This is a progress update, not an approval gate; continue unless a necessary decision remains unresolved.
 
 ### 3. Load the matching fragments
 

--- a/skills/nature-polishing/static/fragments/journal/generic.md
+++ b/skills/nature-polishing/static/fragments/journal/generic.md
@@ -6,9 +6,11 @@ Used when the user has not named a target journal, or the journal is not specifi
 
 - Apply Nature-leaning style without enforcing Nature's strictest length or significance-framing demands.
 - Keep the em-dash and hedging defaults from `core/stance.md`.
-- If the user later names a journal, ask whether to re-polish under that journal's fragment rather than guess.
+- If the user later names a journal, apply that journal's fragment to the ongoing request; ask only if the intended scope of revision remains materially ambiguous.
 
-## Things to ask the user before final polish
+## Optional context
+
+Use these details when supplied; otherwise proceed with the generic defaults and state material assumptions. Ask only when missing information changes scientific meaning or a required deliverable. Do not turn these preferences into an intake checklist.
 
 - Target journal and section format (structured vs unstructured abstract; word limits; reference style).
 - Audience breadth: subfield vs broad readership.

--- a/skills/nature-polishing/static/fragments/journal/nat-comms.md
+++ b/skills/nature-polishing/static/fragments/journal/nat-comms.md
@@ -22,7 +22,7 @@ Open-access, broader than a subfield journal but more specialist-tolerant than N
 
 When polishing a Nature Communications Article, run these word-budget checks before sentence-level work:
 
-1. Estimate total word count **including Methods**. If over ~5,000, flag the gap and ask the user where to cut before polishing.
+1. Estimate total word count **including Methods**. Verify the current journal limit when submission compliance is requested. If over the applicable limit, continue meaning-preserving polishing and flag the gap in Revision notes. Obtain approval before substantive cuts to results, methods, or argument; length diagnosis does not block language edits.
 2. If display items > 10, flag for redistribution into Supplementary Information before deeper edits.
 3. If references > ~60, flag for trimming or consolidation.
 4. If the abstract is > 150 words or contains citations, restructure first.

--- a/skills/nature-writing/SKILL.md
+++ b/skills/nature-writing/SKILL.md
@@ -36,7 +36,7 @@ For each axis in the manifest, decide the value using the manifest's `detect:` h
   Intelligence (NMI), and `nature-family` for other Nature Portfolio titles or
   an unspecified Nature-family request.
 
-State the detected axis values in one short line to the user before drafting, so they can correct you cheaply.
+State the detected axis values in one short line to the user before drafting, so they can correct you cheaply. This is a progress update, not an approval gate; continue unless a necessary decision remains unresolved.
 
 ### 3. Load the matching fragments
 

--- a/skills/nature-writing/static/fragments/journal/generic.md
+++ b/skills/nature-writing/static/fragments/journal/generic.md
@@ -6,9 +6,11 @@ Used when the user has not named a target journal, or the journal is not specifi
 
 - Apply Nature-leaning structure (argument chain, section jobs) without enforcing Nature's strictest length or significance-framing demands.
 - Keep em-dash and hedging defaults from `core/stance.md` and `language/en.md`.
-- If the user later names a journal, ask whether to re-draft under that journal's fragment rather than guess.
+- If the user later names a journal, apply that journal's fragment to the ongoing request; ask only if the intended scope of revision remains materially ambiguous.
 
-## Things to ask the user before final draft
+## Optional context
+
+Use these details when supplied; otherwise proceed with the generic defaults and state material assumptions. Ask only when missing information changes scientific meaning or a required deliverable. Do not turn these preferences into an intake checklist.
 
 - Target journal and section format (structured vs unstructured abstract; word limits; reference style).
 - Audience breadth: subfield vs broad readership.


### PR DESCRIPTION
Figure backend selection and manuscript intake can block independent work or repeat questions in follow-up turns. This change reuses the current task's Python/R choice before a saved preference, limits the unresolved-language gate to dependent plotting steps, and lets read-only review and independent inspection continue. First-time backend selection, backend exclusivity, scientific integrity, and explicit approvals remain required.

Generic writing and polishing use defaults for optional context. Word-budget diagnostics no longer block meaning-preserving language edits; substantive cuts still require approval. Interpretive claim confirmation is limited to unresolved claims that materially affect the figure.

Validation: `python scripts/validate-repository.py` passed for all 20 skill directories; `git diff --check` passed. Instruction-only changes; no backend execution or scientific outputs claimed. Changes are synchronized across the affected routers and referenced guidance.
