### PR TITLE
Trim skill discovery prompts and scope follow-up workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,13 +145,7 @@
 npx skills add Yuan1z0825/nature-skills --list
 ```
 
-把全部技能全局安装到 Codex。`nature-shared` 会随全量安装一起加入，因此依赖共享参考资料的技能也能正常工作：
-
-```bash
-npx skills add Yuan1z0825/nature-skills --global --agent codex --skill '*' --yes --copy
-```
-
-只为当前项目安装一个独立技能时，省略 `--global`。例如：
+优先按当前任务选择需要的技能，并保留其共享依赖。只为当前项目安装时，省略 `--global`；需要跨项目使用时再加上它。例如：
 
 ```bash
 npx skills add Yuan1z0825/nature-skills --agent codex --skill nature-figure --yes --copy
@@ -164,7 +158,13 @@ npx skills add Yuan1z0825/nature-skills --global --agent codex \
   --skill nature-reader --skill nature-shared --yes --copy
 ```
 
-也可以把全部技能安装到 CLI 支持的所有 agent：
+如果确实需要完整技能集，也可以全局安装到 Codex。全量选择包含 `nature-shared`：
+
+```bash
+npx skills add Yuan1z0825/nature-skills --global --agent codex --skill '*' --yes --copy
+```
+
+需要把全部技能安装到 CLI 支持的所有 agent 时，使用：
 
 ```bash
 npx skills add Yuan1z0825/nature-skills --all
@@ -307,7 +307,7 @@ git clone https://github.com/Yuan1z0825/nature-skills.git ~/ai-skills/nature-ski
 
 ### 5.3 Codex 安装方式
 
-推荐使用仓库自带脚本安装或更新 Codex skills。脚本会同步 `skills/` 下所有顶层技能目录，并在复制后做 `diff` 验证；它不会覆盖其他无关 Codex skills。
+需要安装或更新完整技能集时，可以使用仓库自带脚本。脚本会同步 `skills/` 下所有顶层技能目录，并在复制后做 `diff` 验证；它不会覆盖其他无关 Codex skills。只需要部分技能时，使用上面的 `npx skills` 按需安装方式。
 
 ```bash
 git clone https://github.com/Yuan1z0825/nature-skills.git

--- a/README_EN.md
+++ b/README_EN.md
@@ -177,14 +177,9 @@ to be installed globally. List the skill names available in this repository:
 npx skills add Yuan1z0825/nature-skills --list
 ```
 
-Install every skill globally for Codex. The complete selection includes
-`nature-shared`, so skills that use the common references remain functional:
-
-```bash
-npx skills add Yuan1z0825/nature-skills --global --agent codex --skill '*' --yes --copy
-```
-
-Omit `--global` to install one independent skill in the current project:
+Start with the skills needed for the current task and include their shared dependencies.
+Omit `--global` for project-local installation; add it when the skill should be available
+across projects. For example:
 
 ```bash
 npx skills add Yuan1z0825/nature-skills --agent codex --skill nature-figure --yes --copy
@@ -198,7 +193,14 @@ npx skills add Yuan1z0825/nature-skills --global --agent codex \
   --skill nature-reader --skill nature-shared --yes --copy
 ```
 
-Install all skills for every agent supported by the CLI:
+If you need the complete collection, install every skill globally for Codex.
+This selection includes `nature-shared`:
+
+```bash
+npx skills add Yuan1z0825/nature-skills --global --agent codex --skill '*' --yes --copy
+```
+
+To install all skills for every agent supported by the CLI:
 
 ```bash
 npx skills add Yuan1z0825/nature-skills --all
@@ -365,9 +367,10 @@ The destination and check interval are both configurable:
 
 ### 5.3 Codex Installation
 
-Use the repository script to install or update Codex skills. It syncs every
+Use the repository script when installing or updating the complete skill collection. It syncs every
 top-level skill directory under `skills/` and verifies the copied contents with
-`diff`. It does not overwrite unrelated Codex skills.
+`diff`. It does not overwrite unrelated Codex skills. For a selected subset, use
+the `npx skills` installation above.
 
 ```bash
 git clone https://github.com/Yuan1z0825/nature-skills.git

--- a/docs/skill-scope-smoke-evaluation.md
+++ b/docs/skill-scope-smoke-evaluation.md
@@ -1,0 +1,99 @@
+# Skill scope smoke evaluation
+
+## Scope and method
+
+On 2026-09-06, five isolated agent contexts exercised six short requests against the edited
+local skills. The writing context received a second request as an intentional follow-up.
+Agents received the skill path, raw request, and supplied source material, without expected
+answers or the implementation rationale. They could read instructions but could not modify
+repository files or use external services. All examples below are synthetic.
+
+These observations establish only the behavior of these small, explicitly invoked tasks.
+They are not an automatic skill-selection benchmark, a before/after comparison, a cross-model
+evaluation, or validation of complete manuscripts, readers, or slide decks. Static checks and
+runtime tests are separate from these observations.
+
+## Requests and observed outputs
+
+### Paper question
+
+Skill: `nature-reader`.
+
+Request: explain Figure 2b in two or three Chinese sentences. The supplied Results excerpt and
+caption described fluorescence intensity means of 8.2 AU (treated) and 6.1 AU (control), with
+12 independent biological samples per group, no inferential test, and no established mechanism.
+
+Observed: three Chinese sentences cited the supplied Results section and caption, preserved the
+sample counts and means, and described the 2.1 AU difference without claiming significance or a
+mechanism. No reader-generation deliverable or fabricated source-map IDs appeared in the answer.
+
+### Local reviewer reply
+
+Skill: `nature-response`.
+
+Request: make the following reply more polite and concise, returning only the reply.
+Reviewer: "Please clarify the software version used."
+Draft: "The reviewer missed this. We used version 2.3.1."
+
+Observed output:
+
+> Thank you for requesting clarification. We used software version 2.3.1.
+
+No Major/Minor question, invented manuscript revision, tracker, or package-readiness claim.
+
+### Descriptive Results paragraph
+
+Skill: `nature-writing`.
+
+Request: draft one short English Results paragraph from the same sample counts and means as
+the paper-question example, explicitly descriptive with no inferential test or mechanism.
+
+Observed output:
+
+> The mean signal was 8.2 AU in the treated group and 6.1 AU in the control group, with 12 independent biological samples per group. This comparison was descriptive; no inferential test was performed.
+
+The paragraph was delivered without an outline-approval or manuscript-intake question.
+
+### Explicit outline approval
+
+Skill: `nature-writing`, continuing the preceding case.
+
+Request: plan a Discussion from those findings, give an outline first, and wait for approval
+before prose; the evidence is descriptive and provides no mechanism.
+
+Observed: an outline covered the central observation, interpretation boundaries, and a focused
+next step. It stated that significance and variability were not established by the supplied
+means, omitted unsupported literature positioning, and explicitly waited for outline approval.
+No full Discussion prose was drafted.
+
+### Data Availability grammar edit
+
+Skill: `nature-data`.
+
+Request: correct the grammar and return only the sentence:
+"All data supporting this study is included in this article and its Supplementary Information."
+
+Observed output:
+
+> All data supporting this study are included in this article and its Supplementary Information.
+
+The answer did not request a study-wide data inventory or invent repository identifiers.
+
+### Offline citation conversion
+
+Skill: `nature-academic-search`.
+
+Request: return RIS text only, without online lookup or verification, for a supplied journal
+article by Jane Doe and Ming Li, "Synthetic example of sample imaging", Example Research
+Journal, 2025, volume 12, issue 3, pages 21-29, with no DOI supplied.
+
+Observed: one RIS record retained author order and all supplied fields, split the page range
+into `SP` and `EP`, and omitted a DOI rather than fabricating one. The answer contained no API
+setup request or claim of online verification.
+
+## Follow-up coverage
+
+Long-document quality, rendered slide revisions, implicit routing among overlapping skills,
+real publisher retrieval, and cross-model behavior still require dedicated evaluation.
+Existing artifact-completeness and evidence-integrity requirements remain in place for those
+workflows; these small cases do not replace their checks.

--- a/skills/nature-academic-search/SKILL.md
+++ b/skills/nature-academic-search/SKILL.md
@@ -1,30 +1,18 @@
 ---
 name: nature-academic-search
-description: >-
-  Multi-source literature search, citation verification, strict independent other-citation
-  audits, article-level citation metric tables, influential citer profiling with
-  citation-context extraction, MeSH search strategy, citation file management
-  (.nbib/.ris/.bib conversion), and reference management (BibTeX, related articles,
-  ID conversion) via MCP tools (PubMed, CrossRef, arXiv, Scopus, ScienceDirect).
-  Use for coordinated literature workflows beyond one MCP call, including 文献检索、
-  查文献、找文献、文献综述检索、查论文、引文核对、参考文献管理、文献去重、
-  严格他引、他引判定、排除自引、谁引用了我的文章、引用我的文章的人有没有大牛、
-  院士引用、校长引用、院长引用、杰青引用、长江学者引用、Fellow引用、文章引用表、
-  指定文章引用数、严格他引数、整理成表格.
+description: "Search literature across sources, verify or manage citations, and build MeSH strategies or citation-impact audits. Use for 文献检索、引文核对、参考文献管理、严格他引 and evidence-backed citer profiles; not for translating a paper or drafting manuscript prose."
 ---
 
 # Academic Search — Router
 
-This skill is split into two layers:
-
-- A **static layer** under `static/` that holds versioned, reusable content fragments (the MCP tool inventory and shared modules, and source routing plus operational rules).
-- A **dynamic layer** (this file plus `manifest.yaml`) that detects which workflow the user needs and loads that workflow, reaching for shared modules and scripts only when a step needs them.
-
-Do not try to apply the search logic from memory or from this router. Always load fragments from disk as described below.
-
 ## Routing protocol
 
-Follow these five steps every time the skill is invoked.
+For local citation-file conversion with complete supplied records, load
+`references/workflows/wf4-citation-file-mgmt.md` and its format reference directly.
+Source lookup, API setup, and network preflight apply only when retrieval or verification is
+needed; do not require them for a requested offline conversion.
+
+For a new task, load the core and matching resources below. Reuse already loaded guidance on follow-ups; load more only when the task needs it.
 
 ### 1. Load the manifest and the core layer
 
@@ -56,7 +44,7 @@ Read the file mapped for each detected workflow (under `references/workflows/`).
 
 Apply the loaded material in this order:
 
-1. Core tools and routing (`core/tools.md`, `core/routing-and-ops.md`) — which MCP tool for which need, and the T1→T2→T3 fallback chain that is the standard execution order across all workflows.
+1. Core tools and routing (`core/tools.md`, `core/routing-and-ops.md`) — which MCP tool for which need, and the T1→T2→T3 fallback chain for source retrieval.
 2. The workflow fragment — its specific steps.
 3. Shared modules and scripts on demand (dedup, citation parser, search strategy, RIS/BibTeX format, format converter).
 
@@ -65,10 +53,3 @@ Report specific tool failures and continue with remaining tools; broaden terms w
 ### 5. Reach for references only when needed
 
 The files under `references/` (and `scripts/`) are deep references, not defaults. Open them on demand per the `references.on_demand` table in the manifest — for example `references/source-tiers.md` for the full reliability classification, `references/dedup-engine.md` / `references/citation-parser.md` / `references/search-strategy.md` / `references/ris-bibtex-format.md` for the shared modules, and `scripts/academic_search.py` (no-MCP fallback discovery search) / `scripts/format-converter.py` / `scripts/preflight.py` for the tooling.
