### PR TITLE
fix(academic-search): use ESummary JSON for MeSH lookup

### DIFF
--- a/skills/nature-academic-search/mcp-server/sources/pubmed.py
+++ b/skills/nature-academic-search/mcp-server/sources/pubmed.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import time
 import xml.etree.ElementTree as ET
 from typing import Any
@@ -303,7 +304,14 @@ class PubMedSource:
             "retmode": "xml",
         }
         resp = _get("esearch.fcgi", search_params)
-        root = ET.fromstring(resp.content)
+        try:
+            root = ET.fromstring(resp.content)
+        except ET.ParseError as exc:
+            raise DataSourceError(
+                SOURCE_NAME,
+                "Invalid XML response from NCBI MeSH ESearch",
+                exc,
+            ) from exc
 
         id_list = root.find("IdList")
         if id_list is None or len(id_list) == 0:
@@ -314,22 +322,74 @@ class PubMedSource:
         if not ids:
             return {"term": term, "results": []}
 
-        # efetch from mesh db to get descriptor details
-        fetch_params: dict[str, Any] = {
+        # MeSH full-record EFetch is text-only, even when retmode=xml is
+        # requested. ESummary v2 provides structured descriptor metadata,
+        # including the canonical MeSH UI, without parsing the text view.
+        summary_params: dict[str, Any] = {
             "db": "mesh",
             "id": ",".join(ids),
-            "retmode": "xml",
+            "retmode": "json",
+            "version": "2.0",
         }
-        resp = _get("efetch.fcgi", fetch_params)
-        fetch_root = ET.fromstring(resp.content)
+        resp = _get("esummary.fcgi", summary_params)
+        try:
+            payload = resp.json()
+        except (ValueError, requests.JSONDecodeError) as exc:
+            raise DataSourceError(
+                SOURCE_NAME,
+                "Invalid JSON response from NCBI MeSH ESummary",
+                exc,
+            ) from exc
+
+        summary = payload.get("result") if isinstance(payload, dict) else None
+        if not isinstance(summary, dict):
+            raise DataSourceError(
+                SOURCE_NAME,
+                "Malformed NCBI MeSH ESummary response: missing result object",
+            )
 
         results: list[dict[str, str]] = []
-        for descriptor in fetch_root.findall(".//DescriptorRecord"):
-            name_el = descriptor.find("DescriptorName/String")
-            ui_el = descriptor.find("DescriptorUI")
-            name = name_el.text.strip() if name_el is not None and name_el.text else ""
-            ui = ui_el.text.strip() if ui_el is not None and ui_el.text else ""
-            if name:
-                results.append({"name": name, "mesh_id": ui, "ui": ui})
+        for entrez_uid in ids:
+            record = summary.get(entrez_uid)
+            if not isinstance(record, dict):
+                raise DataSourceError(
+                    SOURCE_NAME,
+                    f"Malformed NCBI MeSH ESummary response: missing UID {entrez_uid}",
+                )
+
+            mesh_terms = record.get("ds_meshterms")
+            name = ""
+            if isinstance(mesh_terms, list):
+                name = next(
+                    (
+                        value.strip()
+                        for value in mesh_terms
+                        if isinstance(value, str) and value.strip()
+                    ),
+                    "",
+                )
+
+            ui_value = record.get("ds_meshui")
+            ui = ui_value.strip() if isinstance(ui_value, str) else ""
+
+            if not name:
+                raise DataSourceError(
+                    SOURCE_NAME,
+                    f"Malformed NCBI MeSH ESummary response: missing descriptor name for UID {entrez_uid}",
+                )
+            if not re.fullmatch(r"[A-Z]\d{6,}", ui):
+                raise DataSourceError(
+                    SOURCE_NAME,
+                    f"Malformed NCBI MeSH ESummary response: invalid MeSH UI for UID {entrez_uid}",
+                )
+
+            results.append(
+                {
+                    "name": name,
+                    "mesh_id": ui,
+                    "ui": ui,
+                    "entrez_uid": entrez_uid,
+                }
+            )
 
         return {"term": term, "results": results}

--- a/skills/nature-academic-search/mcp-server/tests/test_sources.py
+++ b/skills/nature-academic-search/mcp-server/tests/test_sources.py
@@ -461,6 +461,134 @@ class TestPubMedSearch:
         assert result["results"][1]["pmid"] == "222"
 
 
+class TestPubMedMeshLookup:
+    """Test MeSH ESearch + ESummary lookup and response validation."""
+
+    @pytest.mark.parametrize(
+        ("term", "entrez_uid", "name", "mesh_ui"),
+        [
+            ("heart failure", "68006333", "Heart Failure", "D006333"),
+            ("diabetes mellitus", "68003920", "Diabetes Mellitus", "D003920"),
+        ],
+    )
+    @patch("sources.pubmed.get_config")
+    @patch("sources.pubmed._get")
+    def test_lookup_mesh_returns_canonical_ui(
+        self, mock_get, mock_config, term, entrez_uid, name, mesh_ui
+    ):
+        mock_config.return_value = _make_pubmed_config()
+
+        esearch_resp = MagicMock()
+        esearch_resp.content = (
+            f"<?xml version='1.0'?><eSearchResult><IdList><Id>{entrez_uid}</Id>"
+            "</IdList></eSearchResult>"
+        ).encode("utf-8")
+        esummary_resp = MagicMock()
+        esummary_resp.json.return_value = {
+            "result": {
+                "uids": [entrez_uid],
+                entrez_uid: {
+                    "uid": entrez_uid,
+                    "ds_meshterms": [name, f"{name} synonym"],
+                    "ds_meshui": mesh_ui,
+                    "ds_recordtype": "descriptor",
+                },
+            }
+        }
+        mock_get.side_effect = [esearch_resp, esummary_resp]
+
+        from sources.pubmed import PubMedSource
+
+        result = PubMedSource().lookup_mesh(term)
+
+        assert result["term"] == term
+        assert result["results"] == [
+            {
+                "name": name,
+                "mesh_id": mesh_ui,
+                "ui": mesh_ui,
+                "entrez_uid": entrez_uid,
+            }
+        ]
+        assert re.fullmatch(r"[A-Z]\d{6,}", result["results"][0]["ui"])
+        assert mock_get.call_args_list[1].args[0] == "esummary.fcgi"
+        assert mock_get.call_args_list[1].args[1]["version"] == "2.0"
+
+    @patch("sources.pubmed.get_config")
+    @patch("sources.pubmed._get")
+    def test_lookup_mesh_nonexistent_term_returns_empty(self, mock_get, mock_config):
+        mock_config.return_value = _make_pubmed_config()
+        response = MagicMock()
+        response.content = (
+            b"<?xml version='1.0'?><eSearchResult><IdList></IdList></eSearchResult>"
+        )
+        mock_get.return_value = response
+
+        from sources.pubmed import PubMedSource
+
+        result = PubMedSource().lookup_mesh("no-such-mesh-term-xyz-987654")
+
+        assert result == {
+            "term": "no-such-mesh-term-xyz-987654",
+            "results": [],
+        }
+        assert mock_get.call_count == 1
+
+    def test_lookup_mesh_empty_term_raises(self):
+        from sources.pubmed import PubMedSource
+        from utils.errors import DataSourceError
+
+        with pytest.raises(DataSourceError, match="Empty MeSH lookup term"):
+            PubMedSource().lookup_mesh("")
+
+    @patch("sources.pubmed.get_config")
+    @patch("sources.pubmed._get")
+    def test_lookup_mesh_invalid_esummary_json_raises(self, mock_get, mock_config):
+        mock_config.return_value = _make_pubmed_config()
+        esearch_resp = MagicMock()
+        esearch_resp.content = (
+            b"<?xml version='1.0'?><eSearchResult><IdList><Id>68006333</Id>"
+            b"</IdList></eSearchResult>"
+        )
+        esummary_resp = MagicMock()
+        esummary_resp.json.side_effect = ValueError("not JSON")
+        mock_get.side_effect = [esearch_resp, esummary_resp]
+
+        from sources.pubmed import PubMedSource
+        from utils.errors import DataSourceError
+
+        with pytest.raises(DataSourceError, match="Invalid JSON.*ESummary"):
+            PubMedSource().lookup_mesh("heart failure")
+
+    @patch("sources.pubmed.get_config")
+    @patch("sources.pubmed._get")
+    def test_lookup_mesh_missing_ui_raises(self, mock_get, mock_config):
+        mock_config.return_value = _make_pubmed_config()
+        esearch_resp = MagicMock()
+        esearch_resp.content = (
+            b"<?xml version='1.0'?><eSearchResult><IdList><Id>68006333</Id>"
+            b"</IdList></eSearchResult>"
+        )
+        esummary_resp = MagicMock()
+        esummary_resp.json.return_value = {
+            "result": {
+                "uids": ["68006333"],
+                "68006333": {
+                    "uid": "68006333",
+                    "ds_meshterms": ["Heart Failure"],
+                    "ds_meshui": "",
+                },
+            }
+        }
+        mock_get.side_effect = [esearch_resp, esummary_resp]
+
+        from sources.pubmed import PubMedSource
+        from utils.errors import DataSourceError
+
+        with pytest.raises(DataSourceError, match="invalid MeSH UI"):
+            PubMedSource().lookup_mesh("heart failure")
+
+
 # ===================================================================
 # 3. arXiv tests
 # ===================================================================


### PR DESCRIPTION
## Problem

`lookup_mesh` searches the NCBI MeSH database with ESearch, then previously called EFetch with `retmode=xml`.

NCBI MeSH full-record EFetch returns `text/plain`, so parsing that response with `xml.etree.ElementTree` raises `ParseError`.

## Fix

- Keep ESearch for obtaining MeSH Entrez UIDs.
- Replace the second step with ESummary v2 JSON.
- Read the canonical descriptor name from `ds_meshterms`.
- Read the canonical MeSH UI from `ds_meshui`.
- Preserve the existing `name`, `mesh_id`, and `ui` response fields.
- Add `entrez_uid` as additional metadata.
- Raise explicit `DataSourceError` for malformed responses instead of silently returning incorrect IDs.

## Verification

- `lookup_mesh("heart failure")` -> `Heart Failure`, `D006333`
- MeSH-specific tests: 6 passed
- Full test suite: 39 passed, 5 skipped
- The skipped tests are credential-gated Elsevier online tests
- MCP handshake passed
- PubMed / CrossRef / arXiv regression tests passed
- `search_papers`, `get_paper_by_id`, and `get_citation` passed
- `git diff --check` passed

## Safety

- No credentials included
- No local absolute paths included
- No unrelated provider behavior changed
