### PR TITLE
docs: add Chatbox installation and usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@
   - [5.1 `npx skills` 安装方式](#51-npx-skills-安装方式)
   - [5.2 Claude Code 安装方式](#52-claude-code-安装方式)
   - [5.3 Codex 安装方式](#53-codex-安装方式)
-  - [5.4 其他 Agent 场景](#54-其他-agent-场景)
-  - [5.5 Chatbox 安装与使用](#55-chatbox-安装与使用)
+  - [5.4 Chatbox 安装与使用](#54-chatbox-安装与使用)
+  - [5.5 其他 Agent 场景](#55-其他-agent-场景)
 - [6. 技能索引](#6-技能索引)
 - [7. 贡献与开发](#7-贡献与开发)
 - [8. Star 历史](#8-star-历史)
@@ -422,19 +422,7 @@ git clone https://github.com/Yuan1z0825/nature-skills.git ~/.codex/.nature-skill
 
 每个安装目标使用独立日志，路径为 `~/.local/state/nature-skills/<目标目录编号>/autoupdate.log`。拉取到的新技能通常在下一次会话中完整生效。
 
-### 5.4 其他 Agent 场景
-
-OpenClaw、OpenCode、Hermes 的具体接入方式见 [OpenClaw / OpenCode / Hermes 接入教程](docs/open-source-agent-frameworks.md)。
-
-用于其他 agent 时，建议保留一个稳定的仓库 clone，再创建轻量 subagent、slash command 或 custom prompt wrapper，指向真实的 `skills/*/SKILL.md`，并保留 `skills/nature-shared/`。
-
-手动或其他 agent 使用时：
-
-1. 将完整技能目录复制到你的 prompt library 或项目中。
-2. 保留 `SKILL.md`、`manifest.yaml`、`static/`、`references/`、脚本、资产和需要的 `skills/nature-shared/` 文件。
-3. 如目标 agent 有自己的格式要求，可调整 frontmatter 和正文结构。
-
-### 5.5 Chatbox 安装与使用
+### 5.4 Chatbox 安装与使用
 
 [Chatbox](https://chatboxai.app/zh) 桌面版提供图形化 Skills 管理界面。请使用带有「设置 → 技能（Skills）」入口的版本；本节适用于桌面端。
 
@@ -472,6 +460,18 @@ OpenClaw、OpenCode、Hermes 的具体接入方式见 [OpenClaw / OpenCode / Her
 Skills 安装的是指令和配套文件。Python/R、PDF/PPTX 工具、浏览器和 MCP 服务等运行依赖仍需按具体技能说明配置；涉及本地文件或脚本时，按 Chatbox 提示授权所需目录和命令。生成图片等外部服务需要对应服务的凭据。安装成功不代表这些外部能力已配置完成。
 
 在技能的操作菜单中可「检查更新」并按提示更新；有共享依赖时也要检查 `nature-shared`。如果 GitHub 扫描或下载失败，可从本仓库的「Code → Download ZIP」下载并解压，点击 Chatbox 的「打开技能文件夹」，将所需的完整技能目录及 `nature-shared` 放到该文件夹的同一级，然后刷新技能列表并启用。保留 `references/`、`static/`、脚本和资产；不要只复制 `SKILL.md`。手动复制时，目录名应与 `SKILL.md` 中的 `name` 一致（例如将 `nature-proposal-writer` 目录命名为 `researchwrite`）。手动复制的技能需要手动更新。
+
+### 5.5 其他 Agent 场景
+
+OpenClaw、OpenCode、Hermes 的具体接入方式见 [OpenClaw / OpenCode / Hermes 接入教程](docs/open-source-agent-frameworks.md)。
+
+用于其他 agent 时，建议保留一个稳定的仓库 clone，再创建轻量 subagent、slash command 或 custom prompt wrapper，指向真实的 `skills/*/SKILL.md`，并保留 `skills/nature-shared/`。
+
+手动或其他 agent 使用时：
+
+1. 将完整技能目录复制到你的 prompt library 或项目中。
+2. 保留 `SKILL.md`、`manifest.yaml`、`static/`、`references/`、脚本、资产和需要的 `skills/nature-shared/` 文件。
+3. 如目标 agent 有自己的格式要求，可调整 frontmatter 和正文结构。
 
 ## 6. 技能索引
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
   - [5.2 Claude Code 安装方式](#52-claude-code-安装方式)
   - [5.3 Codex 安装方式](#53-codex-安装方式)
   - [5.4 其他 Agent 场景](#54-其他-agent-场景)
+  - [5.5 Chatbox 安装与使用](#55-chatbox-安装与使用)
 - [6. 技能索引](#6-技能索引)
 - [7. 贡献与开发](#7-贡献与开发)
 - [8. Star 历史](#8-star-历史)
@@ -432,6 +433,45 @@ OpenClaw、OpenCode、Hermes 的具体接入方式见 [OpenClaw / OpenCode / Her
 1. 将完整技能目录复制到你的 prompt library 或项目中。
 2. 保留 `SKILL.md`、`manifest.yaml`、`static/`、`references/`、脚本、资产和需要的 `skills/nature-shared/` 文件。
 3. 如目标 agent 有自己的格式要求，可调整 frontmatter 和正文结构。
+
+### 5.5 Chatbox 安装与使用
+
+[Chatbox](https://chatboxai.app/zh) 桌面版提供图形化 Skills 管理界面。请使用带有「设置 → 技能（Skills）」入口的版本；本节适用于桌面端。
+
+**从 GitHub 安装**
+
+1. 打开 Chatbox 的「设置 → 技能」，点击「从 GitHub 安装」。
+2. 粘贴 `https://github.com/Yuan1z0825/nature-skills`，点击「扫描」。
+3. 勾选需要的技能，点击「安装已选」。初次体验可选择 `nature-polishing` 和 `nature-shared`；需要整套技能时可以「全选」。
+4. 在「已安装技能」中确认安装结果，并确认需要使用的技能已启用。
+
+`nature-shared` 是共享支持包。使用 `nature-polishing`、`nature-writing`、`nature-response`、`nature-reader` 或 `nature-paper2ppt` 等引用它的技能时，需要一并安装；它不作为独立任务调用。安装单个技能不会自动补齐其他技能依赖。列表可能显示技能的 frontmatter 名称，例如 `nature-proposal-writer` 显示为 `researchwrite`。
+
+**开始使用**
+
+新建对话，选择支持工具调用的模型，开启「智能体模式（Agent Mode）」。把待处理文本粘贴到对话中，并明确写出技能名。例如：
+
+```text
+请使用 nature-polishing，把下面这段中文改写为 Nature 风格英文。
+保持原有学术含义、数值和结论边界，列出主要修改及理由：
+
+[在这里粘贴论文段落]
+```
+
+需要读论文时，可安装 `nature-reader` 和 `nature-shared`，提供论文文件或可访问的本地路径，再请求：
+
+```text
+请使用 nature-reader，把这篇论文做成图文对应的中英文对照 Markdown reader，
+保留公式和来源锚点，并将产物保存到我指定的输出目录。
+```
+
+检查对话中的技能加载和工具执行记录，确认实际加载了所需技能。若未触发，先检查技能开关、智能体模式以及当前模型是否支持工具调用。
+
+**运行依赖与更新**
+
+Skills 安装的是指令和配套文件。Python/R、PDF/PPTX 工具、浏览器和 MCP 服务等运行依赖仍需按具体技能说明配置；涉及本地文件或脚本时，按 Chatbox 提示授权所需目录和命令。生成图片等外部服务需要对应服务的凭据。安装成功不代表这些外部能力已配置完成。
+
+在技能的操作菜单中可「检查更新」并按提示更新；有共享依赖时也要检查 `nature-shared`。如果 GitHub 扫描或下载失败，可从本仓库的「Code → Download ZIP」下载并解压，点击 Chatbox 的「打开技能文件夹」，将所需的完整技能目录及 `nature-shared` 放到该文件夹的同一级，然后刷新技能列表并启用。保留 `references/`、`static/`、脚本和资产；不要只复制 `SKILL.md`。手动复制时，目录名应与 `SKILL.md` 中的 `name` 一致（例如将 `nature-proposal-writer` 目录命名为 `researchwrite`）。手动复制的技能需要手动更新。
 
 ## 6. 技能索引
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -38,6 +38,7 @@
   - [5.2 Claude Code Installation](#52-claude-code-installation)
   - [5.3 Codex Installation](#53-codex-installation)
   - [5.4 Other Agent Scenarios](#54-other-agent-scenarios)
+  - [5.5 Chatbox Installation and Usage](#55-chatbox-installation-and-usage)
 - [6. Skill Index](#6-skill-index)
 - [7. Contribution and Development](#7-contribution-and-development)
 - [8. Star History](#8-star-history)
@@ -513,6 +514,47 @@ For manual or other-agent use:
    assets, and required `skills/nature-shared/` files.
 3. If the target agent has its own format requirements, adjust the frontmatter
    and body structure.
+
+### 5.5 Chatbox Installation and Usage
+
+[Chatbox](https://chatboxai.app/) desktop provides a graphical Skills manager. Use a version with a **Settings → Skills** entry; this section applies to the desktop app.
+
+**Install from GitHub**
+
+1. Open **Settings → Skills** in Chatbox and click **Install from GitHub**.
+2. Paste `https://github.com/Yuan1z0825/nature-skills` and click **Scan**.
+3. Select the skills you need and click **Install Selected**. For a first try, choose `nature-polishing` and `nature-shared`; use **Select all** if you want the full collection.
+4. Check the result under **Installed Skills** and make sure the skills you want to use are enabled.
+
+`nature-shared` is a shared support package. Install it alongside skills that reference it, including `nature-polishing`, `nature-writing`, `nature-response`, `nature-reader`, and `nature-paper2ppt`; do not invoke it as a standalone task. Installing one skill does not automatically install other skill dependencies. The list may show frontmatter names: for example, `nature-proposal-writer` appears as `researchwrite`.
+
+**Start using the skills**
+
+Create a conversation, select a model that supports tool calling, and enable **Agent Mode**. Paste your text into the conversation and name the skill explicitly. For example:
+
+```text
+Use nature-polishing to rewrite the following Chinese paragraph in Nature-style English.
+Preserve its academic meaning, numerical values, and limits on conclusions.
+List the main changes and explain the reasons:
+
+[Paste your manuscript paragraph here]
+```
+
+For paper reading, install `nature-reader` and `nature-shared`, provide the paper file or an accessible local path, and ask:
+
+```text
+Use nature-reader to turn this paper into a Chinese-English Markdown reader
+with aligned figures and text. Preserve equations and source anchors,
+and save the deliverables to my specified output directory.
+```
+
+Check the skill-loading and tool-execution records in the conversation to confirm that the intended skill was loaded. If it does not trigger, check the skill toggle, Agent Mode, and whether the selected model supports tool calling.
+
+**Runtime dependencies and updates**
+
+Installing skills adds instructions and supporting files. Configure Python/R, PDF/PPTX tools, browsers, and MCP services according to each skill's documentation. For local files or scripts, grant the required directory and command access when Chatbox prompts you. External services such as image generation require their own credentials. A successful skill installation does not mean these external capabilities are configured.
+
+Use **Check Update** in a skill's action menu and follow the prompts to update it; also check `nature-shared` when it is a dependency. If GitHub scanning or downloading fails, download and extract this repository through **Code → Download ZIP**, click **Open Skills Folder** in Chatbox, and place the complete skill directories and `nature-shared` alongside one another in that folder. Refresh the skill list and enable them. Preserve `references/`, `static/`, scripts, and assets; do not copy only `SKILL.md`. For manual copies, match the directory name to the `name` in `SKILL.md` (for example, name the `nature-proposal-writer` directory `researchwrite`). Manually copied skills require manual updates.
 
 ## 6. Skill Index
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -37,8 +37,8 @@
   - [5.1 `npx skills` Installation](#51-npx-skills-installation)
   - [5.2 Claude Code Installation](#52-claude-code-installation)
   - [5.3 Codex Installation](#53-codex-installation)
-  - [5.4 Other Agent Scenarios](#54-other-agent-scenarios)
-  - [5.5 Chatbox Installation and Usage](#55-chatbox-installation-and-usage)
+  - [5.4 Chatbox Installation and Usage](#54-chatbox-installation-and-usage)
+  - [5.5 Other Agent Scenarios](#55-other-agent-scenarios)
 - [6. Skill Index](#6-skill-index)
 - [7. Contribution and Development](#7-contribution-and-development)
 - [8. Star History](#8-star-history)
@@ -499,23 +499,7 @@ Each destination has a separate log at
 `~/.local/state/nature-skills/<destination-id>/autoupdate.log`. Newly fetched
 skills normally take full effect in the next session.
 
-### 5.4 Other Agent Scenarios
-
-For OpenClaw, OpenCode, and Hermes, see the dedicated [integration guide](docs/open-source-agent-frameworks_EN.md).
-
-For other agents, keep a stable repository clone and create a lightweight
-subagent, slash command, or custom prompt wrapper that points to the real
-`skills/*/SKILL.md` files. Preserve `skills/nature-shared/`.
-
-For manual or other-agent use:
-
-1. Copy complete skill directories into your prompt library or project.
-2. Preserve `SKILL.md`, `manifest.yaml`, `static/`, `references/`, scripts,
-   assets, and required `skills/nature-shared/` files.
-3. If the target agent has its own format requirements, adjust the frontmatter
-   and body structure.
-
-### 5.5 Chatbox Installation and Usage
+### 5.4 Chatbox Installation and Usage
 
 [Chatbox](https://chatboxai.app/) desktop provides a graphical Skills manager. Use a version with a **Settings → Skills** entry; this section applies to the desktop app.
 
@@ -555,6 +539,22 @@ Check the skill-loading and tool-execution records in the conversation to confir
 Installing skills adds instructions and supporting files. Configure Python/R, PDF/PPTX tools, browsers, and MCP services according to each skill's documentation. For local files or scripts, grant the required directory and command access when Chatbox prompts you. External services such as image generation require their own credentials. A successful skill installation does not mean these external capabilities are configured.
 
 Use **Check Update** in a skill's action menu and follow the prompts to update it; also check `nature-shared` when it is a dependency. If GitHub scanning or downloading fails, download and extract this repository through **Code → Download ZIP**, click **Open Skills Folder** in Chatbox, and place the complete skill directories and `nature-shared` alongside one another in that folder. Refresh the skill list and enable them. Preserve `references/`, `static/`, scripts, and assets; do not copy only `SKILL.md`. For manual copies, match the directory name to the `name` in `SKILL.md` (for example, name the `nature-proposal-writer` directory `researchwrite`). Manually copied skills require manual updates.
+
+### 5.5 Other Agent Scenarios
+
+For OpenClaw, OpenCode, and Hermes, see the dedicated [integration guide](docs/open-source-agent-frameworks_EN.md).
+
+For other agents, keep a stable repository clone and create a lightweight
+subagent, slash command, or custom prompt wrapper that points to the real
+`skills/*/SKILL.md` files. Preserve `skills/nature-shared/`.
+
+For manual or other-agent use:
+
+1. Copy complete skill directories into your prompt library or project.
+2. Preserve `SKILL.md`, `manifest.yaml`, `static/`, `references/`, scripts,
+   assets, and required `skills/nature-shared/` files.
+3. If the target agent has its own format requirements, adjust the frontmatter
+   and body structure.
 
 ## 6. Skill Index
 


### PR DESCRIPTION
## 背景

为使用 Chatbox 桌面版的读者补充 Nature Skills 安装与使用入口。

## 改动

- 在中英文 README 中同步新增「5.4 Chatbox 安装与使用」及目录链接。
- 说明从 GitHub 扫描、选择并安装技能的图形界面流程，以及 nature-shared 的共享依赖关系。
- 提供智能体模式下的论文润色、论文阅读提示词和技能加载检查方法。
- 补充运行依赖、检查更新和手动安装说明。

## 验证

- `python3 scripts/validate-readmes.py` 通过。
- `python3 scripts/validate-readme-mirror.py` 通过。
- `git diff --check` 通过。
- 已对照 Chatbox 当前实现核对安装入口、按钮名称、技能启用及智能体模式条件；本次为文档变更，未执行真实科研任务端到端测试。