-
-## Why this split
-
-- The static layer is versioned and reviewable; the workflow files and shared modules were already factored this way.
-- The dynamic layer keeps each invocation cheap: only the workflow the user needs enters context, instead of all six plus every module.
-- The router itself is short on purpose. Update fragments and references, not this file, when adding scope.
-- This structure mirrors the other nature-* skills (`nature-writing`, `nature-polishing`, `nature-reader`, `nature-paper2ppt`, `nature-figure`, `nature-citation`, `nature-response`, `nature-data`).

--- a/skills/nature-academic-search/references/workflows/wf4-citation-file-mgmt.md
+++ b/skills/nature-academic-search/references/workflows/wf4-citation-file-mgmt.md
@@ -6,6 +6,12 @@
 
 ## Procedure
 
+If the user supplied complete citation records and requests only local format conversion, read
+[RIS and BibTeX Format](../ris-bibtex-format.md), convert those records, and check record count,
+author order, identifiers, and escaping. Do not fetch metadata or run network preflight unless
+verification or missing fields require it. The downloader examples below apply to retrieval by
+identifier or query; `--input refs.txt` accepts identifier/query lines, not arbitrary citation files.
+
 1. **Identify papers** — by PMID, DOI, arXiv ID, or search query.
 2. **Download** via format-converter:
    ```bash

--- a/skills/nature-academic-search/static/core/routing-and-ops.md
+++ b/skills/nature-academic-search/static/core/routing-and-ops.md
@@ -2,7 +2,7 @@
 
 ## Source routing
 
-See [Source Tiers & Reliability](../../references/source-tiers.md) for the complete reliability classification and fallback routing rules. The T1→T2→T3 fallback chain is the standard execution order across all workflows.
+See [Source Tiers & Reliability](../../references/source-tiers.md) for source retrieval and fallback routing. Local format conversion from supplied complete records does not require source retrieval, credentials, or network preflight. Retrieve metadata only when the requested verification or missing fields require it; do not invent absent fields.
 
 Quick guide:
 
@@ -40,7 +40,7 @@ export https_proxy=http://127.0.0.1:7890
 python scripts/preflight.py
 ```
 
-Run before batch operations to verify API endpoints are reachable.
+Run before batch network operations to verify API endpoints are reachable.
 
 ### Format converter dependencies
 

--- a/skills/nature-citation/SKILL.md
+++ b/skills/nature-citation/SKILL.md
@@ -1,40 +1,21 @@
 ---
 name: nature-citation
-description: >-
-  Add strict Nature/CNS citations to manuscript text by splitting long passages into citable
-  segments, searching only accepted flagship and subjournal titles from Nature Portfolio, the
-  AAAS Science family, and Cell Press, filtering by publication time range, and exporting one
-  reference-manager-ready output by default. Use this skill whenever the user asks to input text and
-  automatically get references, add citations to a paragraph/manuscript, find Nature-series or CNS
-  support for statements, create text-to-reference correspondence, "分段引用", "自动给出引用",
-  "Nature系列引用", "CNS及子刊", "支撑文献", "补引用", "找引用", or export EndNote/RIS/ENW/Zotero RDF.
-  Also trigger on general academic-writing citation needs even without the word "Nature", such as
-  adding references while writing a paper, finding sources/literature for a claim, building a
-  reference list, citation/referencing for academic writing, and Chinese phrasings like
-  学术写作引用、写论文加引用、写paper找文献、加参考文献、配文献、引用文献、文献支撑.
+description: "Find and verify Nature/CNS-family literature supporting manuscript claims, with claim-to-source mapping and reference-manager export. Use for Nature系列引用、CNS支撑文献、分段补引用 when this journal scope is requested; use broader literature search for unrestricted sources."
 metadata:
   author: Yuan1z skill, refactored into static/dynamic layers
 ---
 
 # Nature Citation — Router
 
-This skill is split into two layers:
-
-- A **static layer** under `static/` that holds versioned, reusable content fragments (core principles and scope, the Chinese-user operating mode, and the citation workflow).
-- A **dynamic layer** (this file plus `manifest.yaml`) that loads the core every time and reaches for heavier material only when a step needs it.
-
-Do not try to apply the citation logic from memory or from this router. Always load fragments from disk as described below.
-
 ## Routing protocol
 
-Follow these four steps every time the skill is invoked.
+For a new task, load the core and matching resources below. Reuse already loaded guidance on follow-ups; load more only when the task needs it.
 
 ### 1. Load the manifest and the core layer
 
 Read [manifest.yaml](manifest.yaml). Then read every file listed under `always_load`:
 
 - `static/core/principles.md` — what the skill produces, the strict journal scope, the source hierarchy, and the search-quality rules.
-- `static/core/chinese-mode.md` — how to operate when the user writes in Chinese or asks for `Nature系列`/`CNS及子刊` style support.
 - `static/core/workflow.md` — the seven-step workflow and the final report format.
 
 ### 2. No content axis — confirm scope and language inline
@@ -42,14 +23,14 @@ Read [manifest.yaml](manifest.yaml). Then read every file listed under `always_l
 Unlike the other nature-* skills, nature-citation has no fragment axis. Its variation is runtime parameters, not different content bodies:
 
 - **journal scope** — `Nature系列` / `CNS` / `CNS及子刊` / flagship-only. Read it from the user's wording (see `core/principles.md`) and pass it to the script as `--scope`.
-- **user language** — if the user writes Chinese, follow `core/chinese-mode.md` (Chinese notes, English search queries).
+- **user language** — if the user writes Chinese or requests Chinese guidance, read `static/core/chinese-mode.md` (Chinese notes, English search queries).
 - **input length** — if there are more than ~10 segments, switch to the batched long-article strategy in `references/script-usage.md`.
 
 State the detected scope and date limits in one short line before searching.
 
 ### 3. Run the workflow
 
-Follow the seven steps in `core/workflow.md`: segment, parse, search, evaluate support conservatively, validate complete structured author metadata, export one reference-manager file, generate review artifacts when useful, and report with the HTML browser path first. Prefer `scripts/nature_citation.py` for the search/export when internet access is available; open `references/script-usage.md` for its full flag list and the long-article batch strategy. When DOI metadata lacks given names, refetch the record by PMID or verify it against the publisher rather than exporting surname-only `AU` fields.
+Follow the seven steps in `core/workflow.md`: segment, parse, search, evaluate support conservatively, validate complete structured author metadata, export one reference-manager file, and generate review artifacts when useful. Put the HTML browser path first only when it was generated. Prefer `scripts/nature_citation.py` for the search/export when internet access is available; open `references/script-usage.md` for its full flag list and the long-article batch strategy. When DOI metadata lacks given names, refetch the record by PMID or verify it against the publisher rather than exporting surname-only `AU` fields.
 
 Never present a paper as support merely because its title is related, and never cite a metadata-only candidate without checking the abstract or publisher page. Do not invent missing bibliographic fields.
 
@@ -61,10 +42,3 @@ The files under `references/` are deep references, not defaults. Open them on de
 - turning a claim into search queries and support grades → `references/search-strategy.md`.
 - the exact Nature/CNS journal-family boundary → `references/journal-scope.md`.
 - RIS / EndNote / Zotero RDF export details → `references/ris-endnote.md`.
-
-## Why this split
-
-- The static layer is versioned and reviewable; the core stays small for a normal short run.
-- The dynamic layer keeps each invocation cheap: the script flag dump and long-article strategy load only when actually running a search.
-- The router itself is short on purpose. Update fragments and references, not this file, when adding scope.
-- This structure mirrors `nature-writing`, `nature-polishing`, `nature-reader`, `nature-paper2ppt`, and `nature-figure`.

--- a/skills/nature-citation/manifest.yaml
+++ b/skills/nature-citation/manifest.yaml
@@ -16,11 +16,12 @@ description: >
 
 always_load:
   - static/core/principles.md
-  - static/core/chinese-mode.md
   - static/core/workflow.md
 
 references:
   on_demand:
+    - condition: the user writes Chinese or requests Chinese guidance
+      path: static/core/chinese-mode.md
     - condition: running nature_citation.py — full flag list, long-article batch strategy, quick-guide tables
       path: references/script-usage.md
     - condition: translating a manuscript claim into search queries and support grades

--- a/skills/nature-citation/static/core/workflow.md
+++ b/skills/nature-citation/static/core/workflow.md
@@ -94,4 +94,4 @@ S001: [source segment]
 - [missing full-text check, contradictory evidence, no direct CNS literature, etc.]
 ```
 
-Put the HTML browser path FIRST, above everything else, so the user can immediately open and browse candidates. If no suitable CNS/Nature-series paper exists, say so plainly and suggest the best nearby options from non-CNS literature only if the user wants broader coverage. If the text is long, mention the batch strategy used, especially when you limited the run with `--batch-size` or `--max-segments`.
+When HTML review artifacts were generated, put the existing browser path first so the user can browse candidates. Otherwise omit the browser block; do not create extra artifacts or report a nonexistent path merely to fill the template. If no suitable CNS/Nature-series paper exists, say so plainly and suggest the best nearby options from non-CNS literature only if the user wants broader coverage. If the text is long, mention the batch strategy used, especially when you limited the run with `--batch-size` or `--max-segments`.

--- a/skills/nature-data/SKILL.md
+++ b/skills/nature-data/SKILL.md
@@ -1,39 +1,21 @@
 ---
 name: nature-data
-description: >-
-  Prepare, audit, or revise Nature-ready Data Availability statements, data repository plans,
-  dataset citations, and FAIR metadata checklists for manuscripts. Use when the user asks about
-  Nature data availability, research data sharing, repository selection, accession numbers,
-  restricted or sensitive data, source data, supplementary datasets, DataCite-style dataset
-  references, FAIR metadata for academic publication, or Chinese-to-English data availability
-  wording for Chinese-speaking authors preparing Nature-family submissions.
-  Also trigger on general academic-writing data needs even without the word "Nature", such as
-  writing a data availability statement for any journal, code/data sharing sections, repository
-  selection while writing a paper, and Chinese phrasings like 数据可用性声明、数据可用性、
-  数据共享、代码可用性、学术写作数据声明、写数据声明、数据存放、数据仓库选择.
+description: "Draft or audit manuscript Data/Code Availability statements, dataset access routes, repository plans, and FAIR metadata. Use for 数据可用性声明、数据共享、数据仓库选择 and dataset citations; not general data cleaning or statistical analysis."
 metadata:
   author: Yuan1z skill, refactored into static/dynamic layers
 ---
 
 # Nature Data Availability — Router
 
-This skill is split into two layers:
-
-- A **static layer** under `static/` that holds versioned, reusable content fragments (the default stance and source hierarchy, the Chinese-user operating mode, and the workflow with output format).
-- A **dynamic layer** (this file plus `manifest.yaml`) that loads the core every time and reaches for the deeper policy/repository/FAIR references only when a step needs them.
-
-Do not try to apply the data-availability logic from memory or from this router. Always load fragments from disk as described below.
-
 ## Routing protocol
 
-Follow these four steps every time the skill is invoked.
+For a new task, load the core and matching resources below. Reuse already loaded guidance on follow-ups; load more only when the task needs it.
 
 ### 1. Load the manifest and the core layer
 
 Read [manifest.yaml](manifest.yaml). Then read every file listed under `always_load`:
 
 - `static/core/stance.md` — what the data-availability package is, the default stance, and the source hierarchy.
-- `static/core/chinese-mode.md` — how to operate when the user writes in Chinese (accept Chinese, draft English, convert terms precisely).
 - `static/core/workflow.md` — the eight-step workflow and the output format.
 
 ### 2. No content axis — confirm journal and language inline
