### PR TITLE
修正 Word 公式的上标结构

### DIFF
--- a/.github/requirements-ci.txt
+++ b/.github/requirements-ci.txt
@@ -34,6 +34,7 @@ PyJWT==2.13.0
 pypdf==6.14.2
 pypdfium2==5.12.1
 pytest==9.1.1
+python-docx==1.2.0
 python-dotenv==1.2.2
 python-multipart==0.0.32
 PyYAML==6.0.3

--- a/.github/workflows/test-skill-tooling.yml
+++ b/.github/workflows/test-skill-tooling.yml
@@ -72,6 +72,7 @@ jobs:
           python -m pip install \
             -c .github/requirements-ci.txt \
             pytest \
+            python-docx \
             -r skills/nature-academic-search/mcp-server/requirements.txt \
             -r skills/nature-downloader/requirements.txt \
             -r skills/nature-image2ppt/requirements.txt

--- a/skills/nature-paper-to-patent/scripts/math_to_omml.py
+++ b/skills/nature-paper-to-patent/scripts/math_to_omml.py
@@ -46,14 +46,14 @@ def _script(target, node, kind: str) -> None:
     if children:
         _append_mathml(expression, children[0])
     if len(children) > 1:
-        _append_mathml(sub, children[1])
+        _append_mathml(sup if kind == "sSup" else sub, children[1])
     if len(children) > 2:
         _append_mathml(sup, children[2])
     result.append(expression)
     if kind in {"sSub", "sSubSup"}:
         result.append(sub)
     if kind in {"sSup", "sSubSup"}:
-        result.append(sup if kind == "sSubSup" else sub)
+        result.append(sup)
     target.append(result)
 
 

--- a/skills/nature-paper-to-patent/tests/test_math_to_omml_superscript.py
+++ b/skills/nature-paper-to-patent/tests/test_math_to_omml_superscript.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+from xml.etree import ElementTree
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "math_to_omml.py"
+SPEC = importlib.util.spec_from_file_location("math_to_omml", SCRIPT)
+MATH = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MATH)
+
+
+class SuperscriptOmmlTests(unittest.TestCase):
+    def test_msup_uses_superscript_child(self) -> None:
+        mathml = ElementTree.fromstring(
+            '<msup xmlns="http://www.w3.org/1998/Math/MathML">'
+            "<mi>x</mi><mn>2</mn></msup>"
+        )
+        target = MATH._element("oMath")
+
+        MATH._append_mathml(target, mathml)
+
+        superscript = target[0]
+        self.assertTrue(superscript.tag.endswith("}sSup"))
+        self.assertTrue(superscript[1].tag.endswith("}sup"))
+        self.assertEqual("".join(superscript[1].itertext()), "2")
+
+    def test_script_variants_keep_operands_in_the_correct_slots(self) -> None:
+        cases = (
+            ("msub", "sSub", ("e", "sub"), ("x", "i")),
+            ("msup", "sSup", ("e", "sup"), ("x", "2")),
+            ("msubsup", "sSubSup", ("e", "sub", "sup"), ("x", "i", "2")),
+            ("munder", "sSub", ("e", "sub"), ("x", "i")),
+            ("mover", "sSup", ("e", "sup"), ("x", "2")),
+            ("munderover", "sSubSup", ("e", "sub", "sup"), ("x", "i", "2")),
+        )
+        for tag, expected_tag, slots, values in cases:
+            with self.subTest(tag=tag):
+                children = "".join(f"<mi>{value}</mi>" for value in values)
+                mathml = ElementTree.fromstring(
+                    f'<{tag} xmlns="http://www.w3.org/1998/Math/MathML">'
+                    f"{children}</{tag}>"
+                )
+                target = MATH._element("oMath")
+                MATH._append_mathml(target, mathml)
+                script = target[0]
+                self.assertEqual(script.tag, MATH.qn(f"m:{expected_tag}"))
+                self.assertEqual([child.tag for child in script], [MATH.qn(f"m:{s}") for s in slots])
+                self.assertEqual(tuple("".join(child.itertext()) for child in script), values)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
转换 `x^2` 这类公式时，当前生成的是 `m:sSup`，但指数却放在 `m:sub` 中。上标结构应使用 `m:sup`，否则 Word 可能无法正确显示指数。

这里修正了上标内容的写入位置，并补测了上标、下标、上下标组合及上下方标记，确认其他分支的操作数顺序不变。

测试工作流同时补装 `python-docx`，让这些 OMML 回归测试能在 CI 中运行。

验证：专利脚本的 8 项单元测试通过。
