### PR TITLE
避免配置写入失败时丢失 Image2PPT 原配置

### DIFF
--- a/skills/nature-image2ppt/cli/image2ppt/runtime/runtime_env.py
+++ b/skills/nature-image2ppt/cli/image2ppt/runtime/runtime_env.py
@@ -9,9 +9,9 @@ import json
 import os
 import platform
 import shutil
-import stat
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -99,9 +99,22 @@ def write_config_file(path: Path, values: dict) -> None:
     except ImportError as exc:
         raise SystemExit(f"PyYAML is required to write Image2PPT config. Install with {cli_reinstall_hint()}.") from exc
     data = {key: values[key] for key in ENV_FIELDS if values.get(key)}
-    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, stat.S_IRUSR | stat.S_IWUSR)
-    with os.fdopen(fd, "w", encoding="utf-8") as handle:
-        yaml.safe_dump(data, handle, allow_unicode=True, sort_keys=True)
+    fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        os.chmod(temp_name, 0o600)
+        handle = os.fdopen(fd, "w", encoding="utf-8")
+        fd = -1
+        with handle:
+            yaml.safe_dump(data, handle, allow_unicode=True, sort_keys=True)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_name, path)
+        os.chmod(path, 0o600)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        if os.path.exists(temp_name):
+            os.unlink(temp_name)
 
 
 def mask_secret(value: str) -> str:

--- a/skills/nature-image2ppt/tests/test_runtime_config.py
+++ b/skills/nature-image2ppt/tests/test_runtime_config.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI_DIR = ROOT / "cli"
+sys.path.insert(0, str(CLI_DIR))
+
+from image2ppt.runtime import runtime_env  # noqa: E402
+
+
+class RuntimeConfigTests(unittest.TestCase):
+    def test_update_restricts_existing_config_permissions(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            config = Path(directory) / "config.yaml"
+            config.write_text("OPENAI_API_KEY: old-key\n", encoding="utf-8")
+            if sys.platform != "win32":
+                os.chmod(config, 0o644)
+
+            runtime_env.write_config_file(config, {"OPENAI_API_KEY": "new-key"})
+
+            self.assertEqual(
+                runtime_env.read_config_file(config),
+                {"OPENAI_API_KEY": "new-key"},
+            )
+            if sys.platform != "win32":
+                self.assertEqual(config.stat().st_mode & 0o777, 0o600)
+
+    def test_failed_serialization_preserves_existing_config(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            config = Path(directory) / "config.yaml"
+            original = "OPENAI_API_KEY: existing-key\n"
+            config.write_text(original, encoding="utf-8")
+
+            with mock.patch.object(yaml, "safe_dump", side_effect=RuntimeError("write failed")):
+                with self.assertRaisesRegex(RuntimeError, "write failed"):
+                    runtime_env.write_config_file(config, {"OPENAI_API_KEY": "replacement-key"})
+
+            self.assertEqual(config.read_text(encoding="utf-8"), original)
+            self.assertEqual(list(config.parent.glob(f".{config.name}.*")), [])
+
+    def test_failed_flush_or_replace_preserves_existing_config(self) -> None:
+        for operation in ("fsync", "replace"):
+            with self.subTest(operation=operation), tempfile.TemporaryDirectory() as directory:
+                config = Path(directory) / "config.yaml"
+                original = b"OPENAI_API_KEY: existing-key\n"
+                config.write_bytes(original)
+
+                with mock.patch.object(
+                    runtime_env.os, operation, side_effect=OSError("disk error")
+                ):
+                    with self.assertRaisesRegex(OSError, "disk error"):
+                        runtime_env.write_config_file(config, {"OPENAI_API_KEY": "new-key"})
+
+                self.assertEqual(config.read_bytes(), original)
+                self.assertEqual(list(config.parent.glob(f".{config.name}.*")), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
目前更新 `config.yaml` 会先截断原文件。如果 YAML 序列化或后续写入失败，之前保存的配置就可能丢失。

改为先写入同目录的临时文件，完成刷新和落盘后再替换原配置；失败时清理临时文件。临时文件使用 `0600` 权限，替换后也会收紧已有配置的权限（POSIX 平台）。

验证：Image2PPT 全套 168 项测试、31 个子测试通过。配置相关测试覆盖命令行读写、正常更新、序列化失败、落盘失败和替换失败。Windows 本地不检查 POSIX 权限位，权限检查由 Linux CI 执行。