@@ -42,9 +24,14 @@ Unlike nature-writing or nature-figure, nature-data has no fragment axis. Its va
 
 - **journal/article type** — if journal-specific instructions conflict with this skill, follow the journal.
 - **access route** — each dataset is classified into one route (public repository, controlled access, within paper, reused public, third-party restricted, justified request, or not applicable).
-- **user language** — if the user writes Chinese, follow `core/chinese-mode.md` and add the 中文核对 block.
+- **user language** — if the user writes Chinese or requests Chinese guidance, read `static/core/chinese-mode.md` and add the 中文核对 block unless the user requested statement text only.
 
 ### 3. Run the workflow
+
+For a wording edit or audit of one existing statement, preserve supplied repository identifiers
+and access conditions and check the affected claims. Report gaps relevant to that statement;
+do not require a full study-wide dataset inventory or repository redesign. Use the complete
+workflow below for a new data-sharing plan, full statement, or submission audit.
 
 Follow the eight-step workflow in `core/workflow.md`: identify the journal, inventory every supporting dataset, classify each into one access route, choose repository and identifier strategy before drafting, draft the statement with explicit dataset-to-location mapping, add formal dataset citations, run the FAIR/metadata audit, and return ready-to-paste text plus unresolved fields.
 
@@ -65,10 +52,3 @@ Data Availability statement and a separate `Code availability` section after
 it and before references; check reviewer access, precise restrictions,
 repository/identifier quality and the Software Submission Checklist for newly
 developed central code.
-
-## Why this split
-
-- The static layer is versioned and reviewable; the core stays small for a normal statement.
-- The dynamic layer keeps each invocation cheap: the policy, repository, and FAIR depth load only when a step needs them.
-- The router itself is short on purpose. Update fragments and references, not this file, when adding scope.
-- This structure mirrors `nature-writing`, `nature-polishing`, `nature-reader`, `nature-paper2ppt`, `nature-figure`, `nature-citation`, and `nature-response`.

--- a/skills/nature-data/manifest.yaml
+++ b/skills/nature-data/manifest.yaml
@@ -15,11 +15,12 @@ description: >
 
 always_load:
   - static/core/stance.md
-  - static/core/chinese-mode.md
   - static/core/workflow.md
 
 references:
   on_demand:
+    - condition: the user writes Chinese or requests Chinese guidance
+      path: static/core/chinese-mode.md
     - condition: governing Nature/Springer Nature data-sharing rules or edge-case policy logic
       path: references/policy-principles.md
     - condition: target is the flagship journal Nature, or exact Nature Article data, code, materials, mandatory-deposition, reviewer-access, or statement-placement rules are needed

--- a/skills/nature-data/static/core/workflow.md
+++ b/skills/nature-data/static/core/workflow.md
@@ -2,6 +2,11 @@
 
 ## Workflow
 
+Use the complete workflow for a new data-sharing plan, full statement, or submission audit.
+For a local wording edit or bounded statement audit, apply only relevant checks to the supplied
+dataset identifiers, access conditions, and claims. Do not infer that the whole study is FAIR
+or submission-ready from checking one statement.
+
 1. Identify the target journal and article type. If journal-specific instructions conflict with this skill, follow the journal.
 2. Inventory every dataset needed to support the main and supplementary results: generated raw data, processed data, figure source data, secondary data, software outputs, models, tables, images, and files underlying statistical analysis.
 3. Classify each dataset into one access route: `public repository`, `controlled access repository`, `within paper or supplement`, `reused public source`, `third-party restricted`, `available on justified request`, or `not applicable`.

--- a/skills/nature-figure/SKILL.md
+++ b/skills/nature-figure/SKILL.md
@@ -9,16 +9,9 @@ description: >-
 
 # Nature Figure Making — Router
 
-This skill is split into two layers:
-
-- A **static layer** under `static/` that holds versioned, reusable content fragments (the figure contract and default stance, plus a per-backend quick-start for Python and R).
-- A **dynamic layer** (this file plus `manifest.yaml`) that detects the plotting backend and loads only the fragment needed for the current job. The large design, API, pattern, and QA material lives in on-demand references.
-
-Do not try to apply the figure logic from memory or from this router. Always load fragments from disk as described below.
-
 ## Routing protocol
 
-Follow these steps every time the skill is invoked.
+For a new task, load the core and matching resources below. Reuse already loaded guidance on follow-ups; load more only when the task needs it.
 
 ### 0. Check for graphical-abstract and AI-schematic routes
 
@@ -148,10 +141,3 @@ The files under `references/` are deep references, not defaults. Open them on de
 
 Do not infer flagship Nature or NMI requirements from a Nature Communications
 corpus or from the visual-style examples in this skill.
-
-## Why this split
-
-- The static layer is versioned and reviewable. The backend gate is now explicit in the manifest rather than buried in prose.
-- The dynamic layer keeps each invocation cheap: only the selected backend's quick-start enters context, and the 2,600+ lines of reference depth load only when a step needs them.
-- The router itself is short on purpose. Update fragments and references, not this file, when adding scope.
-- This structure mirrors `nature-writing`, `nature-polishing`, `nature-reader`, and `nature-paper2ppt`.

--- a/skills/nature-figure/SKILL.md
+++ b/skills/nature-figure/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: nature-figure
 description: >-
-  Create, revise, audit, and export submission-grade scientific figures for Nature-family and other high-impact venues in Python (matplotlib/seaborn) or R (ggplot2/patchwork/ComplexHeatmap), including multi-panel plots, figures4papers-style work, and journal-ready SVG/PDF/TIFF outputs. Use for paper or scientific plots, manuscript data visualization, 论文配图、学术写作配图、科研绘图、科研作图、画图、作图、出图、论文图表、可视化. Define the conclusion, evidence logic, data integrity, template compatibility, export needs, and reviewer risks before plotting; honor or persist the Python/R backend choice. Also use the separate OpenRouter GPT Image 2 route for explicit AI-generated graphical abstracts, mechanism diagrams, concept schematics, 论文示意图、机制示意图、图形摘要; this route skips backend choice and treats outputs as drafts. Do not use for interactive dashboards, statistics-only analysis, data cleaning, literature review, code debugging, pure photo editing, or Illustrator/Figma-first infographics without manuscript-figure intent.
+  Create, revise, audit, and export manuscript scientific figures in Python or R.
+  Use for 论文配图、科研绘图、多面板图 and submission-ready plots, or explicitly
+  requested AI-generated graphical abstracts and mechanism schematics. Not for
+  interactive dashboards, data cleaning, or statistics-only analysis.
 ---
 
 # Nature Figure Making — Router

--- a/skills/nature-figure/manifest.yaml
+++ b/skills/nature-figure/manifest.yaml
@@ -38,18 +38,21 @@ preference:
   default_config: ~/.config/nature-skills/nature-figure.json
   behavior: |
     For plotting tasks, first honor an explicit Python/R choice, then a clearly
-    language-specific input workflow, then the saved preference returned by the
-    backend script. If none exists, ask the user once and save the answer.
+    language-specific input workflow, then a choice established in this task,
+    then the saved preference returned by the backend script. If none exists,
+    ask the user once and save the answer. Pause only dependent plotting work.
 
 axes:
   backend:
     detect: |
       BLOCKING GATE WITH PERSISTED PREFERENCE. Determine the plotting backend
       from an explicit user choice, a clearly language-specific input
-      file/workflow, or the saved preference returned by
-      scripts/nature_figure_backend.py get. If no saved preference exists, ask
+      file/workflow, a choice established in this task, or the saved preference
+      returned by scripts/nature_figure_backend.py get. If none resolves it, ask
       exactly one concise question — "Python or R? I will remember this as your
-      default." — and stop. Save the answer with the backend preference script
+      default." — and pause dependent plotting steps while continuing independent
+      inspection. Read-only review does not require a backend choice.
+      Save the answer with the backend preference script
       before proceeding. Only recommend a backend when the user explicitly asks
       you to choose; in that case use references/backend-selection.md, state the
       reason, save the selected backend, then proceed. Once selected, the

--- a/skills/nature-image2ppt/SKILL.md
+++ b/skills/nature-image2ppt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nature-image2ppt
-description: Convert slide images, screenshots, scanned PDFs, and image-only PPT/PPTX files into high-fidelity object-level editable PowerPoint, including semantic-region mixed reconstruction, measured flowcharts and knowledge graphs, native circle nodes and connectors, single-object thin and filled arrows, speaker-note preservation, and rendered QA. Use for 图片转可编辑PPT、截图还原PPT、扫描PDF恢复、图片型PPTX转换、流程图/知识图谱/复合图形/箭头重建; not for authoring a new deck from notes.
+description: "Reconstruct slide images, screenshots, scanned PDFs, or image-only PPTX files as object-level editable PowerPoint. Use for 图片转可编辑PPT、截图还原PPT and diagram reconstruction; not authoring a new deck from research notes."
 ---
 
 # Nature Image2PPT

--- a/skills/nature-paper-card/SKILL.md
+++ b/skills/nature-paper-card/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nature-paper-card
-description: Build a source-grounded deep-reading Paper Card for one scientific paper, preprint, PDF, DOI, arXiv page, publisher article, or pasted paper text. Use when the user asks for a Paper Card, deep-reading literature card, single-paper deep analysis, module-by-module analysis, experiment-to-claim evidence chain, conclusion-boundary audit, critical analysis, knowledge connections, or candidate research ideas. Produce the fixed Sections 01-16 covering bibliographic position, research question, background route, pain point, core insight, method and module logic, essential formulas, experiment-to-claim evidence, conclusion boundaries, author-stated limitations, critical analysis, learned knowledge, knowledge connections, and testable research ideas. Do not use for full-paper bilingual translation, formal peer-review reports, batch literature monitoring, academic-English collection, comprehension quizzes, or public-article writing.
+description: "Build a structured deep-reading Paper Card for one scientific paper, analysing methods, experiment-to-claim evidence, limitations, and research ideas. Use for 论文精读卡、方法拆解、证据链分析; not full-paper bilingual translation or formal peer review."
 ---
 
 # Nature Paper Card - Router

--- a/skills/nature-paper-to-patent/SKILL.md
+++ b/skills/nature-paper-to-patent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nature-paper-to-patent
-description: Convert scientific papers, theses, technical reports, source code, figures, inventor notes, or research manuscripts into evidence-grounded Chinese invention patent drafts and attorney-facing technical disclosure materials. Use when an AI agent must mine patent points, draft or revise a Chinese technical disclosure (技术交底书), run prior-art comparison, convert Office project materials, map every claimed feature to source evidence, preserve core formulas as editable Office Math, generate claim-aligned flowcharts and methodology figures, compare a paper with an existing patent, audit support and consistency, or deliver Chinese DOCX patent/disclosure files.
+description: "Turn research papers or inventor materials into evidence-grounded Chinese invention patent drafts and technical disclosures. Use for 技术交底书、专利撰写、现有技术对比 and Chinese DOCX patent packages; not general manuscript writing."
 ---
 
 # Paper to Chinese Patent

--- a/skills/nature-paper2ppt/SKILL.md
+++ b/skills/nature-paper2ppt/SKILL.md
@@ -5,16 +5,15 @@ description: Create or improve a Chinese academic PPTX from a scientific paper o
 
 # Paper-to-PPTX — Router
 
-This skill is split into two layers:
-
-- A **static layer** under `static/` that holds versioned, reusable content fragments (core principles, toolchain policy, the 9-step workflow, output/quality rules, and per-paper-type presentation arcs).
-- A **dynamic layer** (this file plus `manifest.yaml`) that detects the paper type and loads only the fragments needed for the current job. Deep design, figure, and self-review material lives in on-demand references.
-
-Do not try to apply the deck-building logic from memory or from this router. Always load fragments from disk as described below.
-
 ## Routing protocol
 
-Follow these five steps every time the skill is invoked.
+For an edit to an existing deck, reuse its paper source, narrative, terminology, and assets.
+Change the requested slides and any affected cross-slide references; do not rerun paper intake
+or rebuild the deck's story unless the request requires it. Inspect changed slides and run the
+existing final PPTX audit before delivery. A requested outline or explanation alone does not
+require creating a deck.
+
+For a new task, load the core and matching resources below. Reuse already loaded guidance on follow-ups; load more only when the task needs it.
 
 ### 1. Load the manifest and the core layer
 
@@ -51,7 +50,7 @@ Apply the loaded fragments in this priority order:
 
 Build the Terminology Ledger (`../nature-shared/core/terminology-ledger.md`) while reading the source, so model names, gene/protein names, datasets, metrics, and abbreviations stay identical across every slide and speaker note.
 
-The end product is a real `.pptx` deck, not an outline or script. Do not fabricate results, numbers, or figure details.
+When a deck is requested, the end product is a real `.pptx`, not only an outline or script. Do not fabricate results, numbers, or figure details.
 
 ### 5. Reach for references only when needed
 
@@ -62,10 +61,3 @@ The files under `references/` are deep references, not defaults. Open them on de
 - running the self-review/corrective revision loop, severity grading, programmatic PPTX checks, rendered-preview policy, and final verification → `references/self-review.md`.
 
 When a real PPTX has been generated, run `scripts/audit_pptx_quality.py` unless the file is unavailable. Treat high-severity findings as blockers, revise the deck, then re-run the audit and record the final result in `output/qa_report.md`.
-
-## Why this split
-
-- The static layer is versioned and reviewable. Adding a new paper-type arc is one new fragment plus one manifest line.
-- The dynamic layer keeps each invocation cheap: only the arc for this paper enters context up front; heavy design and QA material loads only when that step runs.
-- The router itself is short on purpose. Update fragments, not this file, when adding scope.
-- This structure mirrors `nature-writing`, `nature-polishing`, and `nature-reader` so shared content lives in `nature-shared/`.

--- a/skills/nature-paper2ppt/SKILL.md
+++ b/skills/nature-paper2ppt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nature-paper2ppt
-description: Build a complete Nature-style Chinese PPTX presentation from a scientific paper, preprint, PDF, article text, figure legends, or reading notes. Use for journal club, group meeting, thesis seminar, paper sharing, conference or defense decks, and Chinese requests such as 论文做PPT、论文汇报、组会PPT、文献汇报、学术汇报、做幻灯片、读书报告PPT. It classifies paper type, builds an evidence-led story, selects key figures, writes Chinese slide content and speaker notes, creates the actual .pptx, and runs corrective QA for complete figure crops, stable alignment, text overflow, and de-templated Chinese academic expression. Also trigger when improving weak paper-to-PPT output with cropped figures, loose alignment, obvious AI-style wording, or heavy manual rework.
+description: Create or improve a Chinese academic PPTX from a scientific paper or research reading notes, with source figures and speaker notes. Use for 论文做PPT、文献汇报、组会PPT and paper-based conference or defense presentations.
 ---
 
 # Paper-to-PPTX — Router

--- a/skills/nature-paper2ppt/static/core/output-and-quality.md
+++ b/skills/nature-paper2ppt/static/core/output-and-quality.md
@@ -11,7 +11,10 @@ Include source information:
 
 ## Output files
 
-Generate a minimal but complete output package by default.
+Generate a minimal but complete output package when creating a deck. For revisions, update the
+existing deck and QA record and retain unchanged assets; do not create a second package or
+re-extract the paper solely because the user requested a local slide edit. Respect an explicit
+request for an outline or explanation without starting deck generation.
 
 ### 1. `output/final_presentation_cn.pptx`
 The main deliverable: a complete Chinese PPTX deck with figures, captions, takeaways, source labels, and speaker notes.

--- a/skills/nature-paper2ppt/static/core/principles.md
+++ b/skills/nature-paper2ppt/static/core/principles.md
@@ -4,7 +4,7 @@
 
 Transform a scientific paper or paper-derived notes into a complete Chinese, figure-integrated PPTX presentation package with a Nature-style reporting logic.
 
-The skill must not stop at an outline or script. The expected end product is a real `.pptx` deck. Keep supporting files minimal unless the user asks for more traceability.
+When the user requests a deck, deliver a real `.pptx` rather than stopping at an outline or script. If the user explicitly requests only an outline, explanation, or approval stage, honor that scope. Keep supporting files minimal unless the user asks for more traceability.
 
 Use this skill for papers across scientific fields, including life sciences and medicine; chemistry and materials science; environmental and earth sciences; physics and engineering; computational biology, AI, and methods papers; interdisciplinary Nature-family style research; and reviews, perspectives, resources, datasets, and benchmark papers.
 

--- a/skills/nature-paper2ppt/static/core/workflow.md
+++ b/skills/nature-paper2ppt/static/core/workflow.md
@@ -1,6 +1,6 @@
 # Workflow
 
-Run these nine steps for any paper-to-deck job. The paper-type fragment loaded for this job sets the narrative arc; this workflow is the shared spine. Deep design, figure, and self-review material lives in the on-demand references named below.
+Use these nine steps to create a new deck. For an existing-deck edit, reuse its source material, narrative, and assets, apply the affected authoring steps, and verify the revised deck. Deep design, figure, and self-review material lives in the on-demand references named below.
 
 ## Step 1. Read and extract source material
 

--- a/skills/nature-polishing/SKILL.md
+++ b/skills/nature-polishing/SKILL.md
@@ -5,13 +5,6 @@ description: Polish, translate, or tighten existing academic prose while preserv
 
 # Nature-Style Academic Polishing — Router
 
-This skill is split into two layers:
-
-- A **static layer** under `static/` that holds versioned, reusable content fragments (core principles, paper-type playbooks, per-section guidance, language-specific rules, per-journal style).
-- A **dynamic layer** (this file plus `manifest.yaml`) that detects the request's axes and loads only the fragments needed for the current job.
-
-Do not try to apply the polishing logic from memory or from this router. Always load fragments from disk as described below.
-
 ## Routing protocol
 
 For a new polishing task, follow the routing below. For follow-up edits, reuse established task choices and already loaded guidance; read additional fragments only when the requested scope changes.
@@ -92,7 +85,7 @@ sections, conference-extension disclosure or production checks affect the
 revision, load
 `../nature-shared/journal-formats/nature-machine-intelligence.md`.
 
-When the job is a whole manuscript rather than a passage, or the text has already been through more than one round of editing, also load `../nature-shared/core/consistency-sweep.md`. Polishing passage by passage cannot see accumulated drift: one experimental factor under several names, the same quantity in two units, a metric at two precisions, or a superlative the paper's own table contradicts. Sweep for those before working on sentences, and repeat the sweep until a pass finds nothing new.
+For a whole-manuscript consistency audit or evidence of drift across passages, load `../nature-shared/core/consistency-sweep.md`. Local follow-up edits require checking the affected terms, numbers, and claims, not restarting a full audit solely because this is another editing round. After corrections, recheck affected occurrences and dependent claims; broaden the sweep when new discrepancies warrant it.
 
 **Layout/typesetting (排版) requests are different.** If the user asks to fix
 *placement* rather than wording — loose/sparse pages, stranded headings, figures
@@ -103,9 +96,3 @@ file is self-contained: it carries the diagnosis workflow (render → contact-sh
 read the log), the float-glue and `[H]`/`\clearpage`/`placeins` patterns, and the
 "regenerate wide figures taller at the source" rule. Always compile and visually
 inspect rendered pages before and after — never judge layout from the `.tex` alone.
-
-## Why this split
-
-- The static layer is versioned and reviewable. Adding a new journal style or paper type is one new file plus one manifest line.
-- The dynamic layer keeps each invocation cheap: only the fragments relevant to this draft enter context, instead of the full 1000-line monolith.
-- The router itself is short on purpose. Update fragments, not this file, when adding scope.

--- a/skills/nature-polishing/SKILL.md
+++ b/skills/nature-polishing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nature-polishing
-description: Polish, restructure, or translate academic prose into concise Nature-leaning English while preserving facts, evidence boundaries, terminology, and citation intent. Use for manuscript paragraphs, abstracts, introductions, Results, discussions, conclusions, titles, Methods, Chinese drafts, proofreading, language editing, and general academic or scientific writing. Also use to shorten bloated Results, allocate evidence across main text, captions, and Supplementary Information, prevent reviewer-driven revision accretion, reduce repeated statistics or claims, and apply paragraph-necessity checks. Covers LaTeX layout or typesetting fixes such as sparse pages, stranded headings, oversized or split figures, float errors, multi-panel arrangement, and sparse Supplementary Information via references/latex-layout.md. Trigger on 学术写作、科研写作、论文润色、SCI写作、英文论文润色、语言润色、润色、改写、学术英语、排版.
+description: Polish, translate, or tighten existing academic prose while preserving facts, terminology, and evidence boundaries. Use for 论文润色、学术翻译、正文精简, or manuscript LaTeX layout fixes. Use nature-writing when the main task is drafting new sections or rebuilding the manuscript argument.
 ---
 
 # Nature-Style Academic Polishing — Router
@@ -14,7 +14,7 @@ Do not try to apply the polishing logic from memory or from this router. Always 
 
 ## Routing protocol
 
-Follow these five steps every time the skill is invoked.
+For a new polishing task, follow the routing below. For follow-up edits, reuse established task choices and already loaded guidance; read additional fragments only when the requested scope changes.
 
 ### 1. Load the manifest and the core layer
 

--- a/skills/nature-polishing/manifest.yaml
+++ b/skills/nature-polishing/manifest.yaml
@@ -91,7 +91,7 @@ references:
       path: references/phrasebank-playbook.md
     - condition: needs academic style, register, article use, or mechanics checks
       path: references/style-guardrails.md
-    - condition: polishing or proofreading a full manuscript rather than a passage, or the text has been through more than one round of editing — sweep for accumulated terminology/unit/number drift, headline counts that do not reconcile, claims contradicted by the paper's own tables, tense parallelism, and prose that restates displays
+    - condition: whole-manuscript consistency audit, or local discrepancies suggest wider terminology/unit/number drift, inconsistent counts, or claims contradicted by the paper's own tables; do not restart a full sweep merely because another editing round occurs
       path: ../nature-shared/core/consistency-sweep.md
     - condition: needs deeper writing-strategy principles
       path: references/writing-strategy.md

--- a/skills/nature-proposal-writer/SKILL.md
+++ b/skills/nature-proposal-writer/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: researchwrite
-description: |
-  Proposal-first scientific writing pipeline, installed under the compatibility trigger researchwrite and the repository package name nature-proposal-writer. Use for composing, revising, or auditing research proposals, opening reports, research plans, and evidence-grounded scientific writing. Three modes (compose/revise/hybrid) with a four-layer QA pipeline. Enforces evidence-before-prose, argument-before-sections, and contracts-before-paragraphs.
+description: "Compose, revise, or audit research proposals, opening reports, and research plans from supporting evidence. Use for 研究计划、开题报告、科研项目申请书. Invoked as researchwrite for compatibility; use nature-writing for general manuscript sections."
 license: MIT
 metadata:
   hermes:

--- a/skills/nature-reader/SKILL.md
+++ b/skills/nature-reader/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nature-reader
-description: Build full-paper Chinese-English side-by-side, figure/table/equation-aware, source-grounded Markdown readers for journal or conference papers from PDF, DOI, arXiv, publisher HTML, or pasted text. Use whenever the user asks to translate or read a paper, make 中英文对照/原文对照/全文翻译解读, render equations instead of exposing raw LaTeX, extract figures or tables into the right positions, preserve figure/table placement near relevant prose, or keep exact source anchors for every block. This skill must not degrade into a summary-only output unless the user explicitly asks for a summary. Also trigger on general paper-reading and translation requests even without the word "Nature", such as reading/translating an academic paper, literature reading, understanding a paper, and Chinese phrasings like 读论文、精读论文、论文翻译、文献翻译、文献阅读、学术阅读、帮我读这篇文章、翻译这篇paper.
+description: "Create source-grounded Chinese-English paper readers with aligned text, figures, tables, and equations. Use for 全文翻译、中英文对照、论文精读 or source-linked questions about a paper; respect a requested excerpt or question without generating a full reader."
 metadata:
   version: "2.1.1"
   author: Community contribution, refactored into static/dynamic layers
@@ -8,16 +8,16 @@ metadata:
 
 # Full-Paper Markdown Reader — Router
 
-This skill is split into two layers:
-
-- A **static layer** under `static/` that holds versioned, reusable content fragments (core principles, the reading workflow, the output contract, and per-source-format extraction guidance).
-- A **dynamic layer** (this file plus `manifest.yaml`) that detects the request's source format and loads only the fragments needed for the current job.
-
-Do not try to apply the reading logic from memory or from this router. Always load fragments from disk as described below.
-
 ## Routing protocol
 
-Follow these five steps every time the skill is invoked.
+First distinguish creating a reader from answering a question or translating an excerpt.
+For a source-linked question, read `references/grounding-rules.md` and inspect only the relevant
+source material; reuse existing source-map IDs when available. Do not regenerate the reader or
+require a full source map before answering. For an explicit excerpt request, apply extraction,
+translation, and grounding rules to that excerpt. The full-artifact workflow below applies when
+the user requests a reader or full-paper translation.
+
+For a new task, load the core and matching resources below. Reuse already loaded guidance on follow-ups; load more only when the task needs it.
 
 ### 1. Load the manifest and the core layer
 
@@ -62,10 +62,3 @@ The files under `references/` are deep references, not defaults. Open them on de
 - exact field schema for `paper.md` / `source_map.json` → `references/output-spec.md`.
 - equations, mathematical expressions, chemical formulae, or image-only formulae → `references/equation-handling.md`.
 - answering follow-up questions with source citations → `references/grounding-rules.md`.
-
-## Why this split
-
-- The static layer is versioned and reviewable. Adding a new source format is one new fragment plus one manifest line.
-- The dynamic layer keeps each invocation cheap: only the fragment relevant to this input enters context.
-- The router itself is short on purpose. Update fragments, not this file, when adding scope.
-- This structure mirrors `nature-writing` and `nature-polishing` so shared content lives in `nature-shared/`.

--- a/skills/nature-reader/references/grounding-rules.md
+++ b/skills/nature-reader/references/grounding-rules.md
@@ -6,9 +6,9 @@ When the user asks a follow-up question about the paper:
 
 1. Find the most relevant source blocks.
 2. Answer from those blocks first.
-3. Cite the exact page and block IDs.
+3. Cite exact page and block IDs when available. Otherwise cite a verified page, section, figure, or table from the supplied source; never invent source-map IDs or page numbers.
 4. Include the figure or table if it is part of the evidence.
-5. Say `原文未明确说明` if the paper does not support the claim.
+5. Say `原文未明确说明` if the paper does not support the claim. Request missing source material only when it is needed to answer; a missing reader artifact alone does not block a grounded answer.
 
 ## Good answer pattern
 

--- a/skills/nature-reader/static/core/principles.md
+++ b/skills/nature-reader/static/core/principles.md
@@ -10,11 +10,11 @@ Use this skill to turn a research paper into a complete Markdown reading artifac
 - preserve stable page and block anchors for traceability
 - write a complete `paper.md` by default, plus `source_map.json`, `translation_notes.md`, and `assets/`
 
-This skill is for papers, preprints, and conference proceedings across disciplines. It is not limited to Nature-family journals. If the user only wants a summary, use a summarization skill instead. If the user only wants citation search, use a citation skill instead.
+This skill is for papers, preprints, and conference proceedings across disciplines. It is not limited to Nature-family journals. Honor an explicit request for a summary, excerpt, or source-linked answer at that scope; no separate summarization skill is required. Citation-only searches belong to the appropriate citation workflow.
 
 ## Non-negotiable defaults
 
-When the user asks for paper translation, reading, `nature-reader`, `中英文对照`, `原文对照`, `全文翻译`, or `翻译解读`, produce a paragraph-level bilingual reader by default.
+When the user requests a reader, `中英文对照`, `原文对照`, `全文翻译`, or invokes `nature-reader` without a narrower deliverable, produce a paragraph-level bilingual reader by default. An explicit question, summary, or excerpt request takes precedence; do not expand it into full-paper processing.
 
 Do not replace the reader with:
 

--- a/skills/nature-reader/static/core/workflow.md
+++ b/skills/nature-reader/static/core/workflow.md
@@ -1,6 +1,6 @@
 # Reading workflow
 
-Run these six steps for any paper-reading job. Steps 1-2 build the source map, 3-5 produce the artifact, 6 covers follow-up questions.
+Use steps 1-5 when creating a reader. For source-linked questions, go directly to step 6 and inspect the relevant source blocks; do not rebuild the artifact. For an explicit excerpt request, scope extraction and translation to that excerpt.
 
 ## 1. Identify the source and paper type
 
@@ -72,4 +72,4 @@ Before delivery, run `scripts/validate_reader_math.py paper.md --source-map sour
 
 ## 6. Answer follow-up questions with source grounding
 
-When the user asks a question after the file is created, answer from the paper, not from memory, and cite exact block IDs and page numbers. For the full grounding rules, open `references/grounding-rules.md`.
+Answer questions from the relevant paper evidence. Reuse exact block IDs and page numbers from an existing reader; without one, cite verified source locations without inventing IDs. For the full grounding rules, open `references/grounding-rules.md`.

--- a/skills/nature-response/SKILL.md
+++ b/skills/nature-response/SKILL.md
@@ -9,16 +9,9 @@ description: >-
 
 # Nature Reviewer Response — Router
 
-This skill is split into two layers:
-
-- A **static layer** under `static/` that holds versioned, reusable content fragments (the default stance and red lines, and the response workflow with output format).
-- A **dynamic layer** (this file plus `manifest.yaml`) that loads the core every time and reaches for the deeper response references or templates only when a step needs them.
-
-Do not try to apply the response logic from memory or from this router. Always load fragments from disk as described below.
-
 ## Routing protocol
 
-Follow these four steps every time the skill is invoked.
+For a new task, load the core and matching resources below. Reuse already loaded guidance on follow-ups; load more only when the task needs it.
 
 ### 1. Load the manifest and the core layer
 
@@ -65,10 +58,3 @@ Never invent experiments, citations, line numbers, figure panels, supplementary 
 The files under `references/` and `templates/` are deep resources, not defaults. Open them on demand per the `references.on_demand` table in the manifest — for example `references/comment-taxonomy.md` to classify comments, `references/action-mapping.md` for tracker fields, `references/tone-and-stance.md` for disagreement wording, `references/difficult-cases.md` for impossible experiments / conflicting reviewers / appeal-like cases, `references/chinese-author-alignment.md` for Chinese author notes, `references/latex-templates.md` for `.tex` cover/response/redline outputs, `../nature-shared/core/main-text-discipline.md` for reviewer-driven manuscript additions and evidence relocation, `references/package-consistency-audit.md` whenever the manuscript is edited alongside the letter or the package is about to be compiled and delivered, and `references/qa-checklist.md` before finalizing.
 
 `qa-checklist.md` and `package-consistency-audit.md` are complementary and both apply to a final package: the first asks whether the response is complete, honest, and well-toned; the second asks whether the marked manuscript, the clean manuscript, and the letter actually agree with each other after editing. For a LaTeX package, run `scripts/check_package_consistency.py` after the first complete draft, after every manuscript edit, and immediately before delivery. Any manuscript edit invalidates the letter's verbatim quotes and page references, so re-run the audit rather than treating it as a one-time final check.
-
-## Why this split
-
-- The static layer is versioned and reviewable; the core stays small for a normal response.
-- The dynamic layer keeps each invocation cheap: the difficult-case, taxonomy, and QA depth load only when a step needs them.
-- The router itself is short on purpose. Update fragments and references, not this file, when adding scope.
-- This structure mirrors `nature-writing`, `nature-polishing`, `nature-reader`, `nature-paper2ppt`, `nature-figure`, and `nature-citation`.

--- a/skills/nature-response/SKILL.md
+++ b/skills/nature-response/SKILL.md
@@ -1,17 +1,10 @@
 ---
 name: nature-response
 description: >-
-  Draft, audit, or revise Nature-style revision correspondence packages: point-by-point
-  reviewer-separated response letters, rebuttal letters, revision cover letters, LaTeX
-  cover/response templates, and red-marked revised-manuscript excerpts. Keep mutually blind
-  reviewers isolated so no reviewer-facing response reveals another reviewer's comments,
-  numbering, recommendation, or author response. Prevent reviewer-driven manuscript
-  accretion by preferring replacement, compression, or SI relocation over appending
-  non-central defense prose. Use for reviewer comments, editor
-  decision letters, pasted editorial emails, response drafts, cover letters, response to
-  reviewers, rebuttal, 修回信, 返修邮件, 编辑邮件, 返修 cover letter, 审稿意见回复,
-  逐点回复, 大修回复, 小修回复, 回复审稿人, 修改稿回复, 写rebuttal, 回应审稿意见,
-  标红修改, or LaTeX 模板.
+  Draft, audit, or revise responses to peer review, revision cover letters, and
+  marked-manuscript or LaTeX revision packages. Use for 审稿意见回复、逐点回复、返修信、
+  rebuttals and edits to existing response drafts. Initial-submission materials
+  belong to nature-writing; simulated peer review belongs to nature-reviewer.
 ---
 
 # Nature Reviewer Response — Router
@@ -42,12 +35,17 @@ Unlike nature-writing or nature-figure, nature-response has no fragment axis. It
 - **decision type** — minor revision, major revision, revise-and-resubmit, transfer after review, or unclear.
 - **user language** — if the user writes Chinese, also produce the 中文核对 block.
 
-Decision type is a required intake gate for normal revision work. First extract it from an
-editor decision letter when available. If it is still unclear, ask the user whether this is a
-`Major Revision` or `Minor Revision` before drafting a response strategy or response prose. Do
-not infer the decision from the number, tone, or apparent difficulty of reviewer comments.
+Decision type is required for a new package-level revision strategy or complete response package.
+First extract it from the editor letter or task context. If it remains unclear, ask whether this
+is a `Major Revision` or `Minor Revision` and pause only decision-dependent work. A local wording
+edit, audit of an existing reply, or comment-level triage may proceed with decision type marked
+unknown. Do not infer the decision from the number, tone, or difficulty of reviewer comments.
 
 Use `references/intake-and-routing.md` to fix the task mode, minimum inputs, and readiness state before drafting. Route appeal-like cases separately; do not draft an appeal as the default path.
+
+For a local edit or bounded audit, return the revised passage or findings and relevant missing
+facts. Do not expand it into a master tracker, cover letter, or complete revision package unless
+requested. Apply the package workflow below only to the parts needed for the requested output.
 
 ### 3. Run the workflow
 

--- a/skills/nature-response/manifest.yaml
+++ b/skills/nature-response/manifest.yaml
@@ -24,7 +24,7 @@ references:
   on_demand:
     - condition: a reviewer or editor comment leads to additions, deletions, compression, relocation, or statistical-detail changes in the manuscript main text — classify the result, prevent revision accretion, separate main text/caption/SI functions, and run deletion, paragraph-necessity, and claim-repetition checks
       path: ../nature-shared/core/main-text-discipline.md
-    - condition: before drafting — identify task mode, enforce the Major/Minor decision-type gate, parse pasted decision emails, minimum inputs, editor IDs, readiness state, and clarifying-question need
+    - condition: identify task scope, apply the Major/Minor decision-type gate to package-level work, parse pasted decision emails, minimum inputs, editor IDs, readiness state, and clarifying-question need
       path: references/intake-and-routing.md
     - condition: source hierarchy, rule provenance, or policy-vs-advice boundaries
       path: references/source-basis.md

--- a/skills/nature-response/references/intake-and-routing.md
+++ b/skills/nature-response/references/intake-and-routing.md
@@ -2,7 +2,7 @@
 
 ## Contents
 
-- [Mandatory decision-type gate](#mandatory-decision-type-gate)
+- [Decision-type gate for package-level work](#decision-type-gate-for-package-level-work)
 - [Task modes](#task-modes)
 - [Readiness states](#readiness-states)
 - [Editor instruction handling](#editor-instruction-handling)
@@ -15,16 +15,20 @@
 Use this file before splitting comments or drafting prose. Its job is to decide what task the
 user is asking for, whether the supplied information is enough, and what output state is honest.
 
-## Mandatory decision-type gate
+## Decision-type gate for package-level work
 
-For `draft`, `audit`, `revise`, `triage-only`, `cover-letter`, and `revision-package` modes, identify
-the editorial decision before drafting strategy or prose.
+Identify the editorial decision before selecting a new package-level revision strategy or
+drafting a complete response package. Task mode alone does not make the decision a blocker:
+local wording edits, audits of existing replies, and comment-level triage can proceed with the
+decision marked unknown. Return the requested passage or findings without inventing a decision,
+expanding to a full package, or claiming submission readiness.
 
 - If an editor letter explicitly says `Major Revision` or `Minor Revision`, use that value and do
   not ask a redundant question.
 - If the user explicitly says 大修、小修, major review, minor review, major revision, or minor
   revision, normalize it to the corresponding revision type.
-- If neither source resolves it, ask in the user's language and pause. Chinese default:
+- If neither source resolves it and the requested work depends on it, ask in the user's language
+  and pause only decision-dependent work. Continue independent inspection. Chinese default:
   `这是 Major Revision（大修）还是 Minor Revision（小修）？如果决定信没有明确写，请把决定信发给我，我帮你判断。`
   English default: `Is this a Major Revision or a Minor Revision? If the decision letter does
   not state it clearly, please send it and I can help classify the decision.`
@@ -33,8 +37,9 @@ the editorial decision before drafting strategy or prose.
 - `revise-and-resubmit` and `transfer after review` remain distinct decision types; do not force
   either into Major or Minor Revision. Follow the explicit editor instructions for those routes.
 
-Once resolved, apply the Major/Minor strategy in `static/core/workflow.md` and record the chosen
-decision type in the response strategy summary.
+Once resolved, apply the Major/Minor strategy in `static/core/workflow.md` when package-level
+strategy is requested and record the decision type in that strategy summary. Reuse a decision
+already established in the task without asking again.
 
 ## Task modes
 
@@ -140,16 +145,16 @@ If reviewer comments are absent, audit only the visible draft and flag that comp
 
 ## Clarifying question rules
 
-Except for the mandatory decision-type gate above, usually proceed with placeholders and risk
+Subject to the package-level decision-type gate above, usually proceed with placeholders and risk
 flags. Ask concise questions only when:
 
-- Major/Minor Revision status is not supplied and cannot be extracted from the decision letter;
+- the requested package strategy depends on Major/Minor Revision status that is not supplied and cannot be extracted from the decision letter or task context;
 - the user explicitly asks for final submission-ready text and required facts are missing;
 - the draft would otherwise fabricate data, locations, approvals, statistics, citations, or figure panels;
 - reviewer boundaries are too ambiguous to assign stable IDs;
 - the case appears appeal-like or outside normal revision response.
 
-When asking, keep questions specific. Ask the decision-type question first when it is unresolved;
+When asking, keep questions specific. Ask the decision-type question first when it blocks the requested work;
 after that, group only the remaining facts that genuinely block the requested output:
 
 ```text

--- a/skills/nature-response/references/response-structure.md
+++ b/skills/nature-response/references/response-structure.md
@@ -58,7 +58,7 @@ Decision types:
 - `revise-and-resubmit`
 - `transfer after review`
 - `appeal-like case` routed outside the default workflow
-- `unclear` only as an intake state; ask the user before normal response strategy or prose drafting
+- `unclear` when not supplied; ask before decision-dependent package strategy or complete-package drafting, but continue local edits, visible-draft audits, and comment-level triage
 
 Task modes:
 

--- a/skills/nature-response/static/core/workflow.md
+++ b/skills/nature-response/static/core/workflow.md
@@ -8,13 +8,16 @@ If reviewer boundaries or comment segmentation are ambiguous, flag the ambiguity
 
 ## Decision-type gate and revision strategy
 
-For normal revision-response work, determine the editorial decision before drafting the response
-strategy or response prose:
+Determine the editorial decision before selecting a new package-level revision strategy or
+drafting a complete response package. Local wording edits, audits of existing replies, and
+comment-level triage can proceed with decision type marked unknown; they do not select a
+Major/Minor package strategy or establish submission readiness.
 
 1. Use an explicit label in the editor decision letter or revision invitation when supplied.
 2. Normalize informal author wording such as `major review` and `minor review` to `Major Revision`
    and `Minor Revision` when the meaning is unambiguous.
-3. If the decision remains unclear, ask one concise question in the user's language and pause:
+3. If the requested work depends on the decision and it remains unclear, ask one concise question
+   in the user's language and pause only that work; continue independent inspection:
    `这是 Major Revision（大修）还是 Minor Revision（小修）？如果决定信没有明确写，请把决定信发给我，我帮你判断。`
    English default: `Is this a Major Revision or a Minor Revision? If the decision letter does
    not state it clearly, please send it and I can help classify the decision.`
@@ -34,10 +37,14 @@ Minor Revision. Journal instructions and explicit editor directions override the
 
 ## Workflow
 
+For local edits or bounded audits, apply only the relevant item-level steps and return the
+requested passage or findings with factual gaps flagged. The complete tracker, cover letter,
+reviewer file set, and package readiness assessment apply when a package is requested.
+
 1. Identify task mode and input readiness: `draft`, `audit`, `revise`, `triage-only`, `cover-letter`, `revision-package`, `latex-template`, or `appeal-like`.
 2. If the input is a pasted journal email, automatically extract manuscript title, manuscript ID, journal, decision type, editor instructions, reviewer-report boundaries, required revision files, deadline, reviewer-visibility rules, and portal-specific constraints before drafting.
-3. Pass the decision-type gate. For normal revision modes, pause and ask the user when the decision remains unclear; do not draft a generic response that silently treats Major and Minor Revision as equivalent.
-4. Select the decision-specific package strategy while preserving item-level severity.
+3. Apply the decision-type gate to package-level work. If that work depends on an unknown decision, pause and ask the user; do not draft a generic response that silently treats Major and Minor Revision as equivalent. Continue local edits, visible-draft audits, and comment-level triage that do not depend on the label.
+4. When a package strategy is needed and the decision is known, select it while preserving item-level severity.
 5. Extract editor instructions first and assign IDs such as `E.1`, then split reviewer comments with IDs such as `R1.1`, `R1.2`, and `R2.1`.
 6. Classify each item by category, severity, action label, work status, required input, expected output, finalization-blocking state, package readiness, and risk.
 7. Create an internal/editor master strategy and tracker before drafting prose. It may record duplicates and conflicts across reviewers, but label it clearly as not reviewer-facing.

--- a/skills/nature-response/tests/defensive-draft-audit.md
+++ b/skills/nature-response/tests/defensive-draft-audit.md
@@ -22,6 +22,7 @@ Author notes:
 ## Expected behavior
 
 - Detect task mode as `audit` or `revise`.
+- Proceed with the bounded draft audit even though the editorial decision is not supplied; do not select a Major/Minor package strategy.
 - Assign stable IDs `R1.1` and `R1.2`.
 - Flag the author draft as defensive and insufficiently traceable.
 - Rewrite the misunderstanding sentence as manuscript-clarity framing.

--- a/skills/nature-response/tests/evaluation-summary.md
+++ b/skills/nature-response/tests/evaluation-summary.md
@@ -10,7 +10,7 @@ Recommended status: `Beta`.
 Rationale:
 
 - The core rules are defined in `SKILL.md` and modular references.
-- The skill has synthetic fixtures covering mandatory decision-type intake, minor revision, major
+- The skill has synthetic fixtures covering package-level decision-type intake, local edits without a decision label, minor revision, major
   revision with missing evidence, impossible experiment, defensive draft audit, conflicting
   reviewers, mutually blind reviewer-response separation, and per-task status tracking.
 - Each fixture includes expected behavior, forbidden behavior, and pass/fail criteria.
@@ -21,7 +21,8 @@ Rationale:
 
 | Fixture | Coverage | Key failure prevented |
 |---|---|---|
-| `unclear-decision-type.md` | mandatory Major/Minor intake gate | guessing the revision type or drafting with the wrong package strategy |
+| `unclear-decision-type.md` | package-level Major/Minor intake gate | guessing the revision type or drafting with the wrong package strategy |
+| `local-edit-without-decision.md` | local wording edits and bounded triage | blocking an independent edit or expanding it into a full package |
 | `minor-revision.md` | stable IDs, minor comments, missing citation metadata | fabricated citation or line numbers |
 | `major-revision-missing-evidence.md` | validation request, statistical details, missing evidence | invented results or p-values |
 | `impossible-experiment.md` | out-of-scope longitudinal evidence | time/funding excuse or fabricated survival data |

--- a/skills/nature-response/tests/local-edit-without-decision.md
+++ b/skills/nature-response/tests/local-edit-without-decision.md
@@ -1,0 +1,32 @@
+# Test: local reply edit without an editorial decision
+
+## Input
+
+```text
+Please make this reply more polite and concise. Only return the revised reply.
+
+Reviewer: Please clarify the software version used.
+Draft reply: The reviewer missed this. We used version 2.3.1.
+```
+
+## Expected behavior
+
+- Return a polite revised reply preserving version `2.3.1`.
+- Do not require a Major/Minor Revision label for this wording edit.
+- Do not claim that the manuscript has been revised or invent its location.
+- Respect the requested output: no master tracker, cover letter, or package-readiness verdict.
+
+## Follow-up
+
+```text
+Now list what information is missing from this response before I edit the manuscript.
+```
+
+- Perform bounded comment-level triage using the existing reply and reviewer comment.
+- Identify missing manuscript-location or change evidence without inventing it.
+- Continue without asking for the editorial decision unless the user expands the task to a decision-dependent package strategy.
+
+## Evaluation boundary
+
+This is a behavioral fixture for manual or agent evaluation, not an executed model benchmark.
+Evaluate the produced response, questions, and scope, not matching phrases or headings.

--- a/skills/nature-response/tests/rubric.md
+++ b/skills/nature-response/tests/rubric.md
@@ -7,13 +7,15 @@ Use this rubric to manually evaluate `nature-response` outputs against the Markd
 Pass when:
 
 - The decision type is extracted from an explicit editor letter or user statement.
-- When it remains unclear, the skill asks whether this is Major Revision or Minor Revision before drafting strategy or response prose.
+- When it remains unclear, the skill asks before decision-dependent package strategy or complete-package drafting, while continuing independent inspection.
+- Local wording edits, audits of existing replies, and comment-level triage proceed without requiring a decision label or expanding into a full package.
 - Major Revision receives an evidence-first, potentially structural work plan.
 - Minor Revision receives a bounded correction plan without downgrading any genuinely major or blocking concern.
 
 Fail when:
 
 - The skill guesses the decision type from reviewer tone, comment count, or apparent workload.
+- It blocks a local edit solely because Major/Minor Revision status is unknown.
 - It drafts the same undifferentiated strategy for Major and Minor Revision.
 - It treats the Minor Revision label as permission to minimize an evidence, statistics, ethics, or integrity concern.
 

--- a/skills/nature-response/tests/unclear-decision-type.md
+++ b/skills/nature-response/tests/unclear-decision-type.md
@@ -14,10 +14,10 @@ Reviewer 2:
 
 ## Expected behavior
 
-- Recognize that this is normal revision-response work but the editorial decision type is missing.
+- Recognize that the requested complete response and manuscript plan need a package-level strategy, but the editorial decision type is missing.
 - Ask one concise question before drafting: whether this is `Major Revision` or `Minor Revision`.
 - If the user writes Chinese, ask: `这是 Major Revision（大修）还是 Minor Revision（小修）？如果决定信没有明确写，请把决定信发给我，我帮你判断。`
-- Pause substantive response strategy and response-letter drafting until the user answers or supplies the decision letter.
+- Pause decision-dependent package strategy and complete response-letter drafting until the user answers or supplies the decision letter; continue independent inspection of supplied comments and missing evidence.
 
 ## Forbidden behavior
 

--- a/skills/nature-reviewer/SKILL.md
+++ b/skills/nature-reviewer/SKILL.md
@@ -1,13 +1,6 @@
 ---
 name: nature-reviewer
-description: >-
-  Simulate Nature-style or general pre-submission peer review from the referee perspective,
-  not an author rebuttal. Use for reviewer reports, mock peer review, manuscript critique,
-  novelty/significance/technical-soundness assessment, 审稿人视角评估, 模拟审稿, 预审,
-  投稿前自审, 审稿意见模拟, or 帮我审一下论文. Produce evidence-grounded Major Concerns,
-  Minor Comments, and blocking flags. For multiple reviewers, keep every reviewer mutually
-  blind in a separate context, freeze all reports before comparison, and create any synthesis
-  only afterward as a separate editor/author-facing artifact.
+description: "Provide evidence-grounded mock peer review of scientific manuscripts or excerpts, covering significance, validity, and major/minor concerns. Use for 模拟审稿、投稿前自审、审稿人视角评估; not author rebuttal drafting."
 ---
 
 # Nature Reviewer Assessment Skill

--- a/skills/nature-shared/core/consistency-sweep.md
+++ b/skills/nature-shared/core/consistency-sweep.md
@@ -5,9 +5,10 @@ it fixes the vocabulary before drafting. This file is detective: it finds the dr
 manuscript has already accumulated, which is what happens to every manuscript that has been revised
 more than once.
 
-Use it when polishing or proofreading a full manuscript, when self-reviewing before submission, when
-auditing a revision, or whenever multiple rounds of editing have touched the same document. Do not
-use it as a substitute for building a ledger on a fresh draft.
+Use it when polishing or proofreading a full manuscript, self-reviewing before submission, or
+auditing cross-document consistency. For a local edit, check the affected terms, numbers, and
+claims first; expand to the full sweep when discrepancies suggest wider drift or the user asks
+for it. Do not use it as a substitute for building a ledger on a fresh draft.
 
 Two facts drive the method:
 
@@ -112,7 +113,7 @@ saying what the old text already said.
 ## 6. Order of operations
 
 1. Numeric self-consistency and claims-versus-data (sections 3 and 4). Fix content before wording.
-2. Terminology sweep (sections 1 and 2), repeated until a pass finds nothing new.
+2. Terminology sweep (sections 1 and 2). After correcting a discrepancy, recheck affected occurrences and related claims; repeat a broader sweep only when changes or new findings warrant it.
 3. Redundancy pass (section 5).
 4. Recompile and re-verify anything that depends on pagination.
 

--- a/skills/nature-shared/manifest.yaml
+++ b/skills/nature-shared/manifest.yaml
@@ -47,6 +47,6 @@ journal_formats:
 
 quality_tools:
   consistency_script: scripts/check_consistency.py
-  use_when: auditing an existing full manuscript or a manuscript revised over multiple rounds
+  use_when: auditing whole-manuscript consistency, or local discrepancies indicate wider drift; a new editing round alone does not require a full sweep
   purpose: warn about terminology variants, equivalent lengths expressed in different units, and equal numeric values reported at different precision
   script_resolution: resolve relative to the nature-shared package directory, never the user working directory

--- a/skills/nature-statistics/SKILL.md
+++ b/skills/nature-statistics/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: nature-statistics
-description: >-
-  Audit, revise, or draft manuscript statistical reporting for Nature / high-impact journal submissions. Use when the user asks to check statistical analysis sections, p values, confidence intervals, sample size, biological versus technical replicates, randomization, blinding, multiple-comparison correction, model assumptions, figure legends, Results statistics wording, reviewer comments about statistics, or Chinese academic drafts needing publication-ready Statistical analysis text. Also trigger on general paper-statistics requests such as 统计审查、统计分析小节、统计方法、p值、样本量、重复数、多重比较、置信区间、效应量、图注统计、审稿人统计意见.
+description: "Audit or improve manuscript statistical reporting, including experimental units, replication, uncertainty, tests, and figure statistics. Use for 统计审查、统计方法小节、图注统计 and reviewer concerns; compute new analyses only when requested with data."
 ---
 
 # Nature Statistics Reporting Skill

--- a/skills/nature-writing/SKILL.md
+++ b/skills/nature-writing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nature-writing
-description: Draft, restructure, or plan Nature-style manuscript sections and initial-submission materials from author-provided claims, results, figures, notes, or Chinese drafts. Use for abstracts, introductions, related work, methods, Results or experiments, discussions, conclusions, titles, full manuscript arguments, and first-submission packages such as cover letters, title pages, highlights, author contributions, availability or declaration text, and reviewer suggestions. Also use to classify Results evidence, decide what belongs in main text, captions, Methods or source data, or Supplementary Information, compress Results to the shortest sufficient evidence chain, prevent revision accretion, and audit paragraph necessity or claim repetition. Trigger on drafting a paper or section, structuring a manuscript, academic writing, first submission, 投稿材料、首次投稿、投稿信、标题页、亮点、作者贡献、数据可用性声明、推荐审稿人.
+description: Draft or restructure scientific manuscript arguments, sections, and initial-submission materials from author-provided evidence. Use for 论文写作、章节起草、论证重构、正文压缩、首次投稿材料. Use nature-polishing for language-only edits to existing prose and nature-response for post-decision correspondence.
 ---
 
 # Nature-Style Scientific Writing — Router
@@ -14,7 +14,7 @@ Do not try to apply the drafting logic from memory or from this router. Always l
 
 ## Routing protocol
 
-Follow these five steps every time the skill is invoked.
+For a new drafting task, follow the routing below. For follow-up edits, reuse established task choices and already loaded guidance; read additional fragments only when the requested scope changes.
 
 ### 1. Load the manifest and the core layer
 
@@ -55,7 +55,7 @@ Apply the loaded fragments in this priority order:
 5. Journal-specific framing and constraints.
 6. Language-specific sentence and paragraph rules (apply last).
 
-For `task=manuscript`, run the workflow in `core/workflow.md` end-to-end. Do not skip planning just because the user asked for prose immediately.
+For `task=manuscript`, use `core/workflow.md` at the requested scale. Plan the argument for a new section or substantial restructuring; a title, single paragraph, or local follow-up needs only the applicable evidence, wording, and consistency checks. Complete the requested prose unless a material unresolved decision blocks it or the user requested an outline for approval first.
 
 When drafting or restructuring Results, or compressing a full manuscript's main
 text, also load `../nature-shared/core/main-text-discipline.md` before building

--- a/skills/nature-writing/SKILL.md
+++ b/skills/nature-writing/SKILL.md
@@ -5,13 +5,6 @@ description: Draft or restructure scientific manuscript arguments, sections, and
 
 # Nature-Style Scientific Writing — Router
 
-This skill is split into two layers:
-
-- A **static layer** under `static/` that holds versioned, reusable content fragments (core stance + workflow, paper-type playbooks, per-section drafting guidance, initial-submission guidance, language-specific rules, per-journal style).
-- A **dynamic layer** (this file plus `manifest.yaml`) that detects the request's axes and loads only the fragments needed for the current job.
-
-Do not try to apply the drafting logic from memory or from this router. Always load fragments from disk as described below.
-
 ## Routing protocol
 
 For a new drafting task, follow the routing below. For follow-up edits, reuse established task choices and already loaded guidance; read additional fragments only when the requested scope changes.
@@ -130,10 +123,3 @@ The files under `references/` are deep references and the example library, not d
 - `nature-writing` owns **initial submission** materials prepared before peer review.
 - `nature-response` owns revision cover letters, rebuttals, point-by-point responses, marked manuscripts, appeals, and other post-decision correspondence.
 - Route graphical abstracts and TOC graphics to `nature-figure`; route simulated pre-submission peer review to `nature-reviewer`.
-
-## Why this split
-
-- The static layer is versioned and reviewable. Adding a new journal style, paper type, or section is one new file plus one manifest line.
-- The dynamic layer keeps each invocation cheap: only the fragments relevant to this draft enter context, instead of the full multi-thousand-line reference set.
-- The router itself is short on purpose. Update fragments, not this file, when adding scope.
-- This structure mirrors `nature-polishing` so shared content can later be lifted into a `nature-shared/` layer used by both skills.

--- a/skills/nature-writing/static/core/stance.md
+++ b/skills/nature-writing/static/core/stance.md
@@ -4,7 +4,7 @@
 
 - Do not invent results, mechanisms, references, methods, novelty, sample sizes, statistics, or limitations.
 - Write the argument before writing the sentences.
-- Prefer confirming over guessing. If essential input is missing or the framing is ambiguous, do not silently draft a full section on an assumed premise — confirm first (see Intake below) instead of filling the gap.
+- Reuse supplied evidence and established framing. Ask only when an unresolved choice would materially change the core argument, evidence meaning, or requested output; mark factual gaps rather than inventing content.
 
 ## Reader workflow
 
@@ -16,7 +16,7 @@ See `../../../nature-shared/core/reader-workflow.md` (loaded via manifest `alway
 - Calibrate verbs: `show`, `demonstrate`, `suggest`, `indicate`, `enable`, `may`, `could`.
 - Remove unsupported novelty and universal claims (`first ever`, `unprecedented`, `revolutionary`) unless the evidence genuinely supports them.
 
-## Intake — required inputs before drafting
+## Intake — identify the inputs relevant to the requested scope
 
 Identify before writing:
 
@@ -28,4 +28,4 @@ Identify before writing:
 - **target journal or word limit** if provided
 - **terminology**: on first contact with the material, extract the recurring methods, models, datasets, metrics, abbreviations, and notation into a Terminology Ledger and reuse the canonical forms across every section (see `../../../nature-shared/core/terminology-ledger.md`)
 
-If any of `core claim`, `evidence`, or `boundary` is absent, or the framing is ambiguous, run the **confirmation gate** in `workflow.md` (step 3b) before drafting the full section: echo back your one-sentence argument and key assumptions, ask at most 2–3 targeted questions, and wait for the user. A wrong assumed premise surfaced only in the final notes wastes the entire draft. If the user prefers to proceed without answering, you may still produce a scaffold with explicit placeholders.
+For a new section, identify the core claim, evidence, and boundary from the supplied material and task context. Follow the scoped alignment check in `workflow.md` (step 3b) when a material choice remains unresolved. A missing field alone does not require stopping all drafting: use explicit placeholders for unsupported facts and continue independent passages. For a local edit, retain the established argument and terminology without requesting a fresh manuscript intake.

--- a/skills/nature-writing/static/core/workflow.md
+++ b/skills/nature-writing/static/core/workflow.md
@@ -1,6 +1,6 @@
 # Writing workflow
 
-Run these steps for any drafting or restructuring task. Steps 1-3 are planning, step 3b is an alignment gate, 4-6 are drafting, 7-8 are checking, step 9 is the revision loop.
+Use these steps for a new section or substantial restructuring. For a title, single paragraph, or follow-up edit, apply only the relevant steps and reuse established framing and terminology. Steps 1-3 are planning, step 3b checks unresolved choices, 4-6 are drafting, 7-8 are checking, and step 9 handles revision.
 
 ## 1. Build a one-sentence argument
 
@@ -32,24 +32,15 @@ provenance detail, alternative inference, or edge case. Build the shortest
 sufficient main-text evidence chain and record the destination of everything
 else. Do not bury conclusion-changing evidence in SI.
 
-## 3b. Confirmation gate — align before drafting
+## 3b. Scoped alignment check
 
-Drafting a full section on a wrong assumed premise wastes the whole draft and is the main reason output "does not match what I meant". Before writing full prose, show the user a short alignment block and **stop for confirmation**:
+Proceed from the supplied material and established task context. For a substantial draft, briefly state the core argument and consequential assumptions so the user can correct them; this update is not an approval gate.
 
-- **One-sentence argument** (from step 1) — the single most important thing to get right. Echo it back in plain language.
-- **Plan**: detected paper type, section(s), journal / word limit, and the paragraph map from step 3 as a short bullet list.
-- **Key terminology**: the canonical forms locked in the Terminology Ledger (step 1b) for the main methods, models, datasets, and metrics. Surface them here so the user can fix a wrong canonical term before it propagates through every section.
-- **Primary reader**: who the draft is optimized for, and which of the five reader questions it leads with (relevance / novelty / trust / reuse / meaning — see `../../../nature-shared/core/reader-workflow.md`). Getting the lead question wrong is a common silent cause of "this is not what I meant".
-- **Key assumptions**: anything else you inferred rather than were told — especially what the core contribution is and which result to lead with. Mark each clearly as an assumption.
-- **At most 2–3 targeted questions**, only on genuinely ambiguous, high-leverage points (how to frame the core contribution, target audience / journal, which result leads). Do not ask about things the user already made clear, and do not pad the list to reach three.
+Ask only when an unresolved choice would materially change the core argument, evidence meaning, or requested deliverable and cannot be resolved from context. Explain the choice and pause only the dependent passages. Continue independent work and mark missing facts with explicit placeholders rather than filling them in.
 
-Then wait for the user to confirm or correct before drafting the full section.
+If the user explicitly requested outline approval before prose, deliver the outline and wait. Otherwise complete the requested draft and applicable checks without adding an outline-approval stage. Preserve existing approvals across follow-ups.
 
-Shortcuts:
-
-- **Skip the gate** when the core claim, evidence, and boundary are all clearly given and there is no real ambiguity in framing. In that case just state the one-sentence argument in a single line (per the router) and proceed.
-- **Depth dial**: for a full section or a major rewrite, offer to deliver the outline first (the paragraph map from step 3) and expand to full prose only after the user approves it. Reacting to an outline is far cheaper than reacting to full prose. Skip this for short or single-paragraph requests.
-- **Style, not substance**: if the user says the voice or style "is not mine", do not keep guessing — ask for one short sample of their own writing, then calibrate to it. From the sample, match: typical sentence length and rhythm, hedging level (`demonstrate` vs `may` / `could`), preferred connectives and transitions, person (first-person `we` vs passive), and terminology / abbreviation choices. Match the voice, not the content — never reuse the sample's claims or facts.
+When a requested voice cannot be inferred from supplied prose or prior corrections, ask for a short writing sample and calibrate to its style, never its claims or facts.
 
 ## 4. Draft from evidence outward
 
@@ -79,11 +70,11 @@ Output the draft together with explicit notes on assumptions, missing inputs, an
 
 When the user reacts to a draft, "this is not what I meant" is usually local — a wrong claim, a mis-framed paragraph, the wrong result leading. Do not silently re-draft the whole section: a full rewrite breaks the paragraphs that were already right and forces the user to re-check everything.
 
-- Change **only** the paragraphs or claims the user flagged; keep the rest verbatim.
-- If a requested fix genuinely forces a structural change (reordering sections, moving a claim across paragraphs), say so and confirm the new structure before applying it, rather than restructuring silently.
+- Focus on the paragraphs or claims the user flagged; keep unaffected passages verbatim.
+- If a requested fix requires changes to adjacent passages for consistency, explain and make the necessary changes within the authorized scope. Confirm only a material change to the argument or scope under step 3b, or when the user explicitly reserved structural approval.
 - Keep the Terminology Ledger (step 1b) stable across revisions unless the user changes a term; never let a revision reintroduce a variant of a locked term.
 - After revising, re-run only the checks relevant to what changed (steps 5-7), not the whole workflow.
-- If the user's redirection reveals the original premise was wrong, return to the confirmation gate (step 3b) instead of patching prose on a broken premise.
+- If the user's redirection changes the original premise, use that correction and revisit step 3b only for choices that remain unresolved.
 - Every proposed addition triggers the main-text deletion check: identify the
   new sentence's function, find existing text with the same function, and prefer
   replacement or compression before appending. Re-run the paragraph necessity

--- a/skills/nature-writing/static/fragments/journal/nat-comms.md
+++ b/skills/nature-writing/static/fragments/journal/nat-comms.md
@@ -19,7 +19,7 @@ Open-access, broader than a subfield journal, more specialist-tolerant than *Nat
 
 ## Pre-drafting word budget (Articles)
 
-The ~5,000-word cap **includes Methods**. Before drafting any section, propose a budget and confirm with the user:
+The ~5,000-word cap **includes Methods**. For a new manuscript or substantial restructuring, reuse an established word budget or propose one as a working assumption. Ask only if it conflicts with the requested scope or an explicit author constraint; do not require budget approval for a local section edit:
 
 | Section | Suggested budget |
 |---|---|

--- a/skills/nature-writing/static/fragments/section/method.md
+++ b/skills/nature-writing/static/fragments/section/method.md
@@ -16,7 +16,7 @@ If any element is missing, the module reads as a black box. Flag the gap.
 
 ## Pre-writing checklist
 
-Before drafting Method, confirm with the user:
+Before drafting Method, identify the following from supplied material and task context. Ask only about unresolved facts needed for the requested passage; do not reconfirm established choices:
 
 - Task formulation: inputs, outputs, scope.
 - Overview figure / pipeline diagram: does one exist? It anchors the section.

--- a/skills/nature-writing/tests/scoped-drafting.md
+++ b/skills/nature-writing/tests/scoped-drafting.md
@@ -1,0 +1,45 @@
+# Behavioral fixtures: scoped drafting and clarification
+
+Use these requests with the skill and its referenced instructions. Evaluate actual outputs and
+unnecessary stops, not exact wording. These fixtures are not an executed model benchmark.
+
+## Clear paragraph request
+
+```text
+Draft one short Results paragraph in English from these notes. This is descriptive only:
+treated group, 12 independent samples, mean signal 8.2 AU; control group, 12 independent
+samples, mean signal 6.1 AU. No inferential test was performed. Do not add a mechanism.
+```
+
+Expected: complete the paragraph without requesting outline approval, preserve the supplied
+values and independent sample counts, and avoid significance or causal claims. Do not demand a
+full-paper intake or invent uncertainty estimates.
+
+## Local follow-up
+
+```text
+Make that paragraph shorter and use "fluorescence intensity" instead of "signal".
+```
+
+Expected: reuse the established evidence and boundary, make the requested local edit, and keep
+the counts and values accurate without asking for the contribution, journal, or terminology again.
+
+## Explicit outline approval
+
+```text
+Plan a Discussion from the same findings. Give me an outline first and wait for my approval
+before writing prose. The evidence is descriptive and provides no mechanism.
+```
+
+Expected: provide only a bounded outline, preserve the evidence limit, and wait as explicitly
+requested. Do not reinterpret permission to complete the task as permission to skip this gate.
+
+## Material evidence conflict
+
+```text
+Draft the final Results paragraph. The spreadsheet summary says treated=8.2 and control=6.1,
+but the figure caption reverses these assignments. I cannot tell which is correct.
+```
+
+Expected: ask which source is authoritative and pause the affected group comparison. Do not
+choose a result direction, invent reconciled numbers, or present a final paragraph as verified.


### PR DESCRIPTION
## Problem and resulting behavior

Short writing, paper-reading, and artifact-editing requests can inherit complete-workflow setup and approval gates. This change scopes those requests to their actual deliverables, reuses established context on follow-ups, and makes discovery descriptions distinguish capabilities without embedding the entire procedure.

A question about one figure can be answered from the relevant source without generating a bilingual reader. A local reviewer-reply edit does not need a Major/Minor Revision label. Complete readers, decks, and response packages still retain their artifact, evidence, and applicable approval requirements.

## Changes

- Shorten 15 skill descriptions. Across the 19 triggerable skills, descriptions decrease from 11,835 to 4,311 characters (63.6%). Preserve names, optional metadata, compatibility aliases, and invocation policies.
- Remove repeated architecture explanations from nine skill entrypoints while keeping operational routing and resource links.
- Scope writing/response clarification to decisions that affect the requested work. Preserve explicit outline approvals and the editorial-decision gate for package-level revision strategy.
- Add explicit paths for source-linked paper questions, excerpt translation, existing-deck edits, local availability-statement edits, and offline citation conversion. Keep full-artifact requirements for full-artifact requests.
- Scope manuscript consistency checks to affected content, expanding when discrepancies indicate wider drift. Move Chinese-only citation/data guidance from always-load to conditional loading.
- Align figure manifest routing with task-scoped backend reuse and dependent-only pauses; plotting backend exclusivity and rendered QA remain intact.
- Keep strict CNS filtering within nature-citation and make that scope explicit in discovery. Only report an HTML citation-browser path when the artifact exists.
- Put selective installation before full-collection installation in both READMEs; installer implementations are unchanged.

No runtime scripts, citation-filter implementation, download approvals, automatic invocation policies, or scientific data-integrity rules are changed. No model-specific branches are introduced.

## Validation

- `python -m pytest -q scripts/tests skills/nature-response/tests skills/nature-reviewer/tests skills/nature-figure/tests`: **131 passed, 1 skipped**. The existing PDF collision end-to-end test was skipped because PyMuPDF is unavailable locally; the collision implementation is unchanged.
- Repository, skill metadata, README validation/mirror, skill index, and workflow validators passed.
- Bundled skill-creator `quick_validate.py` passed for all 15 edited entrypoints; `git diff --check` passed.
- Five isolated agent contexts exercised six short explicit-invocation requests: paper-question grounding, local reply editing, descriptive Results drafting, explicit outline approval, availability-statement grammar, and offline RIS conversion. Observed outputs respected scope and evidence boundaries. Details and limitations: [smoke evaluation](docs/skill-scope-smoke-evaluation.md).
- These small trials are not an implicit-routing benchmark, before/after comparison, cross-model evaluation, or full-artifact validation. No measured Astra performance gain is claimed.